### PR TITLE
fix(JobForm): rename ensemble checkbox to "Combine algorithms?" (#65)

### DIFF
--- a/frontend/src/components/JobForm.behavior.test.jsx
+++ b/frontend/src/components/JobForm.behavior.test.jsx
@@ -26,7 +26,7 @@ const getAlgoCheckbox = (name) =>
   screen.getByLabelText(new RegExp(`^${name}\\b`, 'i'))
 
 const getEnsembleCheckbox = () =>
-  screen.getByLabelText(/Also run ensemble/i)
+  screen.getByLabelText(/Combine algorithms\?/i)
 
 describe('Calibration Only — algorithms-first flow', () => {
   beforeEach(() => {

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -351,7 +351,7 @@ export default function JobForm({ onJobSubmitted }) {
                     setEnsemble(e.target.checked);
                   }}
                 />
-                {' '}Also run ensemble (combines algorithms)
+                {' '}Combine algorithms?
               </label>
               {algorithms.length < 2 ? (
                 <small className="form-hint">Requires 2+ algorithms</small>


### PR DESCRIPTION
## Summary

Issue #65 requested two changes; PR #66 landed the algorithms-first layout but kept the label as "Also run ensemble (combines algorithms)". This PR renames it to the question-style framing the reporter asked for.

- `JobForm.jsx:354` — `Also run ensemble (combines algorithms)` → `Combine algorithms?`
- `JobForm.behavior.test.jsx:29` — updated the `getByLabelText` regex accordingly so the 4 behavior tests still find the checkbox

## Test Plan

- [x] `cd frontend && npm test -- --run` → 113/113 pass

Fixes #65

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Style**
  * Updated ensemble checkbox label for improved clarity and conciseness.

* **Tests**
  * Updated test selectors to match updated label text.

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cliu238/comsa_dashboard/pull/67)

<!-- end of auto-generated comment: release notes by coderabbit.ai -->