### PR TITLE
feat: form copy, ordering, controls & VA-Calibration branding (#68)

### DIFF
--- a/docs/superpowers/plans/2026-05-26-issue-68-form-copy-ordering.md
+++ b/docs/superpowers/plans/2026-05-26-issue-68-form-copy-ordering.md
@@ -1,0 +1,548 @@
+# Issue #68 — Form Copy, Ordering & Branding Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Apply issue #68's copy, input-ordering, control, and branding changes to the job form and page title — without changing form behavior, effects, or the backend payload.
+
+**Architecture:** Surgical in-place edits to `JobForm.jsx`, `App.jsx`, `index.html`, and two CSS header comments. The uncertainty dropdown becomes a checkbox that reuses the existing `calibModelType` state (checked → `'Mmatprior'`, unchecked → `'Mmatfixed'`), so the submitted payload is identical. No component extraction, no logic changes.
+
+**Tech Stack:** React 18, Vite, Vitest (`environment: 'node'`; jsdom opt-in per-file via `@vitest-environment jsdom` docblock), @testing-library/react.
+
+---
+
+## Conventions (match the existing repo)
+
+- **Source-level tests** (`*.test.js`, node env): `readFileSync` the `.jsx`/`.html` and assert `toContain` / `not.toContain`. See `src/components/JobForm.test.js`.
+- **Render tests** (`*.test.jsx` with `/** @vitest-environment jsdom */` as the FIRST lines): `render` + `screen` from `@testing-library/react`. Mock `../api/client` (see `src/components/JobForm.behavior.test.jsx`). No `@testing-library/jest-dom` — use `getByLabelText`/`getByText` (throw on absence), `.checked`, `expect(...).toBeTruthy()`.
+- Run tests from `frontend/`: `cd frontend && npx vitest run <path>`.
+- Outbound links use `target="_blank" rel="noopener noreferrer"`.
+
+## File Structure
+
+| File | Responsibility | Action |
+|---|---|---|
+| `frontend/src/App.jsx` | Calibrate-route title (remove subtitle); sidebar brand → "VA-Calibration" | Modify |
+| `frontend/index.html` | `<title>` → "VA-Calibration Platform" | Modify |
+| `frontend/src/App.css`, `frontend/src/index.css` | header comment branding (cosmetic) | Modify |
+| `frontend/src/branding.test.js` | source test for title + branding | Create |
+| `frontend/src/components/JobForm.jsx` | copy/options, uncertainty checkbox, reorder | Modify |
+| `frontend/src/components/JobForm.test.js` | update obsolete issue-#25 assertions | Modify |
+| `frontend/src/components/JobForm.issue68.test.js` | source tests for #68 form copy + checkbox | Create |
+| `frontend/src/components/JobForm.issue68.behavior.test.jsx` | jsdom: checkbox toggle + field order | Create |
+
+---
+
+## Task 1: App-level text — title, subtitle removal, VA-Calibration branding
+
+**Files:**
+- Modify: `frontend/src/App.jsx` (PageHeader for `/`; sidebar `brand-name` span)
+- Modify: `frontend/index.html` (`<title>`)
+- Modify: `frontend/src/App.css` line 2, `frontend/src/index.css` line 2 (header comments)
+- Test: `frontend/src/branding.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/branding.test.js`:
+```js
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const appSrc = readFileSync(resolve(__dir, 'App.jsx'), 'utf-8')
+const htmlSrc = readFileSync(resolve(__dir, '../index.html'), 'utf-8')
+
+describe('Page title (issue #68)', () => {
+  it('Calibrate page heading is the long misclassification title', () => {
+    expect(appSrc).toContain('Correcting for Algorithmic Misclassification in Estimating Cause Distributions')
+  })
+  it('drops the old "Submit and monitor" subtitle', () => {
+    expect(appSrc).not.toContain('Submit and monitor verbal autopsy calibration jobs')
+  })
+})
+
+describe('VA-Calibration branding (issue #68)', () => {
+  it('sidebar brand and tab title use the hyphenated "VA-Calibration"', () => {
+    expect(appSrc).toContain('VA-Calibration')
+    expect(htmlSrc).toContain('VA-Calibration Platform')
+  })
+  it('no unhyphenated "VA Calibration" remains in App.jsx or index.html', () => {
+    expect(appSrc).not.toContain('VA Calibration')
+    expect(htmlSrc).not.toContain('VA Calibration')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/branding.test.js`
+Expected: FAIL — old title/subtitle and unhyphenated "VA Calibration" still present.
+
+- [ ] **Step 3: Update the Calibrate page title in App.jsx**
+
+In `frontend/src/App.jsx`, the `/` route's PageHeader currently reads:
+```jsx
+<PageHeader title="Calibrate" subtitle="Submit and monitor verbal autopsy calibration jobs" />
+```
+Replace with:
+```jsx
+<PageHeader title="Correcting for Algorithmic Misclassification in Estimating Cause Distributions" />
+```
+
+- [ ] **Step 4: Update the sidebar brand in App.jsx**
+
+In the sidebar brand block, change:
+```jsx
+          <span className="brand-name">VA Calibration</span>
+```
+to:
+```jsx
+          <span className="brand-name">VA-Calibration</span>
+```
+
+- [ ] **Step 5: Update index.html title**
+
+In `frontend/index.html` (line 7), change:
+```html
+    <title>VA Calibration Platform</title>
+```
+to:
+```html
+    <title>VA-Calibration Platform</title>
+```
+
+- [ ] **Step 6: Update the two CSS header comments**
+
+In `frontend/src/App.css` line 2 (`   VA Calibration Platform - Modern Data Platform`) and `frontend/src/index.css` line 2 (`   VA Calibration Platform - Design System`), change "VA Calibration Platform" → "VA-Calibration Platform".
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/branding.test.js`
+Expected: PASS (4 tests).
+
+- [ ] **Step 8: Run the existing App/JobForm tests to confirm no regression**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.test.js src/App.routes.test.js`
+Expected: PASS (the nav label "Calibrate" and routes are unchanged).
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/App.jsx frontend/index.html frontend/src/App.css frontend/src/index.css frontend/src/branding.test.js
+git commit -m "feat(ui): new Calibrate page title + VA-Calibration branding (#68)"
+```
+
+---
+
+## Task 2: JobForm copy & options (age, country, CCVA labels, MCMC)
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx`
+- Test: `frontend/src/components/JobForm.issue68.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/components/JobForm.issue68.test.js`:
+```js
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(resolve(__dir, 'JobForm.jsx'), 'utf-8')
+
+describe('Age group label (issue #68)', () => {
+  it('uses "Children (1-59 months)"', () => {
+    expect(src).toContain('Children (1-59 months)')
+    expect(src).not.toContain("label: 'Child (1-59 months)'")
+  })
+})
+
+describe('Country dropdown (issue #68)', () => {
+  it('lists the supported countries alphabetically with an "Other" option', () => {
+    expect(src).toContain("{ value: 'other', label: 'Other' }")
+    expect(src).not.toContain('All the countries')
+    const order = ['Bangladesh', 'Ethiopia', 'Kenya', 'Mali', 'Mozambique', 'Sierra Leone', 'South Africa']
+      .map((c) => src.indexOf(`value: '${c}', label: '${c}'`))
+    order.forEach((p) => expect(p).toBeGreaterThan(-1))
+    for (let i = 1; i < order.length; i++) expect(order[i]).toBeGreaterThan(order[i - 1])
+  })
+})
+
+describe('CCVA algorithm label (issue #68)', () => {
+  it('labels the algorithm field with the CCVA full name', () => {
+    expect(src).toContain('Computer-Coded Verbal Autopsy (CCVA) Algorithm')
+  })
+})
+
+describe('MCMC section (issue #68)', () => {
+  it('renames the toggle to "MCMC Specifics"', () => {
+    expect(src).toContain('MCMC Specifics')
+    expect(src).not.toContain('Advanced MCMC Settings')
+  })
+  it('uses the new three-sentence MCMC hint', () => {
+    expect(src).toContain('Higher iteration improves accuracy but requires more time.')
+    expect(src).toContain('Burn-in discards early samples to warm up MCMC chain.')
+    expect(src).toContain('Thinning reduces dependency between subsequent MCMC samples.')
+  })
+})
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.test.js`
+Expected: FAIL (old strings still present).
+
+- [ ] **Step 3: Update the age group label**
+
+In `frontend/src/components/JobForm.jsx`, the Age Group `CustomSelect` options:
+```jsx
+              { value: 'child', label: 'Child (1-59 months)' }
+```
+→
+```jsx
+              { value: 'child', label: 'Children (1-59 months)' }
+```
+
+- [ ] **Step 4: Replace the Country options (alphabetical + "Other")**
+
+Replace the Country `CustomSelect` `options` array with:
+```jsx
+              options={[
+                { value: 'Bangladesh', label: 'Bangladesh' },
+                { value: 'Ethiopia', label: 'Ethiopia' },
+                { value: 'Kenya', label: 'Kenya' },
+                { value: 'Mali', label: 'Mali' },
+                { value: 'Mozambique', label: 'Mozambique' },
+                { value: 'Sierra Leone', label: 'Sierra Leone' },
+                { value: 'South Africa', label: 'South Africa' },
+                { value: 'other', label: 'Other' }
+              ]}
+```
+(The `country` state default stays `'Mozambique'` — do not change `useState('Mozambique')`.)
+
+- [ ] **Step 5: Relabel the three algorithm-field labels with the CCVA name**
+
+There are three algorithm `<label>`s (one per job type). Update each field label (NOT the per-algorithm option labels like "InterVA (fastest...)"):
+- openVA branch: `<label>Algorithm</label>` → `<label>Computer-Coded Verbal Autopsy (CCVA) Algorithm</label>`
+- pipeline branch: `<label>Algorithm{ensemble ? 's' : ''}` → `<label>Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''}` (keep the rest of that label, including the `{ensemble && (<span ...>)}` part, unchanged)
+- vacalibration branch: `<label>Algorithms *</label>` → `<label>Computer-Coded Verbal Autopsy (CCVA) Algorithms *</label>`
+
+- [ ] **Step 6: Rename the MCMC toggle and replace its hint**
+
+Change the toggle button text:
+```jsx
+              {showAdvanced ? '▾' : '▸'} Advanced MCMC Settings
+```
+→
+```jsx
+              {showAdvanced ? '▾' : '▸'} MCMC Specifics
+```
+Replace the MCMC hint `<small>`:
+```jsx
+                <small className="form-hint">
+                  Higher iterations = more accuracy but longer runtime. Burn-in discards early samples. Thinning reduces autocorrelation.
+                </small>
+```
+→
+```jsx
+                <small className="form-hint">
+                  Higher iteration improves accuracy but requires more time.<br />
+                  Burn-in discards early samples to warm up MCMC chain.<br />
+                  Thinning reduces dependency between subsequent MCMC samples.
+                </small>
+```
+
+- [ ] **Step 7: Run the test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 8: Run the existing JobForm tests (no regression yet expected here)**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.test.js src/components/JobForm.behavior.test.jsx`
+Expected: PASS. (The issue-#25 dropdown assertions are still valid until Task 3.)
+
+- [ ] **Step 9: Commit**
+
+```bash
+git add frontend/src/components/JobForm.jsx frontend/src/components/JobForm.issue68.test.js
+git commit -m "feat(form): age/country/CCVA-label/MCMC copy updates (#68)"
+```
+
+---
+
+## Task 3: Uncertainty control — dropdown → checkbox
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx` (uncertainty `form-group`)
+- Modify: `frontend/src/components/JobForm.test.js` (replace obsolete issue-#25 dropdown assertions)
+- Test (source): append to `frontend/src/components/JobForm.issue68.test.js`
+- Test (jsdom): create `frontend/src/components/JobForm.issue68.behavior.test.jsx`
+
+- [ ] **Step 1: Write the failing source assertions**
+
+Append to `frontend/src/components/JobForm.issue68.test.js`:
+```js
+describe('Uncertainty checkbox (issue #68)', () => {
+  it('uses a checkbox bound to calibModelType, not a Yes/No dropdown', () => {
+    expect(src).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(src).toContain("e.target.checked ? 'Mmatprior' : 'Mmatfixed'")
+    expect(src).not.toContain("'Yes (Informative Prior)'")
+    expect(src).not.toContain("'No (Fixed misclassification matrix)'")
+  })
+  it('uses the new label and hint with the CCVA matrices link', () => {
+    expect(src).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(src).toContain('Controls whether to propagate uncertainty in')
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+    expect(src).not.toContain('Controls how uncertainty in misclassification estimates is handled')
+    expect(src).not.toContain('Propagate uncertainty in misclassification matrix')
+  })
+})
+```
+
+- [ ] **Step 2: Write the failing jsdom behavior test**
+
+Create `frontend/src/components/JobForm.issue68.behavior.test.jsx`:
+```jsx
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+const uncertaintyCheckbox = () =>
+  screen.getByLabelText(/Propagate uncertainty in CCVA misclassification/i)
+
+describe('Uncertainty checkbox behavior (issue #68)', () => {
+  it('renders a checkbox that is checked by default (propagate = on)', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    const cb = uncertaintyCheckbox()
+    expect(cb.type).toBe('checkbox')
+    expect(cb.checked).toBe(true)
+  })
+  it('unchecks when clicked', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    const cb = uncertaintyCheckbox()
+    fireEvent.click(cb)
+    expect(cb.checked).toBe(false)
+  })
+})
+```
+
+- [ ] **Step 3: Run both new tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.test.js src/components/JobForm.issue68.behavior.test.jsx`
+Expected: FAIL — checkbox/handler strings absent; `getByLabelText` can't find the checkbox (it's still a dropdown).
+
+- [ ] **Step 4: Replace the uncertainty form-group with a checkbox**
+
+In `frontend/src/components/JobForm.jsx`, replace the entire uncertainty block:
+```jsx
+        {/* Vacalibration-specific parameters */}
+        {(jobType === 'vacalibration' || jobType === 'pipeline') && (
+          <div className="form-group">
+            <label>Propagate uncertainty in misclassification matrix</label>
+            <CustomSelect
+              value={calibModelType}
+              onChange={setCalibModelType}
+              options={[
+                { value: 'Mmatprior', label: 'Yes (Informative Prior)' },
+                { value: 'Mmatfixed', label: 'No (Fixed misclassification matrix)' }
+              ]}
+            />
+            <small className="form-hint">
+              Controls how uncertainty in misclassification estimates is handled
+            </small>
+          </div>
+        )}
+```
+with:
+```jsx
+        {/* Vacalibration-specific parameters */}
+        {(jobType === 'vacalibration' || jobType === 'pipeline') && (
+          <div className="form-group">
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={calibModelType === 'Mmatprior'}
+                onChange={(e) => setCalibModelType(e.target.checked ? 'Mmatprior' : 'Mmatfixed')}
+              />
+              {' '}Propagate uncertainty in CCVA misclassification
+            </label>
+            <small className="form-hint">
+              Controls whether to propagate uncertainty in{' '}
+              <a
+                href="https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CCVA misclassification estimate
+              </a>
+            </small>
+          </div>
+        )}
+```
+
+- [ ] **Step 5: Update the obsolete issue-#25 assertions in JobForm.test.js**
+
+In `frontend/src/components/JobForm.test.js`, replace the entire `describe('Uncertainty propagation labels (issue #25)', ...)` block (the one asserting the old label and the `'Yes (Informative Prior)'` / `'No (Fixed misclassification matrix)'` option labels) with:
+```js
+describe('Uncertainty propagation control (issue #68 supersedes #25)', () => {
+  it('label is the new CCVA wording, not the old matrix wording', () => {
+    expect(jobFormSrc).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(jobFormSrc).not.toContain('Propagate uncertainty in misclassification matrix')
+    expect(jobFormSrc).not.toContain('Uncertainty Propagation')
+  })
+
+  it('is a checkbox bound to calibModelType (no Yes/No dropdown options)', () => {
+    expect(jobFormSrc).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(jobFormSrc).not.toContain("'Yes (Informative Prior)'")
+    expect(jobFormSrc).not.toContain("'No (Fixed misclassification matrix)'")
+  })
+})
+```
+
+- [ ] **Step 6: Run the new + updated tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.test.js src/components/JobForm.issue68.behavior.test.jsx src/components/JobForm.test.js`
+Expected: PASS.
+
+- [ ] **Step 7: Run the existing behavior test (no regression)**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.behavior.test.jsx`
+Expected: PASS (4 tests — algorithm/ensemble flow is unaffected by the uncertainty checkbox).
+
+- [ ] **Step 8: Commit**
+
+```bash
+git add frontend/src/components/JobForm.jsx frontend/src/components/JobForm.test.js frontend/src/components/JobForm.issue68.test.js frontend/src/components/JobForm.issue68.behavior.test.jsx
+git commit -m "feat(form): uncertainty propagation as a checkbox with CCVA link (#68)"
+```
+
+---
+
+## Task 4: Input reorder
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx` (relocate form-group blocks)
+- Test (jsdom): append to `frontend/src/components/JobForm.issue68.behavior.test.jsx`
+
+- [ ] **Step 1: Write the failing order test**
+
+Append to `frontend/src/components/JobForm.issue68.behavior.test.jsx`:
+```jsx
+describe('Form field order (issue #68)', () => {
+  it('renders fields in the order: Job Type, Country, Age Group, CCVA Algorithm, Propagate uncertainty, Upload, MCMC', () => {
+    const { container } = render(<JobForm onJobSubmitted={() => {}} />)
+    const text = container.textContent
+    const sequence = [
+      'Job Type',
+      'Country',
+      'Age Group',
+      'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
+      'Propagate uncertainty in CCVA misclassification',
+      'VA Data Files',
+      'MCMC Specifics',
+    ]
+    const positions = sequence.map((s) => text.indexOf(s))
+    positions.forEach((p, i) => expect(p, `"${sequence[i]}" not found`).toBeGreaterThan(-1))
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i], `"${sequence[i]}" should come after "${sequence[i - 1]}"`).toBeGreaterThan(positions[i - 1])
+    }
+  })
+})
+```
+(Default `jobType` is `vacalibration`, so Country, uncertainty, upload rows, and MCMC all render.)
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.behavior.test.jsx`
+Expected: FAIL — current order is Job Type, Algorithm, Age Group, Country, ... (Country/Age/Algorithm out of the target order; MCMC before Upload).
+
+- [ ] **Step 3: Reorder the form-group blocks**
+
+In `frontend/src/components/JobForm.jsx`, the `<form>` currently renders these blocks in this order:
+1. Job Type
+2. Algorithm blocks (the three `{jobType === ...}` algorithm `form-group`s)
+3. Age Group
+4. Country (`{jobType !== 'openva' && ...}`)
+5. Uncertainty (now a checkbox, from Task 3)
+6. MCMC (`Advanced` → `MCMC Specifics`)
+7. VA Data upload (the `{jobType === 'vacalibration' ? (...) : (...)}` block)
+8. demo-info / error / progress / form-actions
+
+Move them (cut whole blocks, paste — do not edit their contents) into this order:
+1. Job Type
+2. **Country** block
+3. **Age Group** block
+4. Algorithm blocks (all three `{jobType === ...}` blocks, kept together in their existing relative order: openva, pipeline, vacalibration)
+5. Uncertainty checkbox block
+6. **VA Data upload** block
+7. **MCMC** block
+8. demo-info / error / progress / form-actions (unchanged, stay last)
+
+So the net moves are: Country and Age Group move up above the algorithm blocks; the MCMC block moves down to sit *after* the VA Data upload block. Each block's internal JSX (including its `{jobType ...}` / `{jobType !== 'openva'}` guard) is unchanged — only their order in the file changes.
+
+- [ ] **Step 4: Run the order test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue68.behavior.test.jsx`
+Expected: PASS (checkbox tests + order test).
+
+- [ ] **Step 5: Run the full JobForm + form test set to confirm no regression**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.test.js src/components/JobForm.behavior.test.jsx src/components/JobForm.issue68.test.js src/components/JobForm.issue68.behavior.test.jsx`
+Expected: PASS. (Behavior tests query by label/`.upload-row`, so reorder doesn't affect them; the issue-#25/#26/#28-style source regexes still match because each `{jobType === 'vacalibration'}` block stays a contiguous unit.)
+
+- [ ] **Step 6: Build to confirm valid JSX after the move**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds (no JSX/syntax errors from the relocation).
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/JobForm.jsx frontend/src/components/JobForm.issue68.behavior.test.jsx
+git commit -m "feat(form): reorder inputs per issue #68 (MCMC last)"
+```
+
+---
+
+## Task 5: Full verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire frontend suite**
+
+Run: `cd frontend && npx vitest run --exclude '**/integration.test.js'`
+Expected: all pass. (The integration test needs a live backend on :8000 and can flake under full-suite concurrency — run it separately if the backend is up: `npx vitest run src/api/integration.test.js`.)
+
+- [ ] **Step 2: Manual check (dev server)**
+
+Run: `cd frontend && npm run dev`, open `http://localhost:5173/comsa-dashboard/`, log in, and on the Calibrate page confirm:
+- Heading is "Correcting for Algorithmic Misclassification in Estimating Cause Distributions" (no "Submit and monitor…" subtitle); the #69 credit line still shows beneath it.
+- Sidebar brand reads "VA-Calibration"; browser tab title is "VA-Calibration Platform".
+- Field order top→bottom: Job Type, Country, Age Group, CCVA Algorithm, Propagate uncertainty (checkbox, checked by default), Upload VA Data, then MCMC Specifics.
+- Age Group shows "Children (1-59 months)"; Country list is alphabetical ending in "Other".
+- The "CCVA misclassification estimate" link opens the CCVA-Misclassification-Matrices repo in a new tab.
+- "MCMC Specifics" toggle shows the three-line hint.
+- Submitting still works (payload unchanged: checked → `Mmatprior`, unchecked → `Mmatfixed`).
+
+---
+
+## Self-Review (completed by plan author)
+
+- **Spec coverage:** title + subtitle removal (Task 1); VA-Calibration branding (Task 1); input reorder w/ MCMC last (Task 4); "Children (1-59 months)" (Task 2); alphabetical country list + "Other" (Task 2); CCVA algorithm label (Task 2); uncertainty checkbox default-checked + new label + hint + CCVA link reusing `calibModelType` (Task 3); "MCMC Specifics" + three-line hint (Task 2). All covered. Out-of-scope items (spelled-out prose, package name) correctly untouched.
+- **Existing-test impact:** the issue-#25 block in `JobForm.test.js` (old uncertainty label + Yes/No option labels) is explicitly updated in Task 3 Step 5; issue-#26 button/nav-label assertions and `JobForm.behavior.test.jsx` are verified unaffected (Tasks 1/3/4 regression steps).
+- **Placeholder scan:** none — every code step shows the exact before/after.
+- **Type/string consistency:** the uncertainty handler `e.target.checked ? 'Mmatprior' : 'Mmatfixed'` and `checked={calibModelType === 'Mmatprior'}` match across the implementation (Task 3 Step 4), the source tests (Task 3 Step 1), and the updated `JobForm.test.js` (Task 3 Step 5). The label "Propagate uncertainty in CCVA misclassification", country option `{ value: 'other', label: 'Other' }`, and "MCMC Specifics" are used identically in implementation and tests. The order test (Task 4) reuses the same label strings introduced in Tasks 2–3.

--- a/docs/superpowers/specs/2026-05-26-issue-68-form-copy-ordering-design.md
+++ b/docs/superpowers/specs/2026-05-26-issue-68-form-copy-ordering-design.md
@@ -1,0 +1,119 @@
+# Issue #68 — Form Copy, Ordering & Branding
+
+**Date:** 2026-05-26
+**Issue:** [#68 — general suggestions](https://github.com/cliu238/comsa_dashboard/issues/68)
+**Related:** #69 (Resource/Acknowledgment tabs + credit line, already merged) — the credit line rendered by `PageHeader` stays beneath the new title.
+
+## Goal
+
+Apply the copy, input-ordering, control, and branding changes requested in issue
+#68 to the job-submission form and the page title. These are surgical UI/copy
+edits — no change to form behavior, state, effects, or the backend payload.
+
+## Decisions (from clarifying questions)
+
+| Topic | Decision |
+|---|---|
+| Country list | The 7 vacalibration-supported countries + "Other", alphabetical. NOT all ~195 (the package only has data for these; listing all would imply unsupported calibration). Selected default stays `Mozambique` (COMSA demo data). |
+| "VA-Calibration" scope | Replace visible "VA Calibration" → "VA-Calibration". Leave the R package identifier `vacalibration` (lowercase) untouched everywhere. |
+| Page title | Long phrase becomes the Calibrate page heading; subtitle removed. Sidebar nav item and submit button stay "Calibrate" (short action labels). |
+| CCVA algorithm label | Relabel the algorithm field to include "Computer-Coded Verbal Autopsy (CCVA)" — matches the issue's consistent CCVA usage (confirmed with user). |
+| Uncertainty control | Reuse existing `calibModelType` state (checked → `'Mmatprior'`, unchecked → `'Mmatfixed'`). No new state, identical payload. |
+
+## Architecture
+
+In-place edits to three files. No new components, no refactor (the form's
+coupled algorithm/ensemble/upload effects are left untouched).
+
+| File | Change |
+|---|---|
+| `frontend/src/components/JobForm.jsx` | Reorder form blocks; swap uncertainty dropdown → checkbox; update labels/hints/country list/age label; add CCVA hyperlink. |
+| `frontend/src/App.jsx` | Calibrate-route `PageHeader` title (remove subtitle); sidebar brand → "VA-Calibration". |
+| `frontend/index.html` | `<title>` → "VA-Calibration Platform". |
+| `frontend/src/App.css`, `frontend/src/index.css` | Update the "VA Calibration Platform" header comments → "VA-Calibration Platform" (cosmetic consistency). |
+
+## Detailed changes
+
+### 1. Page title — `App.jsx` (~line 187)
+Before:
+```jsx
+<PageHeader title="Calibrate" subtitle="Submit and monitor verbal autopsy calibration jobs" />
+```
+After:
+```jsx
+<PageHeader title="Correcting for Algorithmic Misclassification in Estimating Cause Distributions" />
+```
+`PageHeader` already renders the credit line (issue #69) and treats `subtitle` as
+optional, so omitting it is safe.
+
+### 2. "VA-Calibration" branding
+- `App.jsx` (~line 116): `<span className="brand-name">VA Calibration</span>` → `VA-Calibration`.
+- `index.html` (line 7): `<title>VA Calibration Platform</title>` → `<title>VA-Calibration Platform</title>`.
+- `App.css` line 2 / `index.css` line 2 header comments: "VA Calibration Platform" → "VA-Calibration Platform".
+- **Left as-is (out of scope):** the spelled-out prose "Verbal Autopsy Calibration Platform" in `LandingPage.jsx:12` and `VideosSection.jsx:27` — these are descriptive expansions, not the "VA Calibration" brand token. The `vacalibration` package name is untouched.
+
+### 3. Input order — `JobForm.jsx`
+Reorder the form `<div className="form-group">` blocks to this sequence (conditionals preserved):
+1. Job Type
+2. Country *(hidden for openVA — unchanged condition)*
+3. Age Group
+4. CCVA Algorithm(s) *(the existing per-jobType algorithm UI block)*
+5. Propagate uncertainty *(calibration jobs only — unchanged condition)*
+6. Upload VA Data
+7. MCMC Specifics *(calibration jobs only — moves from before-upload to last)*
+
+Then the existing demo-info, error, progress, and form-actions blocks follow, unchanged.
+
+### 4. CCVA algorithm label — `JobForm.jsx`
+The three algorithm-section labels ("Algorithm", "Algorithm(s)", "Algorithms *")
+become "Computer-Coded Verbal Autopsy (CCVA) Algorithm(s)" (keep the existing
+`*`/required and singular/plural affordances where present). The algorithm option
+labels and values are unchanged.
+
+### 5. Age group — `JobForm.jsx` (~line 377)
+`{ value: 'child', label: 'Child (1-59 months)' }` → `label: 'Children (1-59 months)'`. Value `child` unchanged.
+
+### 6. Country dropdown — `JobForm.jsx` (~lines 389-398)
+Options, in order:
+```jsx
+{ value: 'Bangladesh', label: 'Bangladesh' },
+{ value: 'Ethiopia', label: 'Ethiopia' },
+{ value: 'Kenya', label: 'Kenya' },
+{ value: 'Mali', label: 'Mali' },
+{ value: 'Mozambique', label: 'Mozambique' },
+{ value: 'Sierra Leone', label: 'Sierra Leone' },
+{ value: 'South Africa', label: 'South Africa' },
+{ value: 'other', label: 'Other' },
+```
+The `country` state default stays `'Mozambique'` (value `other` keeps the same
+backend meaning; only its label changes from "All the countries" to "Other").
+
+### 7. Uncertainty control — `JobForm.jsx` (~lines 404-419)
+Replace the `CustomSelect` with a checkbox (calibration jobs only — same condition):
+- Checkbox `checked={calibModelType === 'Mmatprior'}`; `onChange` sets `calibModelType` to `'Mmatprior'` when checked, `'Mmatfixed'` when unchecked. Default stays `'Mmatprior'` (checked).
+- Label text: **"Propagate uncertainty in CCVA misclassification"**.
+- Hint: **"Controls whether to propagate uncertainty in CCVA misclassification estimate"**, where "CCVA misclassification estimate" is an `<a href="https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices" target="_blank" rel="noopener noreferrer">`.
+
+### 8. MCMC section — `JobForm.jsx` (~lines 429, 465-467)
+- Toggle button text: "Advanced MCMC Settings" → **"MCMC Specifics"** (keep the ▸/▾ caret).
+- Replace the hint with three lines (each on its own line, e.g. separated by `<br />` or separate elements):
+  - "Higher iteration improves accuracy but requires more time."
+  - "Burn-in discards early samples to warm up MCMC chain."
+  - "Thinning reduces dependency between subsequent MCMC samples."
+
+## Error handling / edge cases
+- The uncertainty checkbox derives its checked state from `calibModelType`; no new state means no desync risk. The submitted payload (`calibModelType`) is byte-for-byte what the backend already expects.
+- Country `other` retains its existing value/semantics; only the label changes, so existing jobs/demo are unaffected.
+- Reordering is pure JSX movement; the `useEffect`s and handlers key off state, not DOM order, so behavior is unchanged.
+
+## Testing
+- **Source-level vitest** (matches `JobForm.test.js` / `JobDetail.test.js` pattern — reads `.jsx`/`.html` as text):
+  - `App.jsx` contains the new title string and no longer the old "Calibrate"/"Submit and monitor" PageHeader title; sidebar brand is "VA-Calibration".
+  - `index.html` title is "VA-Calibration Platform".
+  - `JobForm.jsx` contains: "Children (1-59 months)"; the alphabetical country order with label "Other"; "Computer-Coded Verbal Autopsy (CCVA)"; "Propagate uncertainty in CCVA misclassification"; the CCVA-Misclassification-Matrices href; "MCMC Specifics"; the three MCMC hint sentences; and no longer the old strings ("Advanced MCMC Settings", old uncertainty label/hint, "All the countries").
+- **jsdom behavior** (`@vitest-environment jsdom`): render `JobForm`, in Calibration-Only mode toggle the "Propagate uncertainty…" checkbox and assert it starts checked (default) and unchecking it is reflected; assert it's an `<input type="checkbox">` not a select.
+- **Manual:** run the dev server, eyeball the reordered form, the new title + retained credit line, the checkbox, the CCVA link (opens the repo), and the alphabetical country list.
+
+## Out of scope
+- No backend changes. No form-logic/effects changes. No component extraction/refactor.
+- Spelled-out "Verbal Autopsy Calibration Platform" prose (landing hero, video caption) — left as descriptive text unless the user later wants it rebranded.

--- a/frontend/index.html
+++ b/frontend/index.html
@@ -4,7 +4,7 @@
     <meta charset="UTF-8" />
     <link rel="icon" type="image/svg+xml" href="/vite.svg" />
     <meta name="viewport" content="width=device-width, initial-scale=1.0" />
-    <title>VA Calibration Platform</title>
+    <title>VA-Calibration Platform</title>
     <link rel="preconnect" href="https://fonts.googleapis.com">
     <link rel="preconnect" href="https://fonts.gstatic.com" crossorigin>
     <link href="https://fonts.googleapis.com/css2?family=Inter:wght@400;500;600;700&family=JetBrains+Mono:wght@400;500&family=Source+Serif+Pro:wght@400;600;700&display=swap" rel="stylesheet">

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1,5 +1,5 @@
 /* ========================================
-   VA Calibration Platform - Modern Data Platform
+   VA-Calibration Platform - Modern Data Platform
    ======================================== */
 
 /* ========================================

--- a/frontend/src/App.jsx
+++ b/frontend/src/App.jsx
@@ -113,7 +113,7 @@ function Sidebar() {
           <span className="logo-mark">VA</span>
         </div>
         <div className="sidebar-title">
-          <span className="brand-name">VA Calibration</span>
+          <span className="brand-name">VA-Calibration</span>
           <span className="brand-sub">Platform</span>
         </div>
       </div>
@@ -184,7 +184,7 @@ function App() {
             <Route path="/" element={
               loading ? null : user ? (
                 <ProtectedRoute>
-                  <PageHeader title="Calibrate" subtitle="Submit and monitor verbal autopsy calibration jobs" />
+                  <PageHeader title="Correcting for Algorithmic Misclassification in Estimating Cause Distributions" />
                   <Dashboard />
                 </ProtectedRoute>
               ) : (

--- a/frontend/src/branding.test.js
+++ b/frontend/src/branding.test.js
@@ -1,0 +1,28 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const appSrc = readFileSync(resolve(__dir, 'App.jsx'), 'utf-8')
+const htmlSrc = readFileSync(resolve(__dir, '../index.html'), 'utf-8')
+
+describe('Page title (issue #68)', () => {
+  it('Calibrate page heading is the long misclassification title', () => {
+    expect(appSrc).toContain('Correcting for Algorithmic Misclassification in Estimating Cause Distributions')
+  })
+  it('drops the old "Submit and monitor" subtitle', () => {
+    expect(appSrc).not.toContain('Submit and monitor verbal autopsy calibration jobs')
+  })
+})
+
+describe('VA-Calibration branding (issue #68)', () => {
+  it('sidebar brand and tab title use the hyphenated "VA-Calibration"', () => {
+    expect(appSrc).toContain('VA-Calibration')
+    expect(htmlSrc).toContain('VA-Calibration Platform')
+  })
+  it('no unhyphenated "VA Calibration" remains in App.jsx or index.html', () => {
+    expect(appSrc).not.toContain('VA Calibration')
+    expect(htmlSrc).not.toContain('VA Calibration')
+  })
+})

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -1,0 +1,31 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+const uncertaintyCheckbox = () =>
+  screen.getByLabelText(/Propagate uncertainty in CCVA misclassification/i)
+
+describe('Uncertainty checkbox behavior (issue #68)', () => {
+  it('renders a checkbox that is checked by default (propagate = on)', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    const cb = uncertaintyCheckbox()
+    expect(cb.type).toBe('checkbox')
+    expect(cb.checked).toBe(true)
+  })
+  it('unchecks when clicked', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    const cb = uncertaintyCheckbox()
+    fireEvent.click(cb)
+    expect(cb.checked).toBe(false)
+  })
+})

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -29,3 +29,24 @@ describe('Uncertainty checkbox behavior (issue #68)', () => {
     expect(cb.checked).toBe(false)
   })
 })
+
+describe('Form field order (issue #68)', () => {
+  it('renders fields in the order: Job Type, Country, Age Group, CCVA Algorithm, Propagate uncertainty, Upload, MCMC', () => {
+    const { container } = render(<JobForm onJobSubmitted={() => {}} />)
+    const text = container.textContent
+    const sequence = [
+      'Job Type',
+      'Country',
+      'Age Group',
+      'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
+      'Propagate uncertainty in CCVA misclassification',
+      'VA Data Files',
+      'MCMC Specifics',
+    ]
+    const positions = sequence.map((s) => text.indexOf(s))
+    positions.forEach((p, i) => expect(p, `"${sequence[i]}" not found`).toBeGreaterThan(-1))
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i], `"${sequence[i]}" should come after "${sequence[i - 1]}"`).toBeGreaterThan(positions[i - 1])
+    }
+  })
+})

--- a/frontend/src/components/JobForm.issue68.test.js
+++ b/frontend/src/components/JobForm.issue68.test.js
@@ -41,3 +41,19 @@ describe('MCMC section (issue #68)', () => {
     expect(src).toContain('Thinning reduces dependency between subsequent MCMC samples.')
   })
 })
+
+describe('Uncertainty checkbox (issue #68)', () => {
+  it('uses a checkbox bound to calibModelType, not a Yes/No dropdown', () => {
+    expect(src).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(src).toContain("e.target.checked ? 'Mmatprior' : 'Mmatfixed'")
+    expect(src).not.toContain("'Yes (Informative Prior)'")
+    expect(src).not.toContain("'No (Fixed misclassification matrix)'")
+  })
+  it('uses the new label and hint with the CCVA matrices link', () => {
+    expect(src).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(src).toContain('Controls whether to propagate uncertainty in')
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+    expect(src).not.toContain('Controls how uncertainty in misclassification estimates is handled')
+    expect(src).not.toContain('Propagate uncertainty in misclassification matrix')
+  })
+})

--- a/frontend/src/components/JobForm.issue68.test.js
+++ b/frontend/src/components/JobForm.issue68.test.js
@@ -1,0 +1,43 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(resolve(__dir, 'JobForm.jsx'), 'utf-8')
+
+describe('Age group label (issue #68)', () => {
+  it('uses "Children (1-59 months)"', () => {
+    expect(src).toContain('Children (1-59 months)')
+    expect(src).not.toContain("label: 'Child (1-59 months)'")
+  })
+})
+
+describe('Country dropdown (issue #68)', () => {
+  it('lists the supported countries alphabetically with an "Other" option', () => {
+    expect(src).toContain("{ value: 'other', label: 'Other' }")
+    expect(src).not.toContain('All the countries')
+    const order = ['Bangladesh', 'Ethiopia', 'Kenya', 'Mali', 'Mozambique', 'Sierra Leone', 'South Africa']
+      .map((c) => src.indexOf(`value: '${c}', label: '${c}'`))
+    order.forEach((p) => expect(p).toBeGreaterThan(-1))
+    for (let i = 1; i < order.length; i++) expect(order[i]).toBeGreaterThan(order[i - 1])
+  })
+})
+
+describe('CCVA algorithm label (issue #68)', () => {
+  it('labels the algorithm field with the CCVA full name', () => {
+    expect(src).toContain('Computer-Coded Verbal Autopsy (CCVA) Algorithm')
+  })
+})
+
+describe('MCMC section (issue #68)', () => {
+  it('renames the toggle to "MCMC Specifics"', () => {
+    expect(src).toContain('MCMC Specifics')
+    expect(src).not.toContain('Advanced MCMC Settings')
+  })
+  it('uses the new three-sentence MCMC hint', () => {
+    expect(src).toContain('Higher iteration improves accuracy but requires more time.')
+    expect(src).toContain('Burn-in discards early samples to warm up MCMC chain.')
+    expect(src).toContain('Thinning reduces dependency between subsequent MCMC samples.')
+  })
+})

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -225,7 +225,7 @@ export default function JobForm({ onJobSubmitted }) {
         {/* Algorithm Selection - split by job type */}
         {jobType === 'openva' && (
           <div className="form-group">
-            <label>Algorithm</label>
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithm</label>
             <CustomSelect
               value={algorithms[0] || 'InterVA'}
               onChange={handleAlgorithmSelect}
@@ -242,7 +242,7 @@ export default function JobForm({ onJobSubmitted }) {
         {jobType === 'pipeline' && (
           <div className="form-group">
             <label>
-              Algorithm{ensemble ? 's' : ''}
+              Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''}
               {ensemble && (
                 <span className="required"> * Select at least 2 for ensemble</span>
               )}
@@ -310,7 +310,7 @@ export default function JobForm({ onJobSubmitted }) {
 
         {jobType === 'vacalibration' && (
           <div className="form-group">
-            <label>Algorithms *</label>
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithms *</label>
 
             <div className="algorithm-checkboxes">
               <label className="checkbox-label">
@@ -374,7 +374,7 @@ export default function JobForm({ onJobSubmitted }) {
             onChange={setAgeGroup}
             options={[
               { value: 'neonate', label: 'Neonate (0-27 days)' },
-              { value: 'child', label: 'Child (1-59 months)' }
+              { value: 'child', label: 'Children (1-59 months)' }
             ]}
           />
         </div>
@@ -387,14 +387,14 @@ export default function JobForm({ onJobSubmitted }) {
               value={country}
               onChange={setCountry}
               options={[
-                { value: 'Mozambique', label: 'Mozambique' },
                 { value: 'Bangladesh', label: 'Bangladesh' },
                 { value: 'Ethiopia', label: 'Ethiopia' },
                 { value: 'Kenya', label: 'Kenya' },
                 { value: 'Mali', label: 'Mali' },
+                { value: 'Mozambique', label: 'Mozambique' },
                 { value: 'Sierra Leone', label: 'Sierra Leone' },
                 { value: 'South Africa', label: 'South Africa' },
-                { value: 'other', label: 'All the countries' }
+                { value: 'other', label: 'Other' }
               ]}
             />
           </div>
@@ -418,7 +418,7 @@ export default function JobForm({ onJobSubmitted }) {
           </div>
         )}
 
-        {/* Advanced MCMC Settings - only for jobs with calibration */}
+        {/* MCMC Specifics - only for jobs with calibration */}
         {(jobType === 'vacalibration' || jobType === 'pipeline') && (
           <div className="form-group">
             <button
@@ -426,7 +426,7 @@ export default function JobForm({ onJobSubmitted }) {
               className="advanced-toggle"
               onClick={() => setShowAdvanced(!showAdvanced)}
             >
-              {showAdvanced ? '▾' : '▸'} Advanced MCMC Settings
+              {showAdvanced ? '▾' : '▸'} MCMC Specifics
             </button>
             {showAdvanced && (
               <div className="advanced-settings">
@@ -463,7 +463,9 @@ export default function JobForm({ onJobSubmitted }) {
                   </label>
                 </div>
                 <small className="form-hint">
-                  Higher iterations = more accuracy but longer runtime. Burn-in discards early samples. Thinning reduces autocorrelation.
+                  Higher iteration improves accuracy but requires more time.<br />
+                  Burn-in discards early samples to warm up MCMC chain.<br />
+                  Thinning reduces dependency between subsequent MCMC samples.
                 </small>
               </div>
             )}

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -222,6 +222,39 @@ export default function JobForm({ onJobSubmitted }) {
           />
         </div>
 
+        {/* Country: needed for vacalibration and pipeline, not for openva */}
+        {jobType !== 'openva' && (
+          <div className="form-group">
+            <label>Country</label>
+            <CustomSelect
+              value={country}
+              onChange={setCountry}
+              options={[
+                { value: 'Bangladesh', label: 'Bangladesh' },
+                { value: 'Ethiopia', label: 'Ethiopia' },
+                { value: 'Kenya', label: 'Kenya' },
+                { value: 'Mali', label: 'Mali' },
+                { value: 'Mozambique', label: 'Mozambique' },
+                { value: 'Sierra Leone', label: 'Sierra Leone' },
+                { value: 'South Africa', label: 'South Africa' },
+                { value: 'other', label: 'Other' }
+              ]}
+            />
+          </div>
+        )}
+
+        <div className="form-group">
+          <label>Age Group</label>
+          <CustomSelect
+            value={ageGroup}
+            onChange={setAgeGroup}
+            options={[
+              { value: 'neonate', label: 'Neonate (0-27 days)' },
+              { value: 'child', label: 'Children (1-59 months)' }
+            ]}
+          />
+        </div>
+
         {/* Algorithm Selection - split by job type */}
         {jobType === 'openva' && (
           <div className="form-group">
@@ -367,39 +400,6 @@ export default function JobForm({ onJobSubmitted }) {
           </div>
         )}
 
-        <div className="form-group">
-          <label>Age Group</label>
-          <CustomSelect
-            value={ageGroup}
-            onChange={setAgeGroup}
-            options={[
-              { value: 'neonate', label: 'Neonate (0-27 days)' },
-              { value: 'child', label: 'Children (1-59 months)' }
-            ]}
-          />
-        </div>
-
-        {/* Country: needed for vacalibration and pipeline, not for openva */}
-        {jobType !== 'openva' && (
-          <div className="form-group">
-            <label>Country</label>
-            <CustomSelect
-              value={country}
-              onChange={setCountry}
-              options={[
-                { value: 'Bangladesh', label: 'Bangladesh' },
-                { value: 'Ethiopia', label: 'Ethiopia' },
-                { value: 'Kenya', label: 'Kenya' },
-                { value: 'Mali', label: 'Mali' },
-                { value: 'Mozambique', label: 'Mozambique' },
-                { value: 'Sierra Leone', label: 'Sierra Leone' },
-                { value: 'South Africa', label: 'South Africa' },
-                { value: 'other', label: 'Other' }
-              ]}
-            />
-          </div>
-        )}
-
         {/* Vacalibration-specific parameters */}
         {(jobType === 'vacalibration' || jobType === 'pipeline') && (
           <div className="form-group">
@@ -421,6 +421,54 @@ export default function JobForm({ onJobSubmitted }) {
                 CCVA misclassification estimate
               </a>
             </small>
+          </div>
+        )}
+
+        {jobType === 'vacalibration' ? (
+          <div className="form-group">
+            <label>VA Data Files (one CSV per selected algorithm)</label>
+            {uploads.map((upload, index) => (
+              <div key={upload.id} className="upload-row">
+                <span className="upload-algo-label">{upload.algorithm}</span>
+                <input
+                  type="file"
+                  accept=".csv"
+                  onChange={(e) => updateUpload(index, 'file', e.target.files[0])}
+                />
+                {upload.file && <span className="file-name">{upload.file.name}</span>}
+              </div>
+            ))}
+            <small className="form-hint">
+              Upload one CSV file per selected algorithm. Required columns: ID, cause.
+            </small>
+            <div className="sample-download">
+              <div className="sample-links">
+                <span>Sample CSV (neonate, 1190 records):</span>
+                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
+              </div>
+            </div>
+          </div>
+        ) : (
+          <div className="form-group">
+            <label>VA Data File (CSV)</label>
+            <input
+              type="file"
+              accept=".csv"
+              onChange={(e) => updateUpload(0, 'file', e.target.files[0])}
+            />
+            <small className="form-hint">
+              WHO 2016 VA questionnaire format (columns: i004a, i004b, ...)
+            </small>
+            <div className="sample-download">
+              <a
+                href={`${import.meta.env.BASE_URL}${ageGroup === 'neonate' ? 'sample_openva_neonate.csv' : 'sample_openva_child.csv'}`}
+                download
+              >
+                Download sample CSV ({ageGroup === 'neonate' ? 'neonate' : 'child'})
+              </a>
+            </div>
           </div>
         )}
 
@@ -475,54 +523,6 @@ export default function JobForm({ onJobSubmitted }) {
                 </small>
               </div>
             )}
-          </div>
-        )}
-
-        {jobType === 'vacalibration' ? (
-          <div className="form-group">
-            <label>VA Data Files (one CSV per selected algorithm)</label>
-            {uploads.map((upload, index) => (
-              <div key={upload.id} className="upload-row">
-                <span className="upload-algo-label">{upload.algorithm}</span>
-                <input
-                  type="file"
-                  accept=".csv"
-                  onChange={(e) => updateUpload(index, 'file', e.target.files[0])}
-                />
-                {upload.file && <span className="file-name">{upload.file.name}</span>}
-              </div>
-            ))}
-            <small className="form-hint">
-              Upload one CSV file per selected algorithm. Required columns: ID, cause.
-            </small>
-            <div className="sample-download">
-              <div className="sample-links">
-                <span>Sample CSV (neonate, 1190 records):</span>
-                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
-                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
-                <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
-              </div>
-            </div>
-          </div>
-        ) : (
-          <div className="form-group">
-            <label>VA Data File (CSV)</label>
-            <input
-              type="file"
-              accept=".csv"
-              onChange={(e) => updateUpload(0, 'file', e.target.files[0])}
-            />
-            <small className="form-hint">
-              WHO 2016 VA questionnaire format (columns: i004a, i004b, ...)
-            </small>
-            <div className="sample-download">
-              <a
-                href={`${import.meta.env.BASE_URL}${ageGroup === 'neonate' ? 'sample_openva_neonate.csv' : 'sample_openva_child.csv'}`}
-                download
-              >
-                Download sample CSV ({ageGroup === 'neonate' ? 'neonate' : 'child'})
-              </a>
-            </div>
           </div>
         )}
 

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -403,17 +403,23 @@ export default function JobForm({ onJobSubmitted }) {
         {/* Vacalibration-specific parameters */}
         {(jobType === 'vacalibration' || jobType === 'pipeline') && (
           <div className="form-group">
-            <label>Propagate uncertainty in misclassification matrix</label>
-            <CustomSelect
-              value={calibModelType}
-              onChange={setCalibModelType}
-              options={[
-                { value: 'Mmatprior', label: 'Yes (Informative Prior)' },
-                { value: 'Mmatfixed', label: 'No (Fixed misclassification matrix)' }
-              ]}
-            />
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={calibModelType === 'Mmatprior'}
+                onChange={(e) => setCalibModelType(e.target.checked ? 'Mmatprior' : 'Mmatfixed')}
+              />
+              {' '}Propagate uncertainty in CCVA misclassification
+            </label>
             <small className="form-hint">
-              Controls how uncertainty in misclassification estimates is handled
+              Controls whether to propagate uncertainty in{' '}
+              <a
+                href="https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CCVA misclassification estimate
+              </a>
             </small>
           </div>
         )}

--- a/frontend/src/components/JobForm.test.js
+++ b/frontend/src/components/JobForm.test.js
@@ -23,20 +23,17 @@ describe('JobForm button labels (issue #26)', () => {
   })
 })
 
-describe('Uncertainty propagation labels (issue #25)', () => {
-  it('label says "Propagate uncertainty in misclassification matrix" not "Uncertainty Propagation"', () => {
-    expect(jobFormSrc).toContain('Propagate uncertainty in misclassification matrix')
+describe('Uncertainty propagation control (issue #68 supersedes #25)', () => {
+  it('label is the new CCVA wording, not the old matrix wording', () => {
+    expect(jobFormSrc).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(jobFormSrc).not.toContain('Propagate uncertainty in misclassification matrix')
     expect(jobFormSrc).not.toContain('Uncertainty Propagation')
   })
 
-  it('Mmatprior option says "Yes (Informative Prior)" not "Prior (Full Bayesian)"', () => {
-    expect(jobFormSrc).toContain("'Yes (Informative Prior)'")
-    expect(jobFormSrc).not.toContain("'Prior (Full Bayesian)'")
-  })
-
-  it('Mmatfixed option says "No (Fixed misclassification matrix)" not "Fixed (No Uncertainty)"', () => {
-    expect(jobFormSrc).toContain("'No (Fixed misclassification matrix)'")
-    expect(jobFormSrc).not.toContain("'Fixed (No Uncertainty)'")
+  it('is a checkbox bound to calibModelType (no Yes/No dropdown options)', () => {
+    expect(jobFormSrc).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(jobFormSrc).not.toContain("'Yes (Informative Prior)'")
+    expect(jobFormSrc).not.toContain("'No (Fixed misclassification matrix)'")
   })
 })
 

--- a/frontend/src/index.css
+++ b/frontend/src/index.css
@@ -1,5 +1,5 @@
 /* ========================================
-   VA Calibration Platform - Design System
+   VA-Calibration Platform - Design System
    Modern Data Platform Theme
    ======================================== */
 


### PR DESCRIPTION
## Summary
Implements GitHub issue #68 — copy, input-ordering, control, and branding changes to the job form and page title. No backend/payload changes.

- **Page title:** Calibrate heading → "Correcting for Algorithmic Misclassification in Estimating Cause Distributions" (subtitle removed; the #69 credit line still renders beneath). Nav item + submit button stay "Calibrate".
- **Branding:** visible "VA Calibration" → "VA-Calibration" (sidebar, browser tab title, CSS comments). The `vacalibration` R-package name is intentionally left untouched.
- **Input order:** Job Type → Country → Age Group → CCVA Algorithm → Propagate uncertainty → Upload VA Data → MCMC Specifics (MCMC moved last).
- **Age group:** "Children (1-59 months)".
- **Country:** 7 supported countries alphabetical + "Other" (the package only has data for these; default stays Mozambique; underlying values unchanged).
- **Algorithm label:** prefixed "Computer-Coded Verbal Autopsy (CCVA)".
- **Uncertainty control:** Yes/No dropdown → checkbox (default checked), reusing `calibModelType` (checked→`Mmatprior`, unchecked→`Mmatfixed`) so the payload is identical; new hint links the CCVA-Misclassification-Matrices repo.
- **MCMC:** "Advanced MCMC Settings" → "MCMC Specifics" with a new three-line hint.

## Test Plan
- [x] `cd frontend && npx vitest run` — 155 tests pass, incl. a jsdom test asserting the new field order, a checkbox-behavior test, the integration test, and the superseded issue-#25 assertions.
- [x] `npm run build` succeeds; lint clean for changed files (2 pre-existing `AuthContext.jsx` errors only).
- [ ] **Visual check (please eyeball):** automated browser couldn't reach the local dev server. Open `http://localhost:5173/comsa-dashboard/` and confirm the new title, field order, the uncertainty checkbox (checked by default, links the CCVA repo), the alphabetical country list, and "MCMC Specifics".

## Follow-up (out of scope)
The Playwright E2E specs (`frontend/e2e/*.spec.js`) are pre-existing stale — they assert an `h1` of "VA Calibration Platform" and use a `.tabs` selector that predates the sidebar UI. They need a separate update for the current sidebar layout + new title.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Uncertainty propagation control now uses a checkbox interface

* **Style**
  * Rebranded platform as "VA-Calibration"
  * Reorganized job submission form field order
  * Updated form labels (age group, countries, algorithm fields)
  * Enhanced Calibrate page heading; removed subtitle
  * Improved MCMC section help text with clearer formatting

<!-- review_stack_entry_start -->

[![Review Change Stack](https://storage.googleapis.com/coderabbit_public_assets/review-stack-in-coderabbit-ui.svg)](https://app.coderabbit.ai/change-stack/cliu238/comsa_dashboard/pull/71?utm_source=github_walkthrough&utm_medium=github&utm_campaign=change_stack)

<!-- review_stack_entry_end -->

<!-- end of auto-generated comment: release notes by coderabbit.ai -->