### PR TITLE
feat(ui): algorithms-first flow for Calibration Only mode

### DIFF
--- a/docs/superpowers/plans/2026-05-12-calibration-mode-flow-redesign.md
+++ b/docs/superpowers/plans/2026-05-12-calibration-mode-flow-redesign.md
@@ -1,0 +1,756 @@
+# Calibration-Only Algorithms-First Flow — Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Flip the Calibration Only mode UI in `JobForm.jsx` from ensemble-first to algorithms-first so it matches the `vacalibration` R package's mental model (ensemble = additional output, not a mode switch).
+
+**Architecture:** Single-component refactor of `JobForm.jsx`. The conditional that today renders `(jobType === 'vacalibration' || jobType === 'pipeline')` ensemble UI is split: Pipeline keeps its existing ensemble-first checkbox flow, Calibration gets a new algorithms-first block where (a) algorithm checkboxes are always visible, (b) an "Also run ensemble" row is always rendered but disabled when <2 algos are selected, (c) upload rows are always per-algorithm. A new session-scoped sentinel `ensembleUserTouched` powers "sticky" ensemble behavior across 1↔2 crossings. Backend is unchanged.
+
+**Tech Stack:** React 18 + hooks, vitest, @testing-library/react (jsdom env), Playwright for E2E.
+
+**Spec:** `docs/superpowers/specs/2026-05-12-calibration-mode-flow-redesign.md`
+
+---
+
+## File Structure
+
+| File | Action | Responsibility |
+|------|--------|----------------|
+| `frontend/src/components/JobForm.jsx` | Modify | Split `jobType` conditional; new vacalibration block; add `ensembleUserTouched` state and Effect B |
+| `frontend/src/components/JobForm.test.js` | Modify | Update source-level assertions that depended on ensemble-first ordering |
+| `frontend/src/components/JobForm.behavior.test.jsx` | Create | 4 RTL behavior tests for state transitions (uses `@vitest-environment jsdom`) |
+| `frontend/e2e/demo-gallery.spec.js` | (Verify) | Re-run to confirm no selector regression; modify only if needed |
+| `backend/**` | — | No changes |
+
+`JobForm.test.js` uses source-level TDD (greps the JSX source for patterns). That style is fine for structural assertions ("ensemble row is rendered for vacalibration") but cannot verify state transitions, which is why we add a sibling `.behavior.test.jsx` file using React Testing Library for the 4 transition tests.
+
+---
+
+## Task 1: Add 4 RTL behavior tests (failing — TDD red phase)
+
+**Files:**
+- Create: `frontend/src/components/JobForm.behavior.test.jsx`
+
+These tests describe the post-refactor behaviors; they will all fail against the current code.
+
+- [ ] **Step 1: Create the new test file**
+
+Create `frontend/src/components/JobForm.behavior.test.jsx` with:
+
+```jsx
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+// Stub the API client — these tests are pure UI behavior, no backend calls.
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+const renderForm = () => render(<JobForm onJobSubmitted={() => {}} />)
+
+const switchToCalibrationOnly = () => {
+  // CustomSelect renders a button-driven popover. The current Job Type select
+  // shows the label of the current value; click it and pick "Calibration Only".
+  // If CustomSelect's interaction is hard to drive, prefer triggering its
+  // onChange via a native select fallback or fireEvent on the option element.
+  const trigger = screen.getByText(/Full Pipeline|openVA Only|Calibration Only/)
+  fireEvent.click(trigger)
+  fireEvent.click(screen.getByText('Calibration Only'))
+}
+
+const getAlgoCheckbox = (name) =>
+  screen.getByLabelText(new RegExp(`^${name}\\b`, 'i'))
+
+const getEnsembleCheckbox = () =>
+  screen.getByLabelText(/Also run ensemble/i)
+
+describe('Calibration Only — algorithms-first flow', () => {
+  beforeEach(() => {
+    // Make sure each test starts with a clean module/state.
+    vi.clearAllMocks()
+  })
+
+  it('ensemble row is rendered but disabled when only 1 algorithm is selected', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    // Default state: InterVA only.
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble).toBeTruthy()
+    expect(ensemble.disabled).toBe(true)
+
+    // Hint text is visible.
+    expect(screen.getByText(/requires 2\+ algorithms/i)).toBeTruthy()
+  })
+
+  it('auto-enables ensemble when user crosses from 1 to 2 algorithms', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble.checked).toBe(false)
+
+    // Check a second algorithm.
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+
+    // Ensemble enables AND auto-checks.
+    expect(ensemble.disabled).toBe(false)
+    expect(ensemble.checked).toBe(true)
+  })
+
+  it('respects sticky-uncheck: once user unchecks ensemble, do not auto-re-enable on re-crossing', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    // Add a 2nd algo → auto-enables.
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble.checked).toBe(true)
+
+    // User unchecks ensemble.
+    fireEvent.click(ensemble)
+    expect(ensemble.checked).toBe(false)
+
+    // Drop back to 1 algorithm.
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(ensemble.disabled).toBe(true)
+
+    // Re-add 2nd algorithm. Ensemble must stay unchecked (sticky).
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(ensemble.disabled).toBe(false)
+    expect(ensemble.checked).toBe(false)
+  })
+
+  it('renders one labeled upload row per selected algorithm, regardless of ensemble', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    // 1 algorithm → 1 labeled upload row showing "InterVA".
+    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText(/^InSilicoVA/i)).toBeNull()
+
+    // Add a 2nd algorithm → 2 labeled upload rows.
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText(/^InSilicoVA/i).length).toBeGreaterThanOrEqual(1)
+
+    // Each upload row must have its own file input.
+    const fileInputs = document.querySelectorAll('input[type="file"]')
+    expect(fileInputs.length).toBe(2)
+  })
+})
+```
+
+- [ ] **Step 2: Run the tests to verify they all fail**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.behavior.test.jsx`
+Expected: All 4 tests FAIL (current JobForm.jsx renders the ensemble-first UI; behavior assertions will not match).
+
+If a test fails for an unexpected reason (e.g., the helper `switchToCalibrationOnly` can't find the dropdown trigger), inspect `CustomSelect.jsx` and adapt the helper. The default Job Type is already `'vacalibration'` (line 9), so `switchToCalibrationOnly()` may be a no-op in practice — keep it as a guard but accept that it may not need to actually click anything.
+
+- [ ] **Step 3: Commit failing tests**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add frontend/src/components/JobForm.behavior.test.jsx
+git commit -m "test: add behavior tests for algorithms-first calibration UX (failing)"
+```
+
+---
+
+## Task 2: Update source-level test assertions
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.test.js:71-73` (keeps-single-file-input assertion)
+- Modify: `frontend/src/components/JobForm.test.js:43-78` (Checkbox-driven ensemble uploads block — partial)
+
+The current assertions encode the ensemble-first model. Two of them will break under the new design and need updating; the rest still hold for Pipeline mode (which is unchanged).
+
+- [ ] **Step 1: Replace the obsolete "keeps single file input for non-ensemble vacalibration" assertion**
+
+Open `frontend/src/components/JobForm.test.js`. The current block at lines 71-73:
+
+```javascript
+it('keeps single file input for non-ensemble vacalibration', () => {
+  expect(jobFormSrc).toContain("type=\"file\"")
+})
+```
+
+Replace with:
+
+```javascript
+it('vacalibration mode always uses per-algorithm upload rows (no single-file branch)', () => {
+  // The vacalibration JSX branch never renders the "VA Data File (CSV)" label —
+  // that label is reserved for openVA-only and Pipeline non-ensemble modes.
+  // Per-algorithm rows are denoted by `upload-row`/`upload-algo-label`.
+  expect(jobFormSrc).toContain('upload-algo-label')
+
+  // Negative guard: in the vacalibration branch, the legacy single-file label
+  // must not appear. We tolerate the label elsewhere (Pipeline non-ensemble).
+  const calibBlock = jobFormSrc.match(
+    /jobType === 'vacalibration'[\s\S]*?(?=jobType === 'pipeline'|jobType === 'openva'|$)/
+  )?.[0] || ''
+  expect(calibBlock).not.toMatch(/VA Data File \(CSV\)/)
+})
+```
+
+- [ ] **Step 2: Add structural assertion for the new vacalibration branch**
+
+Inside the existing `describe('Checkbox-driven ensemble uploads', ...)` block, append:
+
+```javascript
+it('renders an always-visible ensemble row in the vacalibration branch', () => {
+  // Source contains a disabled hint for the 1-algo case.
+  expect(jobFormSrc).toMatch(/requires 2\+ algorithms/i)
+})
+
+it('introduces ensembleUserTouched sentinel for sticky-uncheck behavior', () => {
+  expect(jobFormSrc).toMatch(/ensembleUserTouched/)
+})
+
+it('splits the jobType conditional so pipeline and vacalibration are separate branches', () => {
+  // The OLD combined conditional `(jobType === 'vacalibration' || jobType === 'pipeline')`
+  // for the ensemble checkbox must not appear in the new code — it has been split.
+  // Pipeline's ensemble-first UI stays under jobType === 'pipeline'.
+  expect(jobFormSrc).toContain("jobType === 'pipeline'")
+  expect(jobFormSrc).toContain("jobType === 'vacalibration'")
+  // The combined form for the ensemble toggle should be gone.
+  expect(jobFormSrc).not.toMatch(
+    /\(jobType === ['"]vacalibration['"] \|\| jobType === ['"]pipeline['"]\)[\s\S]{0,200}ensemble-toggle/
+  )
+})
+
+it('removes the file-algorithm-mismatch hint banner', () => {
+  // The hint is no longer needed because each upload row is labeled.
+  expect(jobFormSrc).not.toContain('algorithm selection below will be used to match the data format')
+})
+```
+
+- [ ] **Step 3: Run JobForm.test.js to confirm new assertions fail**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.test.js`
+Expected: The five new/modified assertions FAIL (current source doesn't match them yet); other assertions still PASS.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add frontend/src/components/JobForm.test.js
+git commit -m "test: update JobForm source-level assertions for algorithms-first flow (failing)"
+```
+
+---
+
+## Task 3: Refactor JobForm.jsx — introduce ensembleUserTouched and split jobType branches
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx` (state hooks at lines 8-25; effects at lines 56-92; render at lines 209-287, 392-453)
+
+This is the meat of the change. It's grouped into one task because the JSX edits are interconnected, but each step is a focused edit.
+
+- [ ] **Step 1: Add `ensembleUserTouched` state hook**
+
+Open `frontend/src/components/JobForm.jsx`. Find the existing state declarations (lines 9-22) and add a new line immediately after the `ensemble` state on line 15:
+
+```javascript
+const [ensemble, setEnsemble] = useState(false);
+const [ensembleUserTouched, setEnsembleUserTouched] = useState(false);
+```
+
+- [ ] **Step 2: Add Effect B — auto-enable ensemble on 1→2 crossing for calibration-only**
+
+Below the existing effect that ends at line 92 (validation effect for ensemble requirements), insert a new effect:
+
+```javascript
+// Effect B (issue: algorithms-first flow): when the user crosses from 1 to 2+
+// algorithms in calibration-only mode, auto-enable the ensemble checkbox —
+// UNLESS the user has explicitly touched it (sticky behavior).
+useEffect(() => {
+  if (
+    jobType === 'vacalibration' &&
+    algorithms.length >= 2 &&
+    !ensembleUserTouched
+  ) {
+    setEnsemble(true);
+  }
+}, [algorithms.length, jobType, ensembleUserTouched]);
+```
+
+- [ ] **Step 3: Wire the ensemble checkbox to set the touched sentinel**
+
+The existing ensemble checkbox at lines 219-227:
+
+```jsx
+<input
+  type="checkbox"
+  checked={ensemble}
+  onChange={(e) => setEnsemble(e.target.checked)}
+/>
+```
+
+This handler is shared between Pipeline and Calibration today. We're about to split the JSX so each mode has its own checkbox. The new vacalibration checkbox uses:
+
+```jsx
+onChange={(e) => {
+  setEnsembleUserTouched(true);
+  setEnsemble(e.target.checked);
+}}
+```
+
+The Pipeline checkbox keeps the simpler `onChange={(e) => setEnsemble(e.target.checked)}`. (We don't need stickiness in Pipeline because its ensemble checkbox is rendered first, not auto-toggled.)
+
+- [ ] **Step 4: Split the algorithm-section JSX by jobType**
+
+Locate the current block at lines 208-287 (the `<div className="form-group">` containing the Algorithm label, ensemble-toggle, hint, and picker). Replace the **entire** block with:
+
+```jsx
+{/* Algorithm Selection - split by job type */}
+{jobType === 'openva' && (
+  <div className="form-group">
+    <label>Algorithm</label>
+    <CustomSelect
+      value={algorithms[0] || 'InterVA'}
+      onChange={handleAlgorithmSelect}
+      options={[
+        { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+        { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+        { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+      ]}
+    />
+    {validationError && <small className="validation-error">{validationError}</small>}
+  </div>
+)}
+
+{jobType === 'pipeline' && (
+  <div className="form-group">
+    <label>
+      Algorithm{ensemble ? 's' : ''}
+      {ensemble && (
+        <span className="required"> * Select at least 2 for ensemble</span>
+      )}
+    </label>
+
+    <div className="ensemble-toggle">
+      <label>
+        <input
+          type="checkbox"
+          checked={ensemble}
+          onChange={(e) => setEnsemble(e.target.checked)}
+        />
+        {' '}Ensemble Mode (combine multiple algorithms)
+      </label>
+    </div>
+
+    {ensemble ? (
+      <div className="algorithm-checkboxes">
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={algorithms.includes('InterVA')}
+            onChange={() => handleAlgorithmToggle('InterVA')}
+          />
+          InterVA (fastest, ~30sec)
+        </label>
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={algorithms.includes('InSilicoVA')}
+            onChange={() => handleAlgorithmToggle('InSilicoVA')}
+          />
+          InSilicoVA (most accurate, ~2-3min)
+        </label>
+        <label className="checkbox-label">
+          <input
+            type="checkbox"
+            checked={algorithms.includes('EAVA')}
+            onChange={() => handleAlgorithmToggle('EAVA')}
+          />
+          EAVA (deterministic, ~1min)
+        </label>
+        {algorithms.length > 1 && (
+          <small className="form-hint warning">
+            Running {algorithms.length} algorithms will take approximately{' '}
+            {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}
+          </small>
+        )}
+      </div>
+    ) : (
+      <CustomSelect
+        value={algorithms[0] || 'InterVA'}
+        onChange={handleAlgorithmSelect}
+        options={[
+          { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+          { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+          { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+        ]}
+      />
+    )}
+
+    {validationError && <small className="validation-error">{validationError}</small>}
+  </div>
+)}
+
+{jobType === 'vacalibration' && (
+  <div className="form-group">
+    <label>Algorithms *</label>
+
+    <div className="algorithm-checkboxes">
+      <label className="checkbox-label">
+        <input
+          type="checkbox"
+          checked={algorithms.includes('InterVA')}
+          onChange={() => handleAlgorithmToggle('InterVA')}
+        />
+        InterVA (fastest, ~30sec)
+      </label>
+      <label className="checkbox-label">
+        <input
+          type="checkbox"
+          checked={algorithms.includes('InSilicoVA')}
+          onChange={() => handleAlgorithmToggle('InSilicoVA')}
+        />
+        InSilicoVA (most accurate, ~2-3min)
+      </label>
+      <label className="checkbox-label">
+        <input
+          type="checkbox"
+          checked={algorithms.includes('EAVA')}
+          onChange={() => handleAlgorithmToggle('EAVA')}
+        />
+        EAVA (deterministic, ~1min)
+      </label>
+    </div>
+
+    {/* Ensemble row: always rendered, disabled when <2 algos */}
+    <div className="ensemble-toggle">
+      <label>
+        <input
+          type="checkbox"
+          checked={ensemble && algorithms.length >= 2}
+          disabled={algorithms.length < 2}
+          onChange={(e) => {
+            setEnsembleUserTouched(true);
+            setEnsemble(e.target.checked);
+          }}
+        />
+        {' '}Also run ensemble (combines algorithms)
+      </label>
+      {algorithms.length < 2 ? (
+        <small className="form-hint">Requires 2+ algorithms</small>
+      ) : (
+        <small className="form-hint">
+          Runs per-algorithm calibration plus an additional combined ensemble result.
+          {algorithms.length > 1 && (
+            <>{' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.</>
+          )}
+        </small>
+      )}
+    </div>
+
+    {validationError && <small className="validation-error">{validationError}</small>}
+  </div>
+)}
+```
+
+- [ ] **Step 5: Split the upload-section JSX by jobType**
+
+Locate the current upload block at lines 392-453 (the ternary `{jobType === 'vacalibration' && ensemble ? (...) : (...)}`). Replace it with:
+
+```jsx
+{jobType === 'vacalibration' ? (
+  <div className="form-group">
+    <label>VA Data Files (one CSV per selected algorithm)</label>
+    {uploads.map((upload, index) => (
+      <div key={upload.id} className="upload-row">
+        <span className="upload-algo-label">{upload.algorithm}</span>
+        <input
+          type="file"
+          accept=".csv"
+          onChange={(e) => updateUpload(index, 'file', e.target.files[0])}
+        />
+        {upload.file && <span className="file-name">{upload.file.name}</span>}
+      </div>
+    ))}
+    <small className="form-hint">
+      Upload one CSV file per selected algorithm. Required columns: ID, cause.
+    </small>
+    <div className="sample-download">
+      <div className="sample-links">
+        <span>Sample CSV (neonate, 1190 records):</span>
+        <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
+        <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
+        <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
+      </div>
+      <small className="sample-source">Source: Pramanik S, Wilson E, Fiksel J, Gilbert B, Datta A (2025). <a href="https://github.com/VA-calibration/vacalibration" target="_blank" rel="noopener noreferrer"><em>vacalibration: Calibration of Computer-Coded Verbal Autopsy Algorithm</em></a>. R package version 2.0. COMSA Mozambique data.</small>
+    </div>
+  </div>
+) : (
+  <div className="form-group">
+    <label>VA Data File (CSV)</label>
+    <input
+      type="file"
+      accept=".csv"
+      onChange={(e) => updateUpload(0, 'file', e.target.files[0])}
+    />
+    <small className="form-hint">
+      WHO 2016 VA questionnaire format (columns: i004a, i004b, ...)
+    </small>
+    <div className="sample-download">
+      <a
+        href={`${import.meta.env.BASE_URL}${ageGroup === 'neonate' ? 'sample_openva_neonate.csv' : 'sample_openva_child.csv'}`}
+        download
+      >
+        Download sample CSV ({ageGroup === 'neonate' ? 'neonate' : 'child'})
+      </a>
+    </div>
+  </div>
+)}
+```
+
+Note: Pipeline mode now uses the "openVA-style" single-file upload branch (the else). This is consistent with how the openVA portion of Pipeline accepts WHO 2016 input. Pipeline's ensemble mode previously didn't get per-algorithm upload rows either (the old multi-upload block was gated on `jobType === 'vacalibration' && ensemble`), so this is no behavior change for Pipeline.
+
+- [ ] **Step 6: Update the existing upload-sync effect to always sync for vacalibration**
+
+Find lines 69-79 (the effect that syncs upload rows from checked algorithms). Replace with:
+
+```javascript
+// Auto-generate upload rows from checked algorithms (calibration-only mode:
+// always per-algorithm; pipeline/openva: single upload).
+useEffect(() => {
+  if (jobType === 'vacalibration') {
+    setUploads(prev => {
+      return algorithms.map(algo => {
+        const existing = prev.find(u => u.algorithm === algo);
+        return existing || { id: nextUploadId++, algorithm: algo, file: null };
+      });
+    });
+  }
+}, [algorithms, jobType]);
+```
+
+Also adjust the earlier effect at lines 56-67 — remove the upload-collapse logic that was tied to `ensemble`. The new version:
+
+```javascript
+// Sync algorithms state when switching between single/multi mode.
+useEffect(() => {
+  const needsSingleSelect =
+    jobType === 'openva' ||
+    (jobType === 'pipeline' && !ensemble);
+
+  if (needsSingleSelect) {
+    setAlgorithms(prev => prev.length > 1 ? [prev[0]] : prev);
+  }
+
+  // For openva/pipeline modes, collapse uploads to a single row.
+  if (jobType !== 'vacalibration') {
+    setUploads(prev => prev.length > 1 ? [prev[0]] : prev);
+  }
+}, [jobType, ensemble]);
+```
+
+- [ ] **Step 7: Update submit-button disabled condition**
+
+Locate the submit button at line 479. The current expression:
+
+```jsx
+disabled={loading || activeJob || (
+  jobType === 'vacalibration' && ensemble
+    ? uploads.some(u => !u.file)
+    : !uploads[0]?.file
+)}
+```
+
+Replace with (vacalibration always requires every upload row to have a file):
+
+```jsx
+disabled={loading || activeJob || (
+  jobType === 'vacalibration'
+    ? uploads.some(u => !u.file)
+    : !uploads[0]?.file
+)}
+```
+
+- [ ] **Step 8: Update validation effect — remove ensemble-specific gating**
+
+The current validation effect at lines 82-92 enforces "ensemble requires ≥2 algos". With the new flow, ensemble is automatically disabled when <2 algos are selected (it can't be set true via UI), so this constraint is structurally enforced. Simplify to:
+
+```javascript
+useEffect(() => {
+  if (algorithms.length === 0) {
+    setValidationError('Please select at least one algorithm');
+  } else if (jobType === 'pipeline' && ensemble && algorithms.length < 2) {
+    // Pipeline still requires explicit validation (its ensemble checkbox is
+    // user-toggled before the algorithm picker — different UX shape).
+    setValidationError('Ensemble calibration requires at least 2 algorithms');
+  } else {
+    setValidationError(null);
+  }
+}, [ensemble, algorithms, jobType]);
+```
+
+- [ ] **Step 9: Update submit / demo handlers — remove vacalibration-specific ensemble validation**
+
+Lines 125-129 in `handleSubmit` and the matching block in `handleDemo` (lines 169-173) currently throw the "Ensemble calibration requires at least 2 algorithms" error for vacalibration too. Since the UI now prevents this state for vacalibration, remove the vacalibration arm:
+
+Replace lines 125-129 with:
+
+```javascript
+if (ensemble && algorithms.length < 2 && jobType === 'pipeline') {
+  setError('Ensemble calibration requires at least 2 algorithms');
+  setLoading(false);
+  return;
+}
+```
+
+Make the identical change in `handleDemo` (lines 169-173).
+
+Also update the submit payload — pass `ensemble: ensemble && algorithms.length >= 2` so the client never sends a logically-invalid combination:
+
+In `handleSubmit` (line 139): replace `ensemble,` with `ensemble: ensemble && algorithms.length >= 2,`.
+In `handleDemo` (line 176): replace `ensemble` with `ensemble: ensemble && algorithms.length >= 2`.
+
+- [ ] **Step 10: Remove the file-algorithm-mismatch hint**
+
+The hint at lines 232-238 (`If your data already contains algorithm information, the algorithm selection below will be used to match the data format`) is in the old combined-conditional block, which Step 4 already replaced. Confirm it's gone by searching:
+
+Run: `grep -n 'algorithm selection below will be used to match' frontend/src/components/JobForm.jsx`
+Expected: (no output)
+
+If still present, delete the offending lines.
+
+- [ ] **Step 11: Run all JobForm tests — expect PASS**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.test.js src/components/JobForm.behavior.test.jsx`
+
+Expected:
+- All assertions in `JobForm.test.js` PASS (including the 4 new ones added in Task 2).
+- All 4 assertions in `JobForm.behavior.test.jsx` PASS.
+
+If a behavior test fails because `screen.getByLabelText` can't find an element, double-check that:
+- The ensemble checkbox is wrapped in its `<label>` (it is, per Step 4).
+- The label text exactly matches the regex (`Also run ensemble`).
+- Algorithm checkboxes are inside `<label className="checkbox-label">` with the algorithm name as label text.
+
+If `switchToCalibrationOnly` is failing on the CustomSelect interaction, you can short-circuit it by relying on the default `jobType = 'vacalibration'` and removing the helper call from the tests (the form starts in calibration-only mode already).
+
+- [ ] **Step 12: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add frontend/src/components/JobForm.jsx
+git commit -m "feat(ui): algorithms-first flow for Calibration Only mode
+
+- Split jobType conditional into separate openva/pipeline/vacalibration JSX
+  branches so the new algorithms-first UI for Calibration doesn't affect
+  Pipeline's existing ensemble-first flow.
+- For vacalibration: algorithm checkboxes always visible; 'Also run ensemble'
+  row always rendered, disabled when <2 algos selected, with hint.
+- Add ensembleUserTouched sentinel powering sticky-uncheck across 1<->2
+  algorithm crossings.
+- Auto-enable ensemble when crossing 1->2 algorithms (Effect B), respecting
+  the touched sentinel.
+- Upload section always shows one labeled row per selected algorithm in
+  calibration-only mode.
+- Remove obsolete file-algorithm-mismatch hint banner.
+- Backend contract unchanged; ensemble is gated client-side as
+  defense-in-depth before submit."
+```
+
+---
+
+## Task 4: Run full test suite + manual smoke test
+
+**Files:** None modified — verification only.
+
+- [ ] **Step 1: Run the entire frontend vitest suite**
+
+Run: `cd frontend && npm test -- --run`
+Expected: All test files PASS. Failure here usually means another file depended on JobForm's old structure (unlikely — only JobForm.test.js and the new behavior file reference JobForm directly).
+
+- [ ] **Step 2: Verify the backend is running and start it if not**
+
+Run: `lsof -ti:8000 || (cd backend && Rscript run.R &)`
+Wait a few seconds for it to come up. Verify with `curl -s http://localhost:8000/health`.
+
+- [ ] **Step 3: Run the Playwright E2E suite**
+
+Run: `cd frontend && npm run test:e2e`
+Expected: Both E2E tests PASS. The E2E tests exercise the Demo Gallery flow, not JobForm directly, so they should be unaffected. If they fail with a selector error, inspect the failure and update the selector in `frontend/e2e/demo-gallery.spec.js`; do NOT update anything in JobForm.jsx.
+
+- [ ] **Step 4: Manual UI smoke test**
+
+Start the frontend (`cd frontend && npm run dev`) and open it in the browser.
+
+Verify the following by hand:
+
+1. Switch Job Type to "Calibration Only". Confirm:
+   - Three algorithm checkboxes visible (InterVA checked by default).
+   - "Also run ensemble" row visible but checkbox **disabled** with "Requires 2+ algorithms" hint.
+   - One upload row labeled "InterVA".
+2. Check "InSilicoVA". Confirm:
+   - Ensemble row becomes **enabled** and **auto-checks**.
+   - Hint changes to "Runs per-algorithm calibration plus an additional combined ensemble result. Estimated runtime: 2-4 minutes."
+   - Upload rows now show "InterVA" and "InSilicoVA".
+3. Uncheck "Also run ensemble". Drop "InSilicoVA". Re-check "InSilicoVA". Confirm:
+   - Ensemble row enabled but checkbox **stays unchecked** (sticky).
+4. Click "Run Demo". Confirm the job submits and runs (backend log shows 2 algorithms loaded).
+5. Switch Job Type to "Full Pipeline". Confirm:
+   - Ensemble checkbox appears FIRST (above the algorithm picker).
+   - Picker is a single dropdown by default; switches to checkboxes when Ensemble Mode is checked.
+   - This is the original flow, unchanged.
+6. Switch Job Type to "openVA Only". Confirm single dropdown picker, single file upload.
+
+- [ ] **Step 5: Commit any final adjustments**
+
+If any step in Task 4 required a code tweak (e.g., E2E selector update), commit it now:
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add -p   # review hunks
+git commit -m "fix: adjustments after end-to-end verification of algorithms-first flow"
+```
+
+If nothing was modified, skip this step.
+
+---
+
+## Acceptance Verification
+
+After Task 4 passes:
+
+- [ ] Acceptance #1: 1 algo selected → ensemble row disabled with "Requires 2+ algorithms" hint; one labeled upload row.
+- [ ] Acceptance #2: 2nd algo checked → ensemble row enables and auto-checks; 2nd labeled upload row appears.
+- [ ] Acceptance #3: Sticky-uncheck behavior verified manually (Task 4 Step 4 case 3) and by behavior test #3.
+- [ ] Acceptance #4: Run Demo with N algorithms loads sample data for exactly those N algorithms; ensemble row included iff ensemble checkbox is checked and N ≥ 2.
+- [ ] Acceptance #5: Pipeline mode and openVA Only mode behave identically to before (manual verification in Task 4 Step 4 cases 5 and 6).
+- [ ] Acceptance #6: Existing vitest suite + 4 new vitest cases + E2E demo-gallery all PASS.
+
+---
+
+## Self-Review Notes
+
+**Spec coverage:**
+- UI Layout — Task 3 Steps 4-5.
+- State Model (ensembleUserTouched, derived `canEnsemble`) — Task 3 Steps 1-3.
+- Effect A (sync uploads) — Task 3 Step 6.
+- Effect B (auto-enable 1→2) — Task 3 Step 2.
+- Effect C (validation) — Task 3 Step 8.
+- Submit payload gating — Task 3 Step 9.
+- Edge case #1 (empty-array guard) — existing code preserved.
+- Edge case #2 (keyed upload preservation) — Task 3 Step 6 retains `prev.find(u => u.algorithm === algo)`.
+- Edge case #3 (Demo respects checkbox selection) — Task 3 Step 9 payload change; backend already supports this.
+- Edge case #4 (job-type switch state persistence) — existing behavior preserved; only rendering branches on jobType.
+- Edge case #5 (remove file-algorithm hint) — Task 3 Step 10.
+- Edge case #6 (Pipeline mode untouched) — Task 3 Step 4 keeps Pipeline branch identical to today's code.
+- Testing plan — Tasks 1, 2, 4.
+
+**No placeholders detected:** All code blocks contain full text; all commands have expected outputs; all file paths are absolute or clearly relative-to-frontend.
+
+**Type/name consistency:** `ensembleUserTouched` / `setEnsembleUserTouched` used consistently across the state declaration, Effect B, and the onChange handler. `handleAlgorithmToggle`, `handleAlgorithmSelect`, `updateUpload`, `uploads`, `algorithms` all use existing names from JobForm.jsx.

--- a/docs/superpowers/specs/2026-05-12-calibration-mode-flow-redesign.md
+++ b/docs/superpowers/specs/2026-05-12-calibration-mode-flow-redesign.md
@@ -1,0 +1,235 @@
+# Calibration-Only Mode: Algorithms-First Flow Redesign
+
+**Date:** 2026-05-12
+**Scope:** `frontend/src/components/JobForm.jsx` — Calibration Only mode UX only
+**Status:** Design approved; ready for implementation plan
+
+## Problem
+
+In Calibration Only mode the user picks **Ensemble Mode** first, then algorithms.
+The picker swaps between a single dropdown (ensemble OFF) and multi-select
+checkboxes (ensemble ON). This treats "ensemble" as a *mode switch*.
+
+The `vacalibration` R package treats ensemble as an *additional output*: pass it
+2+ algorithms with `ensemble = TRUE` and you get per-algorithm calibration rows
+**plus** an extra `"ensemble"` row in `pcalib_postsumm`. The backend already
+auto-derives `ensemble_val` from algorithm count
+(`backend/jobs/algorithms/vacalibration.R:18-19`); only the frontend forces the
+inverted order.
+
+## Goal
+
+Flip the Calibration Only UI to algorithms-first:
+
+1. User picks 1+ algorithms (always multi-select checkboxes).
+2. If 2+ are picked, an **"Also run ensemble"** option appears and is checked
+   by default.
+3. Submit runs per-algorithm calibration for every selected algorithm, plus the
+   ensemble combined result when the option is checked.
+
+This matches the package's mental model and removes the dropdown/checkbox swap.
+
+## Out of Scope
+
+- Pipeline mode UI (keeps current ensemble-first checkbox flow).
+- openVA-only mode UI.
+- Backend code (`vacalibration.R`, `processor.R`, API endpoints) — no changes.
+- `api/client.js` submit payload shape — unchanged.
+- Result display in `JobDetail.jsx`.
+- Sample CSV files in `frontend/public/`.
+
+## UI Layout (Calibration Only)
+
+```
+Job Type:  [ Calibration Only            ▾ ]
+
+Algorithms *
+  ☑ InterVA      (fastest, ~30sec)
+  ☐ InSilicoVA   (most accurate, ~2-3min)
+  ☐ EAVA         (deterministic, ~1min)
+
+  ── when 1 algorithm selected ──
+  ☐ Also run ensemble  (disabled — requires 2+ algorithms)
+
+  ── when 2+ algorithms selected ──
+  ☑ Also run ensemble (combines algorithms)
+    Runs per-algorithm calibration + an additional combined ensemble result.
+
+Age Group:  [ Neonate (0-27 days)        ▾ ]
+Country:    [ Mozambique                 ▾ ]
+Propagate uncertainty: [ Yes (prior)     ▾ ]
+▸ Advanced MCMC Settings
+
+VA Data Files (one CSV per selected algorithm)
+  InterVA      [ Choose file ]
+  InSilicoVA   [ Choose file ]   ← shown only if checked
+  EAVA         [ Choose file ]   ← shown only if checked
+
+[ Calibrate ]    [ Run Demo ]
+```
+
+### Changes vs. current
+
+| Today | New |
+|-------|-----|
+| Ensemble checkbox → algorithm picker | Algorithm picker → ensemble checkbox |
+| Picker swaps dropdown ↔ checkboxes | Picker is always checkboxes |
+| Upload section toggles between single/multi | One labeled upload row per selected algorithm, always |
+| Ensemble checkbox always visible | Ensemble row always visible but **disabled when <2 algorithms** |
+| Default: InterVA only, ensemble OFF | Default: InterVA only, ensemble row visible-disabled |
+
+### Removed UI states
+
+- Single "VA Data File" branch (`JobForm.jsx:419-453`) — gone for calibration-only.
+- Dropdown picker (`JobForm.jsx:274-284`) — gone for calibration-only.
+- File-algorithm-mismatch hint (`JobForm.jsx:232-238`) — removed; per-algorithm
+  upload labels make it self-evident.
+
+## State Model
+
+Reuse existing state variables — no new ones.
+
+```
+algorithms : string[]    // e.g. ['InterVA'] or ['InterVA', 'EAVA']
+ensemble   : boolean     // checked state of "Also run ensemble"
+uploads    : Upload[]    // [{ id, algorithm, file }, ...]
+
+Derived:
+  canEnsemble       = algorithms.length >= 2
+  ensembleEffective = canEnsemble && ensemble   // sent to backend
+  allFilesProvided  = uploads.every(u => u.file)
+```
+
+### Effects
+
+**A. Sync uploads to algorithms (calibration-only mode):**
+
+```
+uploads = algorithms.map(algo =>
+  existing-row-with-same-algorithm || new row { algorithm: algo, file: null }
+)
+```
+
+Preserves files for unchanged algorithms; adds rows for newly-checked algorithms;
+drops rows for unchecked ones.
+
+**B. Auto-enable ensemble on 1 → 2+ crossing:**
+
+If `algorithms.length` transitions from 1 to ≥2 AND the user has not explicitly
+unchecked ensemble in this session, set `ensemble = true`.
+
+A session-scoped sentinel (e.g. `ensembleUserTouched`) tracks whether the user
+clicked the ensemble checkbox. Sticky-uncheck means: user unchecks ensemble →
+drops to 1 algo → re-adds 2nd algo → ensemble stays unchecked.
+
+**C. Validation:**
+
+```
+algorithms.length === 0          → "Select at least one algorithm"
+uploads.some(u => !u.file)       → "Upload a file for each selected algorithm"
+                                    (or rely on submit-button disabled state)
+```
+
+No ensemble-specific validation — `canEnsemble` is derived; can't be invalid.
+
+### Submit payload (unchanged shape)
+
+```javascript
+{
+  jobType: 'vacalibration',
+  algorithms,                          // e.g. ['InterVA', 'EAVA']
+  ensemble: canEnsemble && ensemble,   // boolean — backend already handles this
+  ageGroup, country, calibModelType,
+  nMCMC, nBurn, nThin,
+  uploads                              // [{ algorithm, file }, ...]
+}
+```
+
+## Validation Rules
+
+| Condition | Inline message | Submit disabled? |
+|-----------|----------------|------------------|
+| `algorithms.length === 0` | "Please select at least one algorithm" | ✓ |
+| 1 algo, no file | none | ✓ |
+| ≥2 algos, any missing file | "Upload a file for each selected algorithm" | ✓ |
+| 1 algo, ensemble disabled | hint: "Requires 2+ algorithms" | — |
+| All ok | none | ✗ |
+
+## Edge Cases
+
+1. **Unchecking all algorithms.** Existing guard in `handleAlgorithmToggle`
+   (`JobForm.jsx:97-98`) prevents empty array. Keep.
+
+2. **Removing a middle algorithm.** Other algorithms' files must be preserved.
+   The keyed lookup in Effect A (`existing = prev.find(u => u.algorithm === algo)`)
+   already handles this. Keep.
+
+3. **Run Demo respects checkbox selection.** Demo loads sample data only for
+   currently-checked algorithms. Backend supports this — `vacalibration.R:39-45`
+   iterates `algo_names` and calls `load_vacalibration_sample(algo, ...)` per
+   selected algorithm.
+
+4. **Switching job type away and back.** State persists when toggling
+   `jobType`. Only rendering branches on `jobType`. Current behavior preserved.
+
+5. **File-algorithm hint banner.** Removed (no longer needed with per-algorithm
+   upload labels).
+
+6. **Pipeline mode untouched.** The conditional in `JobForm.jsx:218` splits:
+
+   ```jsx
+   {jobType === 'pipeline' && (
+     // existing ensemble-first checkbox UI (unchanged)
+   )}
+   {jobType === 'vacalibration' && (
+     // new algorithms-first UI
+   )}
+   ```
+
+## Backend Compatibility
+
+**No backend changes.** `vacalibration.R:11-23` already:
+
+- Reads `algo_names` from the job payload.
+- Derives `ensemble_val` from algorithm count when not explicitly set.
+- Forces `ensemble_val = FALSE` if only 1 algorithm is present.
+- Loads sample data per algorithm in the demo path (lines 39-45).
+- Routes uploaded files by filename (`input_<algo>.csv`) in the upload path
+  (lines 47-91).
+
+The frontend's `canEnsemble && ensemble` gate is defense-in-depth — even if the
+client sends `ensemble: true` with 1 algorithm, the backend safely downgrades to
+single-algo and logs a warning.
+
+## Testing Plan
+
+| Test type | Location | What to change |
+|-----------|----------|----------------|
+| Unit (vitest) | `frontend/src/components/JobForm.test.js` | Add 4 cases: ensemble row hidden→disabled→enabled as algos toggle; auto-enable on 1→2 crossing; sticky-uncheck preserved; upload rows match selected algorithms 1:1 |
+| Unit (vitest) | `frontend/src/components/JobForm.test.js` | Update existing assertions that depended on ensemble-first ordering |
+| R backend | `tests/test_vacalibration_backend.R` | No changes — backend behavior unchanged |
+| E2E (Playwright) | `frontend/e2e/demo-gallery.spec.js` | Verify Demo flow still works; selector updates for algorithm checkboxes likely |
+
+## Risk Assessment
+
+- **Backend contract:** unchanged → near-zero backend risk.
+- **Client state surface:** the synchronization between `algorithms`,
+  `ensemble`, and `uploads` is where bugs will hide. Vitest cases focus on
+  transitions (1→2 algos, uncheck-then-recheck), not just static snapshots.
+- **Pipeline mode regression:** mitigated by the explicit `jobType` split — the
+  new branch only renders when `jobType === 'vacalibration'`.
+
+## Acceptance Criteria
+
+1. With Calibration Only selected and 1 algorithm checked: ensemble row visible
+   but disabled with hint "Requires 2+ algorithms"; one labeled upload row
+   visible.
+2. Checking a 2nd algorithm: ensemble row auto-enables with checkbox checked;
+   a 2nd labeled upload row appears.
+3. Unchecking ensemble, then unchecking the 2nd algorithm, then re-checking it:
+   ensemble row enables but checkbox remains unchecked (sticky behavior).
+4. Demo button with N algorithms checked: loads sample data for exactly those N
+   algorithms; ensemble row included in result iff ensemble checkbox is checked
+   and N ≥ 2.
+5. Pipeline mode and openVA Only mode behave identically to today.
+6. Existing vitest suite passes; new vitest cases pass; E2E demo-gallery passes.

--- a/frontend/src/components/JobForm.behavior.test.jsx
+++ b/frontend/src/components/JobForm.behavior.test.jsx
@@ -1,0 +1,95 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+// Stub the API client — these tests are pure UI behavior, no backend calls.
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+const renderForm = () => render(<JobForm onJobSubmitted={() => {}} />)
+
+const switchToCalibrationOnly = () => {
+  // The default jobType is already 'vacalibration' (Calibration Only), so this
+  // helper is a no-op in the current code. After the refactor the default may
+  // change; at that point this helper will need to drive the CustomSelect.
+  // For now: verify the form is in Calibration Only mode, or do nothing.
+}
+
+const getAlgoCheckbox = (name) =>
+  screen.getByLabelText(new RegExp(`^${name}\\b`, 'i'))
+
+const getEnsembleCheckbox = () =>
+  screen.getByLabelText(/Also run ensemble/i)
+
+describe('Calibration Only — algorithms-first flow', () => {
+  beforeEach(() => {
+    vi.clearAllMocks()
+  })
+
+  it('ensemble row is rendered but disabled when only 1 algorithm is selected', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    // Default state: InterVA only.
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble).toBeTruthy()
+    expect(ensemble.disabled).toBe(true)
+
+    // Hint text is visible.
+    expect(screen.getByText(/requires 2\+ algorithms/i)).toBeTruthy()
+  })
+
+  it('auto-enables ensemble when user crosses from 1 to 2 algorithms', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble.checked).toBe(false)
+
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+
+    expect(ensemble.disabled).toBe(false)
+    expect(ensemble.checked).toBe(true)
+  })
+
+  it('respects sticky-uncheck: once user unchecks ensemble, do not auto-re-enable on re-crossing', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    const ensemble = getEnsembleCheckbox()
+    expect(ensemble.checked).toBe(true)
+
+    fireEvent.click(ensemble)
+    expect(ensemble.checked).toBe(false)
+
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(ensemble.disabled).toBe(true)
+
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(ensemble.disabled).toBe(false)
+    expect(ensemble.checked).toBe(false)
+  })
+
+  it('renders one labeled upload row per selected algorithm, regardless of ensemble', () => {
+    renderForm()
+    switchToCalibrationOnly()
+
+    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.queryByText(/^InSilicoVA/i)).toBeNull()
+
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
+    expect(screen.getAllByText(/^InSilicoVA/i).length).toBeGreaterThanOrEqual(1)
+
+    const fileInputs = document.querySelectorAll('input[type="file"]')
+    expect(fileInputs.length).toBe(2)
+  })
+})

--- a/frontend/src/components/JobForm.behavior.test.jsx
+++ b/frontend/src/components/JobForm.behavior.test.jsx
@@ -79,17 +79,26 @@ describe('Calibration Only — algorithms-first flow', () => {
   })
 
   it('renders one labeled upload row per selected algorithm, regardless of ensemble', () => {
-    renderForm()
+    const { container } = renderForm()
     switchToCalibrationOnly()
 
-    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
-    expect(screen.queryByText(/^InSilicoVA/i)).toBeNull()
+    // Scope to upload rows (CSS class `.upload-row`) to avoid matching sample
+    // download links that also contain algorithm names.
+    let uploadRows = container.querySelectorAll('.upload-row')
+    expect(uploadRows.length).toBe(1)
+    expect(uploadRows[0].textContent).toMatch(/InterVA/i)
+    expect(uploadRows[0].textContent).not.toMatch(/InSilicoVA/i)
 
     fireEvent.click(getAlgoCheckbox('InSilicoVA'))
-    expect(screen.getAllByText(/^InterVA/i).length).toBeGreaterThanOrEqual(1)
-    expect(screen.getAllByText(/^InSilicoVA/i).length).toBeGreaterThanOrEqual(1)
 
-    const fileInputs = document.querySelectorAll('input[type="file"]')
+    uploadRows = container.querySelectorAll('.upload-row')
+    expect(uploadRows.length).toBe(2)
+    const allText = Array.from(uploadRows).map(r => r.textContent).join('|')
+    expect(allText).toMatch(/InterVA/i)
+    expect(allText).toMatch(/InSilicoVA/i)
+
+    // Each upload row owns exactly one file input.
+    const fileInputs = container.querySelectorAll('.upload-row input[type="file"]')
     expect(fileInputs.length).toBe(2)
   })
 })

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -13,6 +13,7 @@ export default function JobForm({ onJobSubmitted }) {
   const [uploads, setUploads] = useState([{ id: nextUploadId++, algorithm: '', file: null }]);
   const [calibModelType, setCalibModelType] = useState('Mmatprior');
   const [ensemble, setEnsemble] = useState(false);
+  const [ensembleUserTouched, setEnsembleUserTouched] = useState(false);
   const [showAdvanced, setShowAdvanced] = useState(false);
   const [nMCMC, setNMCMC] = useState(5000);
   const [nBurn, setNBurn] = useState(2000);
@@ -52,23 +53,26 @@ export default function JobForm({ onJobSubmitted }) {
     return () => clearInterval(interval);
   }, [activeJob]);
 
-  // Sync algorithms state when switching between single/multi mode
+  // Sync algorithms state when switching between single/multi mode.
   useEffect(() => {
-    const needsSingleSelect = jobType === 'openva' || (jobType === 'pipeline' && !ensemble) || (jobType === 'vacalibration' && !ensemble);
+    const needsSingleSelect =
+      jobType === 'openva' ||
+      (jobType === 'pipeline' && !ensemble);
 
     if (needsSingleSelect) {
       setAlgorithms(prev => prev.length > 1 ? [prev[0]] : prev);
     }
 
-    // Non-ensemble: keep single upload row
-    if (!(jobType === 'vacalibration' && ensemble)) {
+    // For openva/pipeline modes, collapse uploads to a single row.
+    if (jobType !== 'vacalibration') {
       setUploads(prev => prev.length > 1 ? [prev[0]] : prev);
     }
   }, [jobType, ensemble]);
 
-  // Auto-generate upload rows from checked algorithms (ensemble vacalibration)
+  // Auto-generate upload rows from checked algorithms (calibration-only mode:
+  // always per-algorithm; pipeline/openva: single upload).
   useEffect(() => {
-    if (jobType === 'vacalibration' && ensemble) {
+    if (jobType === 'vacalibration') {
       setUploads(prev => {
         return algorithms.map(algo => {
           const existing = prev.find(u => u.algorithm === algo);
@@ -76,20 +80,33 @@ export default function JobForm({ onJobSubmitted }) {
         });
       });
     }
-  }, [algorithms, jobType, ensemble]);
+  }, [algorithms, jobType]);
 
   // Validation for ensemble requirements
   useEffect(() => {
-    const needsMultiSelect = jobType === 'vacalibration' && ensemble;
-
-    if (needsMultiSelect && algorithms.length < 2) {
-      setValidationError('Ensemble calibration requires at least 2 algorithms');
-    } else if (algorithms.length === 0) {
+    if (algorithms.length === 0) {
       setValidationError('Please select at least one algorithm');
+    } else if (jobType === 'pipeline' && ensemble && algorithms.length < 2) {
+      // Pipeline still requires explicit validation (its ensemble checkbox is
+      // user-toggled before the algorithm picker — different UX shape).
+      setValidationError('Ensemble calibration requires at least 2 algorithms');
     } else {
       setValidationError(null);
     }
   }, [ensemble, algorithms, jobType]);
+
+  // Effect B (algorithms-first flow): when the user crosses from 1 to 2+
+  // algorithms in calibration-only mode, auto-enable the ensemble checkbox —
+  // UNLESS the user has explicitly touched it (sticky behavior).
+  useEffect(() => {
+    if (
+      jobType === 'vacalibration' &&
+      algorithms.length >= 2 &&
+      !ensembleUserTouched
+    ) {
+      setEnsemble(true);
+    }
+  }, [algorithms.length, jobType, ensembleUserTouched]);
 
   const handleAlgorithmToggle = (algo) => {
     setAlgorithms(prev => {
@@ -122,7 +139,7 @@ export default function JobForm({ onJobSubmitted }) {
       return;
     }
 
-    if (ensemble && algorithms.length < 2 && jobType === 'vacalibration') {
+    if (ensemble && algorithms.length < 2 && jobType === 'pipeline') {
       setError('Ensemble calibration requires at least 2 algorithms');
       setLoading(false);
       return;
@@ -136,7 +153,7 @@ export default function JobForm({ onJobSubmitted }) {
         ageGroup,
         country,
         calibModelType,
-        ensemble,
+        ensemble: ensemble && algorithms.length >= 2,
         nMCMC,
         nBurn,
         nThin
@@ -166,14 +183,14 @@ export default function JobForm({ onJobSubmitted }) {
       return;
     }
 
-    if (ensemble && algorithms.length < 2 && jobType === 'vacalibration') {
+    if (ensemble && algorithms.length < 2 && jobType === 'pipeline') {
       setError('Ensemble calibration requires at least 2 algorithms');
       setLoading(false);
       return;
     }
 
     try {
-      const result = await submitDemoJob({ jobType, algorithms, ageGroup, country, calibModelType, ensemble, nMCMC, nBurn, nThin });
+      const result = await submitDemoJob({ jobType, algorithms, ageGroup, country, calibModelType, ensemble: ensemble && algorithms.length >= 2, nMCMC, nBurn, nThin });
       if (result.error) {
         setError(result.error);
       } else {
@@ -205,17 +222,32 @@ export default function JobForm({ onJobSubmitted }) {
           />
         </div>
 
-        {/* Algorithm Selection - show for all job types */}
-        <div className="form-group">
-          <label>
-            Algorithm{(jobType === 'vacalibration' && ensemble) ? 's' : ''}
-            {jobType === 'vacalibration' && ensemble && (
-              <span className="required"> * Select at least 2 for ensemble</span>
-            )}
-          </label>
+        {/* Algorithm Selection - split by job type */}
+        {jobType === 'openva' && (
+          <div className="form-group">
+            <label>Algorithm</label>
+            <CustomSelect
+              value={algorithms[0] || 'InterVA'}
+              onChange={handleAlgorithmSelect}
+              options={[
+                { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+                { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+                { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+              ]}
+            />
+            {validationError && <small className="validation-error">{validationError}</small>}
+          </div>
+        )}
 
-          {/* Ensemble checkbox - for vacalibration and pipeline */}
-          {(jobType === 'vacalibration' || jobType === 'pipeline') && (
+        {jobType === 'pipeline' && (
+          <div className="form-group">
+            <label>
+              Algorithm{ensemble ? 's' : ''}
+              {ensemble && (
+                <span className="required"> * Select at least 2 for ensemble</span>
+              )}
+            </label>
+
             <div className="ensemble-toggle">
               <label>
                 <input
@@ -226,19 +258,60 @@ export default function JobForm({ onJobSubmitted }) {
                 {' '}Ensemble Mode (combine multiple algorithms)
               </label>
             </div>
-          )}
 
-          {/* File-based algorithm hint - show when file is uploaded for vacalibration */}
-          {jobType === 'vacalibration' && uploads[0]?.file && (
-            <div className="file-algorithm-hint">
-              <small className="form-hint">
-                ⓘ If your data already contains algorithm information, the algorithm selection below will be used to match the data format
-              </small>
-            </div>
-          )}
+            {ensemble ? (
+              <div className="algorithm-checkboxes">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InterVA')}
+                    onChange={() => handleAlgorithmToggle('InterVA')}
+                  />
+                  InterVA (fastest, ~30sec)
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InSilicoVA')}
+                    onChange={() => handleAlgorithmToggle('InSilicoVA')}
+                  />
+                  InSilicoVA (most accurate, ~2-3min)
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('EAVA')}
+                    onChange={() => handleAlgorithmToggle('EAVA')}
+                  />
+                  EAVA (deterministic, ~1min)
+                </label>
+                {algorithms.length > 1 && (
+                  <small className="form-hint warning">
+                    Running {algorithms.length} algorithms will take approximately{' '}
+                    {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}
+                  </small>
+                )}
+              </div>
+            ) : (
+              <CustomSelect
+                value={algorithms[0] || 'InterVA'}
+                onChange={handleAlgorithmSelect}
+                options={[
+                  { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+                  { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+                  { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+                ]}
+              />
+            )}
 
-          {/* Dynamic UI: Dropdown for single-select, Checkboxes for multi-select */}
-          {(jobType === 'vacalibration' || jobType === 'pipeline') && ensemble ? (
+            {validationError && <small className="validation-error">{validationError}</small>}
+          </div>
+        )}
+
+        {jobType === 'vacalibration' && (
+          <div className="form-group">
+            <label>Algorithms *</label>
+
             <div className="algorithm-checkboxes">
               <label className="checkbox-label">
                 <input
@@ -264,27 +337,37 @@ export default function JobForm({ onJobSubmitted }) {
                 />
                 EAVA (deterministic, ~1min)
               </label>
-              {algorithms.length > 1 && (
-                <small className="form-hint warning">
-                  Running {algorithms.length} algorithms will take approximately{' '}
-                  {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}
+            </div>
+
+            {/* Ensemble row: always rendered, disabled when <2 algos */}
+            <div className="ensemble-toggle">
+              <label>
+                <input
+                  type="checkbox"
+                  checked={ensemble && algorithms.length >= 2}
+                  disabled={algorithms.length < 2}
+                  onChange={(e) => {
+                    setEnsembleUserTouched(true);
+                    setEnsemble(e.target.checked);
+                  }}
+                />
+                {' '}Also run ensemble (combines algorithms)
+              </label>
+              {algorithms.length < 2 ? (
+                <small className="form-hint">Requires 2+ algorithms</small>
+              ) : (
+                <small className="form-hint">
+                  Runs per-algorithm calibration plus an additional combined ensemble result.
+                  {algorithms.length > 1 && (
+                    <>{' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.</>
+                  )}
                 </small>
               )}
             </div>
-          ) : (
-            <CustomSelect
-              value={algorithms[0] || 'InterVA'}
-              onChange={handleAlgorithmSelect}
-              options={[
-                { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
-                { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
-                { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
-              ]}
-            />
-          )}
 
-          {validationError && <small className="validation-error">{validationError}</small>}
-        </div>
+            {validationError && <small className="validation-error">{validationError}</small>}
+          </div>
+        )}
 
         <div className="form-group">
           <label>Age Group</label>
@@ -389,9 +472,9 @@ export default function JobForm({ onJobSubmitted }) {
           </div>
         )}
 
-        {jobType === 'vacalibration' && ensemble ? (
+        {jobType === 'vacalibration' ? (
           <div className="form-group">
-            <label>VA Data Files (one CSV per algorithm)</label>
+            <label>VA Data Files (one CSV per selected algorithm)</label>
             {uploads.map((upload, index) => (
               <div key={upload.id} className="upload-row">
                 <span className="upload-algo-label">{upload.algorithm}</span>
@@ -404,7 +487,7 @@ export default function JobForm({ onJobSubmitted }) {
               </div>
             ))}
             <small className="form-hint">
-              Upload separate CCVA output files for each algorithm.
+              Upload one CSV file per selected algorithm. Required columns: ID, cause.
             </small>
             <div className="sample-download">
               <div className="sample-links">
@@ -425,29 +508,15 @@ export default function JobForm({ onJobSubmitted }) {
               onChange={(e) => updateUpload(0, 'file', e.target.files[0])}
             />
             <small className="form-hint">
-              {jobType === 'vacalibration'
-                ? 'Required columns: ID, cause (with cause names)'
-                : 'WHO 2016 VA questionnaire format (columns: i004a, i004b, ...)'}
+              WHO 2016 VA questionnaire format (columns: i004a, i004b, ...)
             </small>
             <div className="sample-download">
-              {jobType === 'vacalibration' ? (
-                <>
-                  <div className="sample-links">
-                    <span>Sample CSV (neonate, 1190 records):</span>
-                    <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
-                    <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
-                    <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
-                  </div>
-                  <small className="sample-source">Source: Pramanik S, Wilson E, Fiksel J, Gilbert B, Datta A (2025). <a href="https://github.com/VA-calibration/vacalibration" target="_blank" rel="noopener noreferrer"><em>vacalibration: Calibration of Computer-Coded Verbal Autopsy Algorithm</em></a>. R package version 2.0. COMSA Mozambique data.</small>
-                </>
-              ) : (
-                <a
-                  href={`${import.meta.env.BASE_URL}${ageGroup === 'neonate' ? 'sample_openva_neonate.csv' : 'sample_openva_child.csv'}`}
-                  download
-                >
-                  Download sample CSV ({ageGroup === 'neonate' ? 'neonate' : 'child'})
-                </a>
-              )}
+              <a
+                href={`${import.meta.env.BASE_URL}${ageGroup === 'neonate' ? 'sample_openva_neonate.csv' : 'sample_openva_child.csv'}`}
+                download
+              >
+                Download sample CSV ({ageGroup === 'neonate' ? 'neonate' : 'child'})
+              </a>
             </div>
           </div>
         )}
@@ -477,7 +546,7 @@ export default function JobForm({ onJobSubmitted }) {
 
         <div className="form-actions">
           <button type="submit" disabled={loading || activeJob || (
-            jobType === 'vacalibration' && ensemble
+            jobType === 'vacalibration'
               ? uploads.some(u => !u.file)
               : !uploads[0]?.file
           )}>

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -106,7 +106,7 @@ export default function JobForm({ onJobSubmitted }) {
     ) {
       setEnsemble(true);
     }
-  }, [algorithms.length, jobType, ensembleUserTouched]);
+  }, [algorithms, jobType, ensembleUserTouched]);
 
   const handleAlgorithmToggle = (algo) => {
     setAlgorithms(prev => {
@@ -358,9 +358,7 @@ export default function JobForm({ onJobSubmitted }) {
               ) : (
                 <small className="form-hint">
                   Runs per-algorithm calibration plus an additional combined ensemble result.
-                  {algorithms.length > 1 && (
-                    <>{' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.</>
-                  )}
+                  {' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.
                 </small>
               )}
             </div>

--- a/frontend/src/components/JobForm.test.js
+++ b/frontend/src/components/JobForm.test.js
@@ -69,17 +69,14 @@ describe('Checkbox-driven ensemble uploads', () => {
   })
 
   it('vacalibration mode always uses per-algorithm upload rows (no single-file branch)', () => {
-    // The vacalibration JSX branch never renders the "VA Data File (CSV)" label —
-    // that label is reserved for openVA-only and Pipeline non-ensemble modes.
-    // Per-algorithm rows are denoted by `upload-row`/`upload-algo-label`.
-    expect(jobFormSrc).toContain('upload-algo-label')
-
-    // Negative guard: in the vacalibration branch, the legacy single-file label
-    // must not appear. We tolerate the label elsewhere (Pipeline non-ensemble).
-    const calibBlock = jobFormSrc.match(
-      /jobType === 'vacalibration'[\s\S]*?(?=jobType === 'pipeline'|jobType === 'openva'|$)/
-    )?.[0] || ''
-    expect(calibBlock).not.toMatch(/VA Data File \(CSV\)/)
+    expect(jobFormSrc).toContain('upload-algo-label');
+    // The upload section for vacalibration must be unconditional (not gated on ensemble).
+    // Current (bad): jobType === 'vacalibration' && ensemble ? (multi) : (single)
+    // New (good):    jobType === 'vacalibration' ? (multi) : (single for pipeline/openva)
+    // Guard: the old ternary that gates per-algo upload rows on BOTH vacalibration AND ensemble must be gone.
+    expect(jobFormSrc).not.toMatch(
+      /jobType === 'vacalibration' && ensemble\s*\?[\s\S]{0,400}upload-row/
+    );
   })
 
   it('pipeline ensemble shows checkboxes + single file (no per-algo uploads)', () => {
@@ -87,8 +84,11 @@ describe('Checkbox-driven ensemble uploads', () => {
   })
 
   it('renders an always-visible ensemble row in the vacalibration branch', () => {
-    // Source contains a disabled hint for the 1-algo case.
-    expect(jobFormSrc).toMatch(/requires 2\+ algorithms/i)
+    // Anchor the hint to the vacalibration JSX block so the assertion can't be
+    // satisfied by a hint that lives in the pipeline or openva branch instead.
+    expect(jobFormSrc).toMatch(
+      /jobType === 'vacalibration'[\s\S]{0,2000}requires 2\+ algorithms/i
+    );
   })
 
   it('introduces ensembleUserTouched sentinel for sticky-uncheck behavior', () => {
@@ -98,12 +98,8 @@ describe('Checkbox-driven ensemble uploads', () => {
   it('splits the jobType conditional so pipeline and vacalibration are separate branches', () => {
     // The OLD combined conditional `(jobType === 'vacalibration' || jobType === 'pipeline')`
     // for the ensemble checkbox must not appear in the new code — it has been split.
-    // Pipeline's ensemble-first UI stays under jobType === 'pipeline'.
-    expect(jobFormSrc).toContain("jobType === 'pipeline'")
-    expect(jobFormSrc).toContain("jobType === 'vacalibration'")
-    // The combined form for the ensemble toggle should be gone.
     expect(jobFormSrc).not.toMatch(
-      /\(jobType === ['"]vacalibration['"] \|\| jobType === ['"]pipeline['"]\)[\s\S]{0,200}ensemble-toggle/
+      /\(jobType === ['"]vacalibration['"]\s*\|\|\s*jobType === ['"]pipeline['"]\)[\s\S]{0,200}ensemble-toggle/
     )
   })
 

--- a/frontend/src/components/JobForm.test.js
+++ b/frontend/src/components/JobForm.test.js
@@ -68,12 +68,48 @@ describe('Checkbox-driven ensemble uploads', () => {
     expect(jobFormSrc).not.toContain('addUpload')
   })
 
-  it('keeps single file input for non-ensemble vacalibration', () => {
-    expect(jobFormSrc).toContain("type=\"file\"")
+  it('vacalibration mode always uses per-algorithm upload rows (no single-file branch)', () => {
+    // The vacalibration JSX branch never renders the "VA Data File (CSV)" label —
+    // that label is reserved for openVA-only and Pipeline non-ensemble modes.
+    // Per-algorithm rows are denoted by `upload-row`/`upload-algo-label`.
+    expect(jobFormSrc).toContain('upload-algo-label')
+
+    // Negative guard: in the vacalibration branch, the legacy single-file label
+    // must not appear. We tolerate the label elsewhere (Pipeline non-ensemble).
+    const calibBlock = jobFormSrc.match(
+      /jobType === 'vacalibration'[\s\S]*?(?=jobType === 'pipeline'|jobType === 'openva'|$)/
+    )?.[0] || ''
+    expect(calibBlock).not.toMatch(/VA Data File \(CSV\)/)
   })
 
   it('pipeline ensemble shows checkboxes + single file (no per-algo uploads)', () => {
     expect(jobFormSrc).toContain('algorithm-checkboxes')
+  })
+
+  it('renders an always-visible ensemble row in the vacalibration branch', () => {
+    // Source contains a disabled hint for the 1-algo case.
+    expect(jobFormSrc).toMatch(/requires 2\+ algorithms/i)
+  })
+
+  it('introduces ensembleUserTouched sentinel for sticky-uncheck behavior', () => {
+    expect(jobFormSrc).toMatch(/ensembleUserTouched/)
+  })
+
+  it('splits the jobType conditional so pipeline and vacalibration are separate branches', () => {
+    // The OLD combined conditional `(jobType === 'vacalibration' || jobType === 'pipeline')`
+    // for the ensemble checkbox must not appear in the new code — it has been split.
+    // Pipeline's ensemble-first UI stays under jobType === 'pipeline'.
+    expect(jobFormSrc).toContain("jobType === 'pipeline'")
+    expect(jobFormSrc).toContain("jobType === 'vacalibration'")
+    // The combined form for the ensemble toggle should be gone.
+    expect(jobFormSrc).not.toMatch(
+      /\(jobType === ['"]vacalibration['"] \|\| jobType === ['"]pipeline['"]\)[\s\S]{0,200}ensemble-toggle/
+    )
+  })
+
+  it('removes the file-algorithm-mismatch hint banner', () => {
+    // The hint is no longer needed because each upload row is labeled.
+    expect(jobFormSrc).not.toContain('algorithm selection below will be used to match the data format')
   })
 })
 

--- a/frontend/vite.config.js
+++ b/frontend/vite.config.js
@@ -10,6 +10,7 @@ export default defineConfig({
   },
   test: {
     environment: 'node',
+    globals: true,
     exclude: ['e2e/**', 'node_modules/**'],
   }
 })


### PR DESCRIPTION
## Summary

Flip Calibration Only mode in `JobForm.jsx` from ensemble-first to algorithms-first so the UI matches the `vacalibration` R package's mental model (ensemble = additional output, not a mode switch).

- Algorithm checkboxes are always visible; "Also run ensemble" row is always rendered but disabled when <2 algorithms selected, with hint "Requires 2+ algorithms".
- Auto-enables ensemble on 1→2 algorithm crossing; sticky-uncheck via new `ensembleUserTouched` sentinel so re-crossing doesn't override user intent.
- Upload section always shows one labeled file row per selected algorithm in calibration-only mode (one CSV per algorithm).
- Pipeline mode and openVA Only mode are unchanged — `jobType` conditional now splits into three independent branches.
- Backend untouched; ensemble payload gated client-side as defense-in-depth.

Spec: `docs/superpowers/specs/2026-05-12-calibration-mode-flow-redesign.md`
Plan: `docs/superpowers/plans/2026-05-12-calibration-mode-flow-redesign.md`

## Test Plan

- [x] Unit tests: `cd frontend && npm test -- --run` → 113/113 pass (11 files)
- [x] Source-level structural assertions in `JobForm.test.js` (5 new/modified)
- [x] RTL state-transition tests in new `JobForm.behavior.test.jsx` (4 new — ensemble disabled state, auto-enable on 1→2, sticky-uncheck, per-algorithm upload rows)
- [ ] Manual UI smoke test (6 acceptance points in spec):
  1. Calibration Only + 1 algo → ensemble row disabled with "Requires 2+ algorithms" hint
  2. Check 2nd algo → ensemble auto-enables and checks; 2nd upload row appears
  3. Uncheck ensemble → drop to 1 → re-add 2nd: ensemble stays unchecked (sticky)
  4. Run Demo with N algorithms loads sample data for exactly N
  5. Pipeline mode: ensemble-first flow unchanged
  6. openVA Only mode: single dropdown picker, single file upload

## Known follow-ups (not in this PR)

- Add automated coverage for Demo button payload shape (acceptance #4) — currently verified by code review only
- Add automated coverage for Pipeline-branch structure (acceptance #5) — currently verified by code review only

## Out of scope

- Pre-existing E2E selector drift (`demo-gallery.spec.js` asserts `<h1>VA Calibration Platform</h1>` but landing page renders `<h1>COMSA</h1>` since PR #64)
- Pre-existing vacalibration v2.0/v2.2 parameter mismatch in installed R env
- Port 5173 collision with another local project (env-specific)

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Calibration-Only mode now features an algorithms-first interface with automatic ensemble detection
  * "Also run ensemble" option becomes enabled when 2+ algorithms are selected
  * Ensemble selection is now "sticky"—manual unchecking prevents auto-re-enabling when algorithm selection changes

* **Tests**
  * Added behavior tests for ensemble enable/disable transitions and per-algorithm file upload alignment
  * Updated unit tests to reflect new UI structure

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cliu238/comsa_dashboard/pull/66)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->