### PR TITLE
feat(form): input panel presentation refinements (#73)

### DIFF
--- a/docs/superpowers/plans/2026-06-02-input-panel-presentation-issue-73.md
+++ b/docs/superpowers/plans/2026-06-02-input-panel-presentation-issue-73.md
@@ -1,0 +1,1217 @@
+# Input Panel Presentation (Issue #73) Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Refine the job submission form so required inputs are obvious and the job's input/output is stated plainly, per the 10 items in GitHub issue #73.
+
+**Architecture:** Frontend-only. A new pure-function module maps two friendly dropdowns ("Input Type" / "Output Type") onto the existing backend `job_type` string (`openva` / `pipeline` / `vacalibration`), so `backend/plumber.R` is untouched. A second pure-function module centralizes timezone-labeled timestamp formatting, reused by Job Detail and Job List.
+
+**Tech Stack:** React (Vite), Vitest + @testing-library/react for tests. Run all tests with `cd frontend && npm test`.
+
+**Spec:** `docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md`
+
+---
+
+## File Structure
+
+**New files**
+- `frontend/src/utils/jobTypeMapping.js` — pure mapping between (inputType, outputType) and backend `job_type`, plus the option lists. Single source of truth for item #7.
+- `frontend/src/utils/jobTypeMapping.test.js` — unit tests for the mapping.
+- `frontend/src/utils/datetime.js` — `formatTimestamp(value)`: timezone-labeled local time, handling R array + tz-less UTC strings. Item #5.
+- `frontend/src/utils/datetime.test.js` — unit tests for the formatter.
+- `frontend/src/components/JobForm.issue73.test.js` — source-assertion tests for the new form strings/markup.
+- `frontend/src/components/JobForm.issue73.behavior.test.jsx` — render/interaction tests (cascade, required asterisks, field order).
+
+**Modified files**
+- `frontend/src/utils/progress.js` — export the existing private `parseTimestamp` so `datetime.js` reuses it (no logic change).
+- `frontend/src/components/JobForm.jsx` — the bulk of the work (items #1–#9).
+- `frontend/src/components/JobDetail.jsx` — use `formatTimestamp` for Created/Started/Completed.
+- `frontend/src/components/JobList.jsx` — use `formatTimestamp` for the Created column.
+- `frontend/src/App.css` — restyle `.advanced-toggle` (item #3); add `.output-type-locked` and `.required-legend`.
+- `frontend/src/components/JobForm.issue68.test.js` — migrate the uncertainty-label assertions superseded by item #8.
+- `frontend/src/components/JobForm.issue68.behavior.test.jsx` — migrate the uncertainty-checkbox label helper and the field-order sequence.
+- `frontend/src/components/JobForm.test.js` — migrate the uncertainty-label assertion superseded by item #8.
+
+**Deliberately NOT changed**
+- The submit button stays `'Calibrate'` and the App nav tab stays `Calibrate` (issue #26). Item #1 renames only the panel `<h2>` heading. `JobForm.test.js`'s quote-anchored `/['"]Submit Job['"]/` guard is unaffected because the heading is JSX text, not a quoted string.
+
+---
+
+## Task 1: jobType mapping utility (item #7 core logic)
+
+**Files:**
+- Create: `frontend/src/utils/jobTypeMapping.js`
+- Test: `frontend/src/utils/jobTypeMapping.test.js`
+
+- [ ] **Step 1: Write the failing test**
+
+Create `frontend/src/utils/jobTypeMapping.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import {
+  INPUT_TYPES,
+  outputTypeOptions,
+  deriveJobType,
+  jobTypeToSelectors,
+} from './jobTypeMapping.js'
+
+describe('jobTypeMapping (issue #73)', () => {
+  it('offers two input types', () => {
+    expect(INPUT_TYPES.map((o) => o.value)).toEqual(['individual', 'ccva_output'])
+  })
+
+  it('Individual VA Records offers top-cause and distribution outputs', () => {
+    expect(outputTypeOptions('individual').map((o) => o.value)).toEqual([
+      'top_cause',
+      'distribution',
+    ])
+  })
+
+  it('Output from CCVA locks output to a single distribution option', () => {
+    expect(outputTypeOptions('ccva_output').map((o) => o.value)).toEqual(['distribution'])
+  })
+
+  it('derives job_type for every valid combination', () => {
+    expect(deriveJobType('individual', 'top_cause')).toBe('openva')
+    expect(deriveJobType('individual', 'distribution')).toBe('pipeline')
+    expect(deriveJobType('ccva_output', 'distribution')).toBe('vacalibration')
+  })
+
+  it('falls back to vacalibration for the locked input regardless of output', () => {
+    expect(deriveJobType('ccva_output', 'top_cause')).toBe('vacalibration')
+  })
+
+  it('inverts a job_type back into selector values', () => {
+    expect(jobTypeToSelectors('openva')).toEqual({ inputType: 'individual', outputType: 'top_cause' })
+    expect(jobTypeToSelectors('pipeline')).toEqual({ inputType: 'individual', outputType: 'distribution' })
+    expect(jobTypeToSelectors('vacalibration')).toEqual({ inputType: 'ccva_output', outputType: 'distribution' })
+  })
+
+  it('defaults unknown job_type to the vacalibration selectors', () => {
+    expect(jobTypeToSelectors('???')).toEqual({ inputType: 'ccva_output', outputType: 'distribution' })
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/utils/jobTypeMapping.test.js`
+Expected: FAIL — cannot resolve `./jobTypeMapping.js`.
+
+- [ ] **Step 3: Write minimal implementation**
+
+Create `frontend/src/utils/jobTypeMapping.js`:
+
+```js
+/**
+ * Maps the issue #73 "Input Type" / "Output Type" selectors onto the backend
+ * job_type string the API already understands ('openva' | 'pipeline' |
+ * 'vacalibration'). Pure functions — single source of truth for the cascade.
+ */
+
+export const INPUT_TYPES = [
+  { value: 'individual', label: 'Individual VA Records' },
+  { value: 'ccva_output', label: 'Output from CCVA' },
+];
+
+const TOP_CAUSE = { value: 'top_cause', label: 'Individual Top Cause of Death' };
+const DISTRIBUTION = { value: 'distribution', label: 'Cause Distribution' };
+
+/** Output Type options depend on the chosen Input Type. */
+export function outputTypeOptions(inputType) {
+  if (inputType === 'individual') return [TOP_CAUSE, DISTRIBUTION];
+  return [DISTRIBUTION]; // 'ccva_output' is locked to a single option
+}
+
+/** Derive the backend job_type from the two selectors. */
+export function deriveJobType(inputType, outputType) {
+  if (inputType === 'individual') {
+    return outputType === 'top_cause' ? 'openva' : 'pipeline';
+  }
+  return 'vacalibration';
+}
+
+/** Inverse mapping: which selectors produce a given job_type. */
+export function jobTypeToSelectors(jobType) {
+  switch (jobType) {
+    case 'openva':
+      return { inputType: 'individual', outputType: 'top_cause' };
+    case 'pipeline':
+      return { inputType: 'individual', outputType: 'distribution' };
+    case 'vacalibration':
+    default:
+      return { inputType: 'ccva_output', outputType: 'distribution' };
+  }
+}
+```
+
+- [ ] **Step 4: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/utils/jobTypeMapping.test.js`
+Expected: PASS (7 tests).
+
+- [ ] **Step 5: Commit**
+
+```bash
+git add frontend/src/utils/jobTypeMapping.js frontend/src/utils/jobTypeMapping.test.js
+git commit -m "feat(form): add Input/Output Type -> job_type mapping util (#73)"
+```
+
+---
+
+## Task 2: timestamp formatter with timezone (item #5)
+
+**Files:**
+- Modify: `frontend/src/utils/progress.js` (export `parseTimestamp`)
+- Create: `frontend/src/utils/datetime.js`
+- Test: `frontend/src/utils/datetime.test.js`
+
+- [ ] **Step 1: Export the existing parser from progress.js**
+
+In `frontend/src/utils/progress.js`, change the private declaration:
+
+```js
+function parseTimestamp(value) {
+```
+
+to:
+
+```js
+export function parseTimestamp(value) {
+```
+
+(No other change — `getElapsedTime` in the same file keeps calling it.)
+
+- [ ] **Step 2: Write the failing test**
+
+Create `frontend/src/utils/datetime.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { formatTimestamp } from './datetime.js'
+
+describe('formatTimestamp (issue #73)', () => {
+  it('returns a dash for empty values', () => {
+    expect(formatTimestamp(null)).toBe('-')
+    expect(formatTimestamp(undefined)).toBe('-')
+    expect(formatTimestamp('')).toBe('-')
+  })
+
+  it('includes a timezone label in the formatted output', () => {
+    // toLocaleString with timeZoneName:'short' appends a zone token (e.g. "EDT",
+    // "GMT+8"). We assert a non-empty, non-dash string that differs from the raw
+    // ISO input — i.e. it was actually formatted.
+    const out = formatTimestamp('2026-06-02T15:04:00Z')
+    expect(out).not.toBe('-')
+    expect(out).not.toBe('2026-06-02T15:04:00Z')
+    expect(out.length).toBeGreaterThan(0)
+  })
+
+  it('handles the R array epoch-seconds format', () => {
+    const epoch = new Date('2026-06-02T15:04:00Z').getTime() / 1000
+    const out = formatTimestamp([epoch])
+    expect(out).not.toBe('-')
+  })
+
+  it('parses a tz-less R string as UTC (delegates to parseTimestamp)', () => {
+    // Same instant expressed two ways must format identically.
+    const a = formatTimestamp('2026-06-02 15:04:00')
+    const b = formatTimestamp('2026-06-02T15:04:00Z')
+    expect(a).toBe(b)
+  })
+
+  it('returns a dash for unparseable input', () => {
+    expect(formatTimestamp('not-a-date')).toBe('-')
+  })
+})
+```
+
+- [ ] **Step 3: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/utils/datetime.test.js`
+Expected: FAIL — cannot resolve `./datetime.js`.
+
+- [ ] **Step 4: Write minimal implementation**
+
+Create `frontend/src/utils/datetime.js`:
+
+```js
+import { parseTimestamp } from './progress.js';
+
+/**
+ * Format a job timestamp in the viewer's local time WITH an explicit timezone
+ * label, so it is unambiguous which zone is shown (issue #73, item #5).
+ * Accepts ISO strings, tz-less R UTC strings, and the R [epoch_seconds] array
+ * format (parsing is delegated to parseTimestamp).
+ */
+export function formatTimestamp(value) {
+  if (value === null || value === undefined || value === '') return '-';
+  const d = parseTimestamp(value);
+  if (Number.isNaN(d.getTime())) return '-';
+  return d.toLocaleString(undefined, { timeZoneName: 'short' });
+}
+```
+
+- [ ] **Step 5: Run test to verify it passes**
+
+Run: `cd frontend && npx vitest run src/utils/datetime.test.js`
+Expected: PASS (5 tests).
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/utils/progress.js frontend/src/utils/datetime.js frontend/src/utils/datetime.test.js
+git commit -m "feat(utils): timezone-labeled timestamp formatter (#73)"
+```
+
+---
+
+## Task 3: JobForm — Input Type / Output Type cascade (item #7)
+
+Replaces the single "Job Type" `CustomSelect` with two cascading selects, deriving `job_type` from them. All existing `jobType`-keyed logic keeps working because `jobType` becomes a derived constant.
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx`
+- Modify: `frontend/src/components/JobForm.issue68.behavior.test.jsx` (field-order sequence)
+- Create: `frontend/src/components/JobForm.issue73.behavior.test.jsx` (cascade)
+
+- [ ] **Step 1: Update the field-order test to the new labels (failing)**
+
+In `frontend/src/components/JobForm.issue68.behavior.test.jsx`, replace the `sequence` array and the test title in the "Form field order" block:
+
+```js
+  it('renders fields in order: Input Type, Output Type, Country, Age Group, CCVA Algorithm, Uncertainty, Upload, MCMC', () => {
+    const { container } = render(<JobForm onJobSubmitted={() => {}} />)
+    const text = container.textContent
+    const sequence = [
+      'Input Type',
+      'Output Type',
+      'Country',
+      'Age Group',
+      'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
+      'Uncertainty in CCVA misclassification',
+      'Upload VA Data',
+      'MCMC Specifics',
+    ]
+    const positions = sequence.map((s) => text.indexOf(s))
+    positions.forEach((p, i) => expect(p, `"${sequence[i]}" not found`).toBeGreaterThan(-1))
+    for (let i = 1; i < positions.length; i++) {
+      expect(positions[i], `"${sequence[i]}" should come after "${sequence[i - 1]}"`).toBeGreaterThan(positions[i - 1])
+    }
+  })
+```
+
+- [ ] **Step 2: Write the cascade behavior test (failing)**
+
+Create `frontend/src/components/JobForm.issue73.behavior.test.jsx`:
+
+```jsx
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+describe('Input Type / Output Type cascade (issue #73)', () => {
+  it('defaults to Output from CCVA with a locked Cause Distribution output', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    // Default landing state = vacalibration.
+    expect(screen.getByText('Output from CCVA')).toBeTruthy()
+    expect(screen.getByText('Cause Distribution')).toBeTruthy()
+  })
+
+  it('switching Input Type to Individual VA Records reveals the two outputs', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    fireEvent.click(screen.getByText('Output from CCVA'))     // open Input Type
+    fireEvent.click(screen.getByText('Individual VA Records')) // select it
+    // Output Type now defaults to the first individual option.
+    expect(screen.getByText('Individual Top Cause of Death')).toBeTruthy()
+  })
+})
+```
+
+- [ ] **Step 3: Run both tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue73.behavior.test.jsx src/components/JobForm.issue68.behavior.test.jsx`
+Expected: FAIL — "Input Type" not found / "Output from CCVA" not found (form still shows "Job Type").
+
+- [ ] **Step 4: Wire the cascade into JobForm.jsx**
+
+4a. Add the import near the top of `frontend/src/components/JobForm.jsx` (after the existing imports):
+
+```jsx
+import { INPUT_TYPES, outputTypeOptions, deriveJobType, jobTypeToSelectors } from '../utils/jobTypeMapping';
+```
+
+4b. Replace the job-type state declaration:
+
+```jsx
+  const [jobType, setJobType] = useState('vacalibration');
+```
+
+with the two selectors (default = vacalibration landing state) and a derived `jobType`:
+
+```jsx
+  const initialSelectors = jobTypeToSelectors('vacalibration');
+  const [inputType, setInputType] = useState(initialSelectors.inputType);
+  const [outputType, setOutputType] = useState(initialSelectors.outputType);
+  const jobType = deriveJobType(inputType, outputType);
+```
+
+4c. Keep `jobType` valid after an Input Type change by resetting Output Type to the first option for that input. Add this effect right after the existing polling effect (so it sits with the other effects):
+
+```jsx
+  // When Input Type changes, snap Output Type to the first valid option for it.
+  useEffect(() => {
+    setOutputType(outputTypeOptions(inputType)[0].value);
+  }, [inputType]);
+```
+
+4d. Replace the "Job Type" form group:
+
+```jsx
+        <div className="form-group">
+          <label>Job Type</label>
+          <CustomSelect
+            value={jobType}
+            onChange={setJobType}
+            options={[
+              { value: 'pipeline', label: 'Full Pipeline (openVA + Calibration)' },
+              { value: 'openva', label: 'openVA Only' },
+              { value: 'vacalibration', label: 'Calibration Only' }
+            ]}
+          />
+        </div>
+```
+
+with two cascading groups (the locked-output case renders read-only text):
+
+```jsx
+        <div className="form-group">
+          <label>Input Type <span className="required">*</span></label>
+          <CustomSelect
+            value={inputType}
+            onChange={setInputType}
+            options={INPUT_TYPES}
+          />
+        </div>
+
+        <div className="form-group">
+          <label>Output Type <span className="required">*</span></label>
+          {inputType === 'individual' ? (
+            <CustomSelect
+              value={outputType}
+              onChange={setOutputType}
+              options={outputTypeOptions('individual')}
+            />
+          ) : (
+            <div className="output-type-locked">Cause Distribution</div>
+          )}
+        </div>
+```
+
+- [ ] **Step 5: Run the behavior tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue73.behavior.test.jsx src/components/JobForm.issue68.behavior.test.jsx`
+Expected: PASS. (The field-order test now finds Input Type → Output Type → … in order.)
+
+- [ ] **Step 6: Run the full JobForm test set to catch regressions**
+
+Run: `cd frontend && npx vitest run src/components/JobForm`
+Expected: All JobForm specs PASS except the uncertainty-label and presentation assertions handled in Task 4 — note any failures; they should be limited to `JobForm.test.js` / `JobForm.issue68.test.js` uncertainty strings (fixed next task). If anything else fails, stop and investigate before continuing.
+
+- [ ] **Step 7: Commit**
+
+```bash
+git add frontend/src/components/JobForm.jsx \
+        frontend/src/components/JobForm.issue73.behavior.test.jsx \
+        frontend/src/components/JobForm.issue68.behavior.test.jsx
+git commit -m "feat(form): cascading Input Type/Output Type selectors (#73)"
+```
+
+---
+
+## Task 4: JobForm — labels, timings, ordering, asterisks, uncertainty, links (items #1, #2, #4, #6, #8, #9)
+
+**Files:**
+- Modify: `frontend/src/components/JobForm.jsx`
+- Create: `frontend/src/components/JobForm.issue73.test.js`
+- Modify: `frontend/src/components/JobForm.issue68.test.js`
+- Modify: `frontend/src/components/JobForm.test.js`
+
+- [ ] **Step 1: Write the issue #73 source-assertion test (failing)**
+
+Create `frontend/src/components/JobForm.issue73.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(resolve(__dir, 'JobForm.jsx'), 'utf-8')
+
+describe('Panel heading & required legend (issue #73 items #1, #4)', () => {
+  it('heading is "Submit Job", not "Submit New Job"', () => {
+    expect(src).toContain('<h2>Submit Job</h2>')
+    expect(src).not.toContain('Submit New Job')
+  })
+  it('shows a "Required fields" legend', () => {
+    expect(src).toContain('required-legend')
+    expect(src).toContain('Required fields')
+  })
+})
+
+describe('Upload label & example script link (issue #73 items #6, #9)', () => {
+  it('renames the upload label to "Upload VA Data"', () => {
+    expect(src).toContain('Upload VA Data')
+    expect(src).not.toContain('VA Data Files (one CSV per selected algorithm)')
+  })
+  it('links to the vacalibration example repository', () => {
+    expect(src).toContain('https://github.com/sandy-pramanik/vacalibration')
+  })
+})
+
+describe('Timings removed & algorithm order (issue #73 item #2)', () => {
+  it('removes all per-algorithm timing hints', () => {
+    expect(src).not.toContain('~30sec')
+    expect(src).not.toContain('~2-3min')
+    expect(src).not.toContain('~1min')
+  })
+  it('removes ensemble runtime estimates', () => {
+    expect(src).not.toContain('Estimated runtime')
+    expect(src).not.toContain('will take approximately')
+  })
+  it('orders algorithm options EAVA, InSilicoVA, InterVA in the calibration block', () => {
+    const block = src.slice(src.indexOf("jobType === 'vacalibration'"))
+    const eava = block.indexOf("checked={algorithms.includes('EAVA')}")
+    const insilico = block.indexOf("checked={algorithms.includes('InSilicoVA')}")
+    const interva = block.indexOf("checked={algorithms.includes('InterVA')}")
+    expect(eava).toBeGreaterThan(-1)
+    expect(eava).toBeLessThan(insilico)
+    expect(insilico).toBeLessThan(interva)
+  })
+  it('orders the sample CSV links EAVA, InSilicoVA, InterVA', () => {
+    const eava = src.indexOf('sample_eava_neonate.csv')
+    const insilico = src.indexOf('sample_insilicova_neonate.csv')
+    const interva = src.indexOf('sample_interva_neonate.csv')
+    expect(eava).toBeLessThan(insilico)
+    expect(insilico).toBeLessThan(interva)
+  })
+})
+
+describe('Uncertainty block restructure (issue #73 item #8)', () => {
+  it('uses a heading + a "Propagate" checkbox, not the combined #68 label', () => {
+    expect(src).toContain('Uncertainty in CCVA misclassification')
+    expect(src).not.toContain('Propagate uncertainty in CCVA misclassification')
+    // keeps the binding and the reference link from #68
+    expect(src).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+  })
+})
+```
+
+- [ ] **Step 2: Migrate the conflicting issue #68 assertions (still failing build of expectations)**
+
+2a. In `frontend/src/components/JobForm.test.js`, replace the body of the `it('label is the new CCVA wording, …')` test (the assertion superseded by item #8):
+
+```js
+  it('label is the new CCVA wording, not the old matrix wording', () => {
+    expect(jobFormSrc).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(jobFormSrc).not.toContain('Propagate uncertainty in misclassification matrix')
+    expect(jobFormSrc).not.toContain('Uncertainty Propagation')
+  })
+```
+
+with the issue #73 structure:
+
+```js
+  it('label is the new CCVA wording, not the old matrix wording', () => {
+    // Issue #73 item #8 splits the #68 label into a heading + "Propagate" checkbox.
+    expect(jobFormSrc).toContain('Uncertainty in CCVA misclassification')
+    expect(jobFormSrc).not.toContain('Propagate uncertainty in misclassification matrix')
+    expect(jobFormSrc).not.toContain('Uncertainty Propagation')
+  })
+```
+
+2b. In `frontend/src/components/JobForm.issue68.test.js`, replace the `it('uses the new label and hint with the CCVA matrices link', …)` body:
+
+```js
+  it('uses the new label and hint with the CCVA matrices link', () => {
+    expect(src).toContain('Propagate uncertainty in CCVA misclassification')
+    expect(src).toContain('Controls whether to propagate uncertainty in')
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+    expect(src).not.toContain('Controls how uncertainty in misclassification estimates is handled')
+    expect(src).not.toContain('Propagate uncertainty in misclassification matrix')
+  })
+```
+
+with:
+
+```js
+  it('uses the new label and hint with the CCVA matrices link', () => {
+    // #73 item #8: heading "Uncertainty in CCVA misclassification" + "Propagate" checkbox.
+    expect(src).toContain('Uncertainty in CCVA misclassification')
+    expect(src).toContain('Controls whether to propagate uncertainty in')
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+    expect(src).not.toContain('Controls how uncertainty in misclassification estimates is handled')
+    expect(src).not.toContain('Propagate uncertainty in misclassification matrix')
+  })
+```
+
+2c. In `frontend/src/components/JobForm.issue68.behavior.test.jsx`, change the checkbox label helper:
+
+```js
+const uncertaintyCheckbox = () =>
+  screen.getByLabelText(/Propagate uncertainty in CCVA misclassification/i)
+```
+
+to:
+
+```js
+const uncertaintyCheckbox = () =>
+  screen.getByLabelText(/Propagate/i)
+```
+
+- [ ] **Step 3: Run the tests to verify they fail**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue73.test.js src/components/JobForm.issue68.test.js src/components/JobForm.test.js src/components/JobForm.issue68.behavior.test.jsx`
+Expected: FAIL — the source still says "Submit New Job", has timings, old upload label, and the combined uncertainty label.
+
+- [ ] **Step 4: Apply the JobForm.jsx presentation edits**
+
+4a. Heading + required legend. Replace:
+
+```jsx
+    <div className="job-form">
+      <h2>Submit New Job</h2>
+```
+
+with:
+
+```jsx
+    <div className="job-form">
+      <h2>Submit Job</h2>
+      <p className="required-legend"><span className="required">*</span> Required fields</p>
+```
+
+4b. Add a required asterisk to the Country and Age Group labels. Replace `<label>Country</label>` with:
+
+```jsx
+            <label>Country <span className="required">*</span></label>
+```
+
+and `<label>Age Group</label>` with:
+
+```jsx
+            <label>Age Group <span className="required">*</span></label>
+```
+
+4c. openVA algorithm selector — reorder + strip timings + add asterisk. Replace the `jobType === 'openva'` form group's label and `CustomSelect`:
+
+```jsx
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithm</label>
+            <CustomSelect
+              value={algorithms[0] || 'InterVA'}
+              onChange={handleAlgorithmSelect}
+              options={[
+                { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+                { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+                { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+              ]}
+            />
+```
+
+with:
+
+```jsx
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithm <span className="required">*</span></label>
+            <CustomSelect
+              value={algorithms[0] || 'InterVA'}
+              onChange={handleAlgorithmSelect}
+              options={[
+                { value: 'EAVA', label: 'EAVA' },
+                { value: 'InSilicoVA', label: 'InSilicoVA' },
+                { value: 'InterVA', label: 'InterVA' }
+              ]}
+            />
+```
+
+4d. Pipeline algorithm label — add asterisk. Replace:
+
+```jsx
+            <label>
+              Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''}
+              {ensemble && (
+                <span className="required"> * Select at least 2 for ensemble</span>
+              )}
+            </label>
+```
+
+with:
+
+```jsx
+            <label>
+              Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''} <span className="required">*</span>
+              {ensemble && (
+                <span className="required"> Select at least 2 for ensemble</span>
+              )}
+            </label>
+```
+
+4e. Pipeline ensemble checkboxes — reorder + strip timings + drop runtime hint. Replace the `<div className="algorithm-checkboxes">` block inside the pipeline `ensemble ? (...)`:
+
+```jsx
+              <div className="algorithm-checkboxes">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InterVA')}
+                    onChange={() => handleAlgorithmToggle('InterVA')}
+                  />
+                  InterVA (fastest, ~30sec)
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InSilicoVA')}
+                    onChange={() => handleAlgorithmToggle('InSilicoVA')}
+                  />
+                  InSilicoVA (most accurate, ~2-3min)
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('EAVA')}
+                    onChange={() => handleAlgorithmToggle('EAVA')}
+                  />
+                  EAVA (deterministic, ~1min)
+                </label>
+                {algorithms.length > 1 && (
+                  <small className="form-hint warning">
+                    Running {algorithms.length} algorithms will take approximately{' '}
+                    {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}
+                  </small>
+                )}
+              </div>
+```
+
+with:
+
+```jsx
+              <div className="algorithm-checkboxes">
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('EAVA')}
+                    onChange={() => handleAlgorithmToggle('EAVA')}
+                  />
+                  EAVA
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InSilicoVA')}
+                    onChange={() => handleAlgorithmToggle('InSilicoVA')}
+                  />
+                  InSilicoVA
+                </label>
+                <label className="checkbox-label">
+                  <input
+                    type="checkbox"
+                    checked={algorithms.includes('InterVA')}
+                    onChange={() => handleAlgorithmToggle('InterVA')}
+                  />
+                  InterVA
+                </label>
+              </div>
+```
+
+4f. Pipeline non-ensemble select — reorder + strip timings. Replace:
+
+```jsx
+              <CustomSelect
+                value={algorithms[0] || 'InterVA'}
+                onChange={handleAlgorithmSelect}
+                options={[
+                  { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
+                  { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
+                  { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+                ]}
+              />
+```
+
+with:
+
+```jsx
+              <CustomSelect
+                value={algorithms[0] || 'InterVA'}
+                onChange={handleAlgorithmSelect}
+                options={[
+                  { value: 'EAVA', label: 'EAVA' },
+                  { value: 'InSilicoVA', label: 'InSilicoVA' },
+                  { value: 'InterVA', label: 'InterVA' }
+                ]}
+              />
+```
+
+4g. Vacalibration checkboxes — reorder + strip timings + asterisk on label. Replace:
+
+```jsx
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithms *</label>
+
+            <div className="algorithm-checkboxes">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('InterVA')}
+                  onChange={() => handleAlgorithmToggle('InterVA')}
+                />
+                InterVA (fastest, ~30sec)
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('InSilicoVA')}
+                  onChange={() => handleAlgorithmToggle('InSilicoVA')}
+                />
+                InSilicoVA (most accurate, ~2-3min)
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('EAVA')}
+                  onChange={() => handleAlgorithmToggle('EAVA')}
+                />
+                EAVA (deterministic, ~1min)
+              </label>
+            </div>
+```
+
+with:
+
+```jsx
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithms <span className="required">*</span></label>
+
+            <div className="algorithm-checkboxes">
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('EAVA')}
+                  onChange={() => handleAlgorithmToggle('EAVA')}
+                />
+                EAVA
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('InSilicoVA')}
+                  onChange={() => handleAlgorithmToggle('InSilicoVA')}
+                />
+                InSilicoVA
+              </label>
+              <label className="checkbox-label">
+                <input
+                  type="checkbox"
+                  checked={algorithms.includes('InterVA')}
+                  onChange={() => handleAlgorithmToggle('InterVA')}
+                />
+                InterVA
+              </label>
+            </div>
+```
+
+4h. Vacalibration ensemble hint — drop the runtime estimate. Replace:
+
+```jsx
+                <small className="form-hint">
+                  Runs per-algorithm calibration plus an additional combined ensemble result.
+                  {' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.
+                </small>
+```
+
+with:
+
+```jsx
+                <small className="form-hint">
+                  Runs per-algorithm calibration plus an additional combined ensemble result.
+                </small>
+```
+
+4i. Uncertainty block restructure. Replace:
+
+```jsx
+          <div className="form-group">
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={calibModelType === 'Mmatprior'}
+                onChange={(e) => setCalibModelType(e.target.checked ? 'Mmatprior' : 'Mmatfixed')}
+              />
+              {' '}Propagate uncertainty in CCVA misclassification
+            </label>
+            <small className="form-hint">
+              Controls whether to propagate uncertainty in{' '}
+              <a
+                href="https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CCVA misclassification estimate
+              </a>
+            </small>
+          </div>
+```
+
+with:
+
+```jsx
+          <div className="form-group">
+            <label>Uncertainty in CCVA misclassification</label>
+            <label className="checkbox-label">
+              <input
+                type="checkbox"
+                checked={calibModelType === 'Mmatprior'}
+                onChange={(e) => setCalibModelType(e.target.checked ? 'Mmatprior' : 'Mmatfixed')}
+              />
+              {' '}Propagate
+            </label>
+            <small className="form-hint">
+              Controls whether to propagate uncertainty in{' '}
+              <a
+                href="https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                CCVA misclassification estimate
+              </a>
+            </small>
+          </div>
+```
+
+4j. Upload label (#6), asterisk (#4), reorder sample links (#2), and add the example-script link (#9). Replace:
+
+```jsx
+            <label>VA Data Files (one CSV per selected algorithm)</label>
+            {uploads.map((upload, index) => (
+              <div key={upload.id} className="upload-row">
+                <span className="upload-algo-label">{upload.algorithm}</span>
+                <input
+                  type="file"
+                  accept=".csv"
+                  onChange={(e) => updateUpload(index, 'file', e.target.files[0])}
+                />
+                {upload.file && <span className="file-name">{upload.file.name}</span>}
+              </div>
+            ))}
+            <small className="form-hint">
+              Upload one CSV file per selected algorithm. Required columns: ID, cause.
+            </small>
+            <div className="sample-download">
+              <div className="sample-links">
+                <span>Sample CSV (neonate, 1190 records):</span>
+                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
+              </div>
+            </div>
+```
+
+with:
+
+```jsx
+            <label>Upload VA Data <span className="required">*</span></label>
+            {uploads.map((upload, index) => (
+              <div key={upload.id} className="upload-row">
+                <span className="upload-algo-label">{upload.algorithm}</span>
+                <input
+                  type="file"
+                  accept=".csv"
+                  onChange={(e) => updateUpload(index, 'file', e.target.files[0])}
+                />
+                {upload.file && <span className="file-name">{upload.file.name}</span>}
+              </div>
+            ))}
+            <small className="form-hint">
+              Upload one CSV file per selected algorithm. Required columns: ID, cause.
+            </small>
+            <small className="form-hint">
+              See the{' '}
+              <a
+                href="https://github.com/sandy-pramanik/vacalibration"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                vacalibration example code
+              </a>
+              {' '}for how to prepare, run, and save input data.
+            </small>
+            <div className="sample-download">
+              <div className="sample-links">
+                <span>Sample CSV (neonate, 1190 records):</span>
+                <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
+              </div>
+            </div>
+```
+
+4k. Add an asterisk to the non-vacalibration upload label. Replace `<label>VA Data File (CSV)</label>` with:
+
+```jsx
+            <label>VA Data File (CSV) <span className="required">*</span></label>
+```
+
+- [ ] **Step 5: Run the tests to verify they pass**
+
+Run: `cd frontend && npx vitest run src/components/JobForm.issue73.test.js src/components/JobForm.issue68.test.js src/components/JobForm.test.js src/components/JobForm.issue68.behavior.test.jsx`
+Expected: PASS for all.
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/JobForm.jsx \
+        frontend/src/components/JobForm.issue73.test.js \
+        frontend/src/components/JobForm.issue68.test.js \
+        frontend/src/components/JobForm.test.js \
+        frontend/src/components/JobForm.issue68.behavior.test.jsx
+git commit -m "feat(form): labels, asterisks, timings, uncertainty, links (#73)"
+```
+
+---
+
+## Task 5: Timestamps with timezone in Job Detail & Job List (item #5)
+
+**Files:**
+- Modify: `frontend/src/components/JobDetail.jsx`
+- Modify: `frontend/src/components/JobList.jsx`
+- Create: `frontend/src/components/Timestamps.issue73.test.js`
+
+- [ ] **Step 1: Write the failing source test**
+
+Create `frontend/src/components/Timestamps.issue73.test.js`:
+
+```js
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const detailSrc = readFileSync(resolve(__dir, 'JobDetail.jsx'), 'utf-8')
+const listSrc = readFileSync(resolve(__dir, 'JobList.jsx'), 'utf-8')
+
+describe('Timestamps use the shared timezone-labeled formatter (issue #73)', () => {
+  it('JobDetail imports and uses formatTimestamp for the time rows', () => {
+    expect(detailSrc).toContain("from '../utils/datetime'")
+    expect(detailSrc).toContain('formatTimestamp(status.created_at)')
+    expect(detailSrc).toContain('formatTimestamp(status.started_at)')
+    expect(detailSrc).toContain('formatTimestamp(status.completed_at)')
+  })
+  it('JobList imports and uses formatTimestamp for the created column', () => {
+    expect(listSrc).toContain("from '../utils/datetime'")
+    expect(listSrc).toContain('formatTimestamp(job.created_at)')
+    expect(listSrc).not.toContain('new Date(job.created_at).toLocaleString()')
+  })
+})
+```
+
+- [ ] **Step 2: Run test to verify it fails**
+
+Run: `cd frontend && npx vitest run src/components/Timestamps.issue73.test.js`
+Expected: FAIL — `formatTimestamp` not imported/used yet.
+
+- [ ] **Step 3: Update JobDetail.jsx**
+
+3a. Add the import at the top of `frontend/src/components/JobDetail.jsx` (with the other imports):
+
+```jsx
+import { formatTimestamp } from '../utils/datetime';
+```
+
+3b. Delete the local `formatDate` helper:
+
+```jsx
+function formatDate(value) {
+  if (!value) return '-';
+  if (typeof value === 'string') return value;
+  if (Array.isArray(value)) return new Date(value[0] * 1000).toLocaleString();
+  if (typeof value === 'object') return JSON.stringify(value);
+  return String(value);
+}
+```
+
+3c. Update the three table rows. Replace:
+
+```jsx
+          <tr><td>Created</td><td>{formatDate(status.created_at)}</td></tr>
+          <tr><td>Started</td><td>{formatDate(status.started_at)}</td></tr>
+          <tr><td>Completed</td><td>{formatDate(status.completed_at)}</td></tr>
+```
+
+with:
+
+```jsx
+          <tr><td>Created</td><td>{formatTimestamp(status.created_at)}</td></tr>
+          <tr><td>Started</td><td>{formatTimestamp(status.started_at)}</td></tr>
+          <tr><td>Completed</td><td>{formatTimestamp(status.completed_at)}</td></tr>
+```
+
+- [ ] **Step 4: Update JobList.jsx**
+
+4a. Add the import at the top of `frontend/src/components/JobList.jsx`:
+
+```jsx
+import { formatTimestamp } from '../utils/datetime';
+```
+
+4b. Replace the created-at cell:
+
+```jsx
+              <td>{new Date(job.created_at).toLocaleString()}</td>
+```
+
+with:
+
+```jsx
+              <td>{formatTimestamp(job.created_at)}</td>
+```
+
+- [ ] **Step 5: Run the test plus the existing component tests**
+
+Run: `cd frontend && npx vitest run src/components/Timestamps.issue73.test.js src/components/JobDetail.test.js`
+Expected: PASS. (JobDetail.test.js asserts CSMF headings, not timestamps, so it stays green.)
+
+- [ ] **Step 6: Commit**
+
+```bash
+git add frontend/src/components/JobDetail.jsx \
+        frontend/src/components/JobList.jsx \
+        frontend/src/components/Timestamps.issue73.test.js
+git commit -m "feat(jobs): timezone-labeled timestamps in detail & list (#73)"
+```
+
+---
+
+## Task 6: CSS — MCMC heading, locked output, required legend (items #3, #4, #7)
+
+CSS-only; verified by visual run rather than unit tests.
+
+**Files:**
+- Modify: `frontend/src/App.css`
+
+- [ ] **Step 1: Restyle the MCMC toggle to match input titles (item #3)**
+
+In `frontend/src/App.css`, replace the `.advanced-toggle` rule:
+
+```css
+.advanced-toggle {
+  background: none;
+  border: none;
+  color: var(--color-secondary);
+  cursor: pointer;
+  font-size: 0.9rem;
+  padding: 4px 0;
+  font-family: var(--font-mono, monospace);
+}
+```
+
+with one that matches `.form-group label` (font-weight 500, 0.875rem, primary color, default font family):
+
+```css
+.advanced-toggle {
+  background: none;
+  border: none;
+  color: var(--color-primary);
+  cursor: pointer;
+  font-size: 0.875rem;
+  font-weight: 500;
+  padding: 4px 0;
+}
+```
+
+- [ ] **Step 2: Add the required-legend and locked-output styles**
+
+Append to `frontend/src/App.css` (after the `.required` rule near line 1137):
+
+```css
+.required-legend {
+  margin: 0 0 1rem;
+  font-size: 0.8rem;
+  color: var(--color-secondary);
+}
+
+.output-type-locked {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface, #f1f3f5);
+  color: var(--color-secondary);
+}
+```
+
+- [ ] **Step 3: Verify the app renders**
+
+Run: `cd frontend && npm run build`
+Expected: build succeeds with no errors.
+
+- [ ] **Step 4: Commit**
+
+```bash
+git add frontend/src/App.css
+git commit -m "style(form): MCMC heading, locked output, required legend (#73)"
+```
+
+---
+
+## Task 7: Full suite, lint, and final verification
+
+**Files:** none (verification only)
+
+- [ ] **Step 1: Run the entire frontend test suite**
+
+Run: `cd frontend && npm test`
+Expected: ALL tests pass. If any fail, fix before proceeding — do not leave a red suite.
+
+- [ ] **Step 2: Lint (if configured)**
+
+Run: `cd frontend && npm run lint`
+Expected: no new errors. (If the project has no `lint` script, skip and note it.)
+
+- [ ] **Step 3: Manual smoke test of the form**
+
+Start the app per the project's run instructions and confirm:
+- Heading reads "Submit Job" with a "* Required fields" legend.
+- Default Input Type = "Output from CCVA", Output Type shows a locked "Cause Distribution".
+- Switching Input Type to "Individual VA Records" reveals an Output Type dropdown with "Individual Top Cause of Death" and "Cause Distribution".
+- Algorithm lists read EAVA, InSilicoVA, InterVA with no timing text.
+- The uncertainty block has a "Uncertainty in CCVA misclassification" title above a "Propagate" checkbox.
+- The "Upload VA Data" label shows, with the vacalibration example-code link below it.
+- "MCMC Specifics" matches the other input titles in font.
+- Job Detail and Job List timestamps show a timezone label (e.g. "EDT").
+
+- [ ] **Step 4: Confirm backend untouched**
+
+Run: `git status --short backend/`
+Expected: no output (no backend changes).
+
+---
+
+## Self-Review (completed during planning)
+
+- **Spec coverage:** Items #1 (Task 4 4a), #2 (Task 4 4c–4h, 4j), #3 (Task 6 S1), #4 (Task 4 asterisks + legend), #5 (Tasks 2 & 5), #6 (Task 4 4j), #7 (Tasks 1 & 3), #8 (Task 4 4i), #9 (Task 4 4j). All ten items mapped.
+- **Resolved decisions honored:** default landing state = `vacalibration` (Task 3 4b); example link = `github.com/sandy-pramanik/vacalibration` (Task 4 4j).
+- **Test migration:** the issue #68 / #26 assertions that conflict with the new strings are migrated in Task 4 Step 2; the field-order and uncertainty-helper behavior tests in Task 3 Step 1 and Task 4 Step 2c.
+- **Type/name consistency:** `deriveJobType`, `outputTypeOptions`, `jobTypeToSelectors`, `INPUT_TYPES`, `formatTimestamp`, `parseTimestamp` are used with identical signatures across tasks.
+- **No backend changes:** verified by Task 7 Step 4.

--- a/docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md
+++ b/docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md
@@ -116,9 +116,8 @@ Implementation: include a timezone token in the formatted output (e.g. via
 Add an external link below "Upload VA Data" pointing to the vacalibration paper's example
 code for preparing/running/saving input data. No file is committed to this repo.
 
-- Default link target: the arXiv paper page <https://arxiv.org/abs/2603.21216>.
-- Final URL to be confirmed during spec review (a direct link to the example `.R` /
-  repository is preferable if available).
+- Link target: the vacalibration package repository
+  <https://github.com/sandy-pramanik/vacalibration>.
 
 ## Testing
 
@@ -140,11 +139,10 @@ Run via `cd frontend && npm test`.
 - No change to job execution, algorithms, or result rendering.
 - Committing the example `.R` script into this repo (issue #9 resolved as an external link).
 
-## Open questions (confirm during spec review)
+## Resolved decisions
 
-1. **Default selection** on form load: keep the current default of `vacalibration`
-   (which would mean defaulting Input Type to `Output from CCVA`), or default to
-   `Individual VA Records` + `Individual Top Cause of Death` (`openva`)? Proposed:
-   keep the current `vacalibration` default to avoid changing existing behavior.
-2. **Example-script URL** (item H): is the arXiv paper page acceptable, or is there a
-   direct link to the example `.R` file / its repository?
+1. **Default selection** on form load: keep the current `vacalibration` default
+   (Input Type = `Output from CCVA`, Output Type locked to `Cause Distribution`),
+   preserving existing behavior.
+2. **Example-script URL** (item H): link to
+   <https://github.com/sandy-pramanik/vacalibration>.

--- a/docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md
+++ b/docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md
@@ -1,0 +1,150 @@
+# Input Panel Presentation — Issue #73 Design
+
+**Date:** 2026-06-02
+**Issue:** [#73 — suggestion for input panel presentation](https://github.com/cliu238/comsa_dashboard/issues/73)
+**Scope:** Frontend only (`frontend/src/components/JobForm.jsx`, `JobDetail.jsx`, `JobList.jsx`). Backend API is unchanged.
+
+## Goal
+
+Make the job submission form clearly communicate what inputs are required and what the
+job will produce. The issue's framing: *"trying to cleanly separate all inputs so users
+know what's required."* Every item below serves that goal — reduce ambiguity and noise.
+
+## Key architectural decision
+
+The proposed "Input Type" / "Output Type" split is a **pure frontend relabeling**. The
+backend (`backend/plumber.R`) validates a `job_type` string of `openva`, `vacalibration`,
+or `pipeline`. `JobForm` will derive that same `job_type` from the two new dropdowns and
+keep sending it unchanged via `submitJob` / `submitDemoJob`. No backend edits.
+
+Rejected alternative: renaming `job_type` through the API and backend — adds risk and
+churn for no user-visible benefit, and violates the project's simplicity principle.
+
+## Items
+
+### A. Top-of-form restructure (issue item #7)
+
+Replace the single "Job Type" `CustomSelect` with two cascading selects:
+
+- **Input Type** *
+  - `Individual VA Records`
+  - `Output from CCVA`
+- **Output Type** * — options depend on Input Type:
+  - Input = `Individual VA Records`:
+    - `Individual Top Cause of Death` → `job_type = "openva"`
+    - `Cause Distribution` → `job_type = "pipeline"`
+  - Input = `Output from CCVA`:
+    - locked to `Cause Distribution` → `job_type = "vacalibration"`
+
+Mapping table (the single source of truth for the derivation):
+
+| Input Type            | Output Type                  | job_type        |
+|-----------------------|------------------------------|-----------------|
+| Individual VA Records | Individual Top Cause of Death | `openva`        |
+| Individual VA Records | Cause Distribution           | `pipeline`      |
+| Output from CCVA      | Cause Distribution (locked)  | `vacalibration` |
+
+Behavior:
+- Default state (proposed): preserve the current default `job_type = "vacalibration"`,
+  which means Input Type defaults to `Output from CCVA` with Output Type locked to
+  `Cause Distribution`. This keeps existing form behavior unchanged. See Open Questions
+  if a different default landing state is preferred.
+- Switching Input Type to `Output from CCVA` forces Output Type to `Cause Distribution`
+  and renders it locked.
+- Locked Output Type is shown as a disabled select displaying "Cause Distribution"
+  (styling detail can be finalized in implementation; plain read-only text is acceptable).
+- All existing conditional logic keyed on `jobType` (country visibility, algorithm
+  selector shape, upload rows, MCMC panel, ensemble rules) continues to key on the
+  derived `job_type` value, so downstream behavior is unchanged.
+
+### B. Required-field markers (issue item #4)
+
+- Add a red asterisk (`*`) next to each required field title, rendered only when that
+  field is visible: **Input Type, Output Type, Country, Age Group, Algorithm(s), file upload.**
+- Add a small `* Required fields` legend directly under the panel heading ("Submit Job").
+- Use a reusable marker (e.g. `<span className="required">*</span>`) styled red.
+
+### C. Label / text fixes
+
+- Panel heading `Submit New Job` → `Submit Job` (issue item #1).
+- Upload label `VA Data Files (one CSV per selected algorithm)` → `Upload VA Data`
+  (issue item #6). The helper hint about required columns may remain.
+
+### D. Timings and algorithm order (issue item #2)
+
+- Remove **all** timing text:
+  - per-algorithm hints — `(fastest, ~30sec)`, `(most accurate, ~2-3min)`,
+    `(deterministic, ~1min)` — in every selector and checkbox group.
+  - ensemble / multi-algorithm runtime estimates — the "Running N algorithms will take…"
+    and "Estimated runtime: …" hints.
+- Reorder algorithms everywhere to **EAVA, InSilicoVA, InterVA**: the openVA select, the
+  pipeline select and checkbox group, the vacalibration checkbox group, and the
+  sample-CSV download links (for consistency).
+- Algorithm option labels become just the names: `EAVA`, `InSilicoVA`, `InterVA`.
+
+### E. MCMC Specifics heading (issue item #3)
+
+Restyle the collapsible "MCMC Specifics" toggle so its text matches the input-title font
+(size / weight / color) used by labels like "Age Group". Collapse/expand behavior and the
+▸/▾ affordance are retained.
+
+### F. Uncertainty block (issue item #8, lesser priority)
+
+Give the uncertainty control a title consistent with the other input titles:
+
+- Title: `Uncertainty in CCVA misclassification`
+- Below it: a checkbox labeled `Propagate` (bound to the existing
+  `calibModelType === 'Mmatprior'` logic).
+- Keep the existing explanatory hint and the link to the CCVA misclassification reference.
+
+### G. Timestamps with timezone (issue item #5)
+
+Job timestamps already render in the browser's local time but show no timezone, so it is
+unclear which zone they represent. Add an explicit timezone label to the local-time
+display in **both**:
+
+- `JobDetail.jsx` — the Created / Started / Completed rows (`formatDate`).
+- `JobList.jsx` — the created-at table column.
+
+Implementation: include a timezone token in the formatted output (e.g. via
+`toLocaleString` with `timeZoneName: 'short'`), producing output like
+`Jun 2, 2026, 3:04 PM EDT`. Continue to correctly handle the R array timestamp format
+(`[epoch_seconds]`) already supported by `formatDate`.
+
+### H. Example script link (issue item #9)
+
+Add an external link below "Upload VA Data" pointing to the vacalibration paper's example
+code for preparing/running/saving input data. No file is committed to this repo.
+
+- Default link target: the arXiv paper page <https://arxiv.org/abs/2603.21216>.
+- Final URL to be confirmed during spec review (a direct link to the example `.R` /
+  repository is preferable if available).
+
+## Testing
+
+Write tests before/with implementation:
+
+- **Mapping**: `(inputType, outputType) → job_type` for all three valid combinations plus
+  the locked `Output from CCVA` case. This is the core new logic.
+- **Timestamp formatter**: produces a timezone-labeled local-time string; still handles the
+  R `[epoch_seconds]` array format.
+- **Required markers**: required field titles render the `*` marker when visible.
+- **Regression**: existing `JobForm`, `JobDetail`, `JobList` unit tests stay green
+  (update any assertions tied to renamed labels or removed timing strings).
+
+Run via `cd frontend && npm test`.
+
+## Out of scope
+
+- No backend / `plumber.R` changes.
+- No change to job execution, algorithms, or result rendering.
+- Committing the example `.R` script into this repo (issue #9 resolved as an external link).
+
+## Open questions (confirm during spec review)
+
+1. **Default selection** on form load: keep the current default of `vacalibration`
+   (which would mean defaulting Input Type to `Output from CCVA`), or default to
+   `Individual VA Records` + `Individual Top Cause of Death` (`openva`)? Proposed:
+   keep the current `vacalibration` default to avoid changing existing behavior.
+2. **Example-script URL** (item H): is the arXiv paper page acceptable, or is there a
+   direct link to the example `.R` file / its repository?

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1142,7 +1142,7 @@ footer {
 
 .required-legend {
   margin: 0 0 1rem;
-  font-size: 0.8rem;
+  font-size: 0.825rem;
   color: var(--color-secondary);
 }
 
@@ -1151,8 +1151,11 @@ footer {
   padding: 0.625rem 0.75rem;
   border: 1px solid var(--color-border);
   border-radius: var(--radius-sm);
-  background: var(--color-surface, #f1f3f5);
+  background: var(--color-surface-hover, #f1f3f5);
   color: var(--color-secondary);
+  font-size: 0.875rem;
+  font-family: var(--font-sans);
+  cursor: default;
 }
 
 .ensemble-indicator {

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1140,6 +1140,21 @@ footer {
   font-weight: normal;
 }
 
+.required-legend {
+  margin: 0 0 1rem;
+  font-size: 0.8rem;
+  color: var(--color-secondary);
+}
+
+.output-type-locked {
+  width: 100%;
+  padding: 0.625rem 0.75rem;
+  border: 1px solid var(--color-border);
+  border-radius: var(--radius-sm);
+  background: var(--color-surface, #f1f3f5);
+  color: var(--color-secondary);
+}
+
 .ensemble-indicator {
   color: var(--color-info);
   font-weight: 500;
@@ -1345,11 +1360,11 @@ footer {
 .advanced-toggle {
   background: none;
   border: none;
-  color: var(--color-secondary);
+  color: var(--color-primary);
   cursor: pointer;
-  font-size: 0.9rem;
+  font-size: 0.875rem;
+  font-weight: 500;
   padding: 4px 0;
-  font-family: var(--font-mono, monospace);
 }
 
 .advanced-toggle:hover {

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -6,6 +6,7 @@ import { buildCsmfFacets, buildCsmfTableRows, csmfWhisker } from './CSMFChart.js
 import { formatCauseDisplay, sortCausesByValue } from '../utils/causeDisplay.js';
 import { formatAlgorithmList, formatAgeGroup } from '../utils/labels.js';
 import ProgressIndicator from './ProgressIndicator';
+import { formatTimestamp } from '../utils/datetime';
 
 // Cache bust: v0.0.3 - Force rebuild with package.json change
 export default function JobDetail({ jobId, onBack }) {
@@ -138,14 +139,6 @@ export default function JobDetail({ jobId, onBack }) {
   );
 }
 
-function formatDate(value) {
-  if (!value) return '-';
-  if (typeof value === 'string') return value;
-  if (Array.isArray(value)) return new Date(value[0] * 1000).toLocaleString();
-  if (typeof value === 'object') return JSON.stringify(value);
-  return String(value);
-}
-
 function StatusTab({ status, log }) {
   const isRunning = status.status === 'running' || status.status === 'pending';
 
@@ -158,9 +151,9 @@ function StatusTab({ status, log }) {
         <tbody>
           <tr><td>Status</td><td>{status.status}</td></tr>
           <tr><td>Type</td><td>{status.type}</td></tr>
-          <tr><td>Created</td><td>{formatDate(status.created_at)}</td></tr>
-          <tr><td>Started</td><td>{formatDate(status.started_at)}</td></tr>
-          <tr><td>Completed</td><td>{formatDate(status.completed_at)}</td></tr>
+          <tr><td>Created</td><td>{formatTimestamp(status.created_at)}</td></tr>
+          <tr><td>Started</td><td>{formatTimestamp(status.started_at)}</td></tr>
+          <tr><td>Completed</td><td>{formatTimestamp(status.completed_at)}</td></tr>
         </tbody>
       </table>
     </div>

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -31,16 +31,17 @@ describe('Uncertainty checkbox behavior (issue #68)', () => {
 })
 
 describe('Form field order (issue #68)', () => {
-  it('renders fields in the order: Job Type, Country, Age Group, CCVA Algorithm, Propagate uncertainty, Upload, MCMC', () => {
+  it('renders fields in order: Input Type, Output Type, Country, Age Group, CCVA Algorithm, Uncertainty, Upload, MCMC', () => {
     const { container } = render(<JobForm onJobSubmitted={() => {}} />)
     const text = container.textContent
     const sequence = [
-      'Job Type',
+      'Input Type',
+      'Output Type',
       'Country',
       'Age Group',
       'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
-      'Propagate uncertainty in CCVA misclassification',
-      'VA Data Files',
+      'Uncertainty in CCVA misclassification',
+      'Upload VA Data',
       'MCMC Specifics',
     ]
     const positions = sequence.map((s) => text.indexOf(s))

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -40,8 +40,8 @@ describe('Form field order (issue #68)', () => {
       'Country',
       'Age Group',
       'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
-      'Uncertainty in CCVA misclassification',
-      'Upload VA Data',
+      'Propagate uncertainty in CCVA misclassification',
+      'VA Data Files',
       'MCMC Specifics',
     ]
     const positions = sequence.map((s) => text.indexOf(s))

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -13,7 +13,7 @@ vi.mock('../api/client', () => ({
 }))
 
 const uncertaintyCheckbox = () =>
-  screen.getByLabelText(/Propagate uncertainty in CCVA misclassification/i)
+  screen.getByLabelText(/Propagate/i)
 
 describe('Uncertainty checkbox behavior (issue #68)', () => {
   it('renders a checkbox that is checked by default (propagate = on)', () => {
@@ -40,8 +40,8 @@ describe('Form field order (issue #68)', () => {
       'Country',
       'Age Group',
       'Computer-Coded Verbal Autopsy (CCVA) Algorithm',
-      'Propagate uncertainty in CCVA misclassification',
-      'VA Data Files',
+      'Uncertainty in CCVA misclassification',
+      'Upload VA Data',
       'MCMC Specifics',
     ]
     const positions = sequence.map((s) => text.indexOf(s))

--- a/frontend/src/components/JobForm.issue68.test.js
+++ b/frontend/src/components/JobForm.issue68.test.js
@@ -50,7 +50,8 @@ describe('Uncertainty checkbox (issue #68)', () => {
     expect(src).not.toContain("'No (Fixed misclassification matrix)'")
   })
   it('uses the new label and hint with the CCVA matrices link', () => {
-    expect(src).toContain('Propagate uncertainty in CCVA misclassification')
+    // #73 item #8: heading "Uncertainty in CCVA misclassification" + "Propagate" checkbox.
+    expect(src).toContain('Uncertainty in CCVA misclassification')
     expect(src).toContain('Controls whether to propagate uncertainty in')
     expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
     expect(src).not.toContain('Controls how uncertainty in misclassification estimates is handled')

--- a/frontend/src/components/JobForm.issue68.test.js
+++ b/frontend/src/components/JobForm.issue68.test.js
@@ -14,9 +14,9 @@ describe('Age group label (issue #68)', () => {
 })
 
 describe('Country dropdown (issue #68)', () => {
-  it('lists the supported countries alphabetically with an "Other" option', () => {
-    expect(src).toContain("{ value: 'other', label: 'Other' }")
-    expect(src).not.toContain('All the countries')
+  it('lists the supported countries alphabetically with an "All the countries" option', () => {
+    expect(src).toContain("{ value: 'other', label: 'All the countries' }")
+    expect(src).not.toContain("label: 'Other'")
     const order = ['Bangladesh', 'Ethiopia', 'Kenya', 'Mali', 'Mozambique', 'Sierra Leone', 'South Africa']
       .map((c) => src.indexOf(`value: '${c}', label: '${c}'`))
     order.forEach((p) => expect(p).toBeGreaterThan(-1))

--- a/frontend/src/components/JobForm.issue73.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue73.behavior.test.jsx
@@ -1,0 +1,28 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi } from 'vitest'
+import { render, screen, fireEvent } from '@testing-library/react'
+import JobForm from './JobForm'
+
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+describe('Input Type / Output Type cascade (issue #73)', () => {
+  it('defaults to Output from CCVA with a locked Cause Distribution output', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    expect(screen.getByText('Output from CCVA')).toBeTruthy()
+    expect(screen.getByText('Cause Distribution')).toBeTruthy()
+  })
+
+  it('switching Input Type to Individual VA Records reveals the two outputs', () => {
+    render(<JobForm onJobSubmitted={() => {}} />)
+    fireEvent.click(screen.getByText('Output from CCVA'))     // open Input Type
+    fireEvent.click(screen.getByText('Individual VA Records')) // select it
+    expect(screen.getByText('Individual Top Cause of Death')).toBeTruthy()
+  })
+})

--- a/frontend/src/components/JobForm.issue73.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue73.behavior.test.jsx
@@ -23,6 +23,10 @@ describe('Input Type / Output Type cascade (issue #73)', () => {
     render(<JobForm onJobSubmitted={() => {}} />)
     fireEvent.click(screen.getByText('Output from CCVA'))     // open Input Type
     fireEvent.click(screen.getByText('Individual VA Records')) // select it
+    // Output Type select now shows the first option in its trigger...
     expect(screen.getByText('Individual Top Cause of Death')).toBeTruthy()
+    // ...and opening it reveals BOTH outputs (not just one).
+    fireEvent.click(screen.getByText('Individual Top Cause of Death'))
+    expect(screen.getByText('Cause Distribution')).toBeTruthy()
   })
 })

--- a/frontend/src/components/JobForm.issue73.test.js
+++ b/frontend/src/components/JobForm.issue73.test.js
@@ -1,0 +1,65 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const src = readFileSync(resolve(__dir, 'JobForm.jsx'), 'utf-8')
+
+describe('Panel heading & required legend (issue #73 items #1, #4)', () => {
+  it('heading is "Submit Job", not "Submit New Job"', () => {
+    expect(src).toContain('<h2>Submit Job</h2>')
+    expect(src).not.toContain('Submit New Job')
+  })
+  it('shows a "Required fields" legend', () => {
+    expect(src).toContain('required-legend')
+    expect(src).toContain('Required fields')
+  })
+})
+
+describe('Upload label & example script link (issue #73 items #6, #9)', () => {
+  it('renames the upload label to "Upload VA Data"', () => {
+    expect(src).toContain('Upload VA Data')
+    expect(src).not.toContain('VA Data Files (one CSV per selected algorithm)')
+  })
+  it('links to the vacalibration example repository', () => {
+    expect(src).toContain('https://github.com/sandy-pramanik/vacalibration')
+  })
+})
+
+describe('Timings removed & algorithm order (issue #73 item #2)', () => {
+  it('removes all per-algorithm timing hints', () => {
+    expect(src).not.toContain('~30sec')
+    expect(src).not.toContain('~2-3min')
+    expect(src).not.toContain('~1min')
+  })
+  it('removes ensemble runtime estimates', () => {
+    expect(src).not.toContain('Estimated runtime')
+    expect(src).not.toContain('will take approximately')
+  })
+  it('orders algorithm options EAVA, InSilicoVA, InterVA in the calibration block', () => {
+    const block = src.slice(src.indexOf("jobType === 'vacalibration'"))
+    const eava = block.indexOf("checked={algorithms.includes('EAVA')}")
+    const insilico = block.indexOf("checked={algorithms.includes('InSilicoVA')}")
+    const interva = block.indexOf("checked={algorithms.includes('InterVA')}")
+    expect(eava).toBeGreaterThan(-1)
+    expect(eava).toBeLessThan(insilico)
+    expect(insilico).toBeLessThan(interva)
+  })
+  it('orders the sample CSV links EAVA, InSilicoVA, InterVA', () => {
+    const eava = src.indexOf('sample_eava_neonate.csv')
+    const insilico = src.indexOf('sample_insilicova_neonate.csv')
+    const interva = src.indexOf('sample_interva_neonate.csv')
+    expect(eava).toBeLessThan(insilico)
+    expect(insilico).toBeLessThan(interva)
+  })
+})
+
+describe('Uncertainty block restructure (issue #73 item #8)', () => {
+  it('uses a heading + a "Propagate" checkbox, not the combined #68 label', () => {
+    expect(src).toContain('Uncertainty in CCVA misclassification')
+    expect(src).not.toContain('Propagate uncertainty in CCVA misclassification')
+    expect(src).toContain("checked={calibModelType === 'Mmatprior'}")
+    expect(src).toContain('https://github.com/sandy-pramanik/CCVA-Misclassification-Matrices')
+  })
+})

--- a/frontend/src/components/JobForm.issue73.test.js
+++ b/frontend/src/components/JobForm.issue73.test.js
@@ -15,6 +15,11 @@ describe('Panel heading & required legend (issue #73 items #1, #4)', () => {
     expect(src).toContain('required-legend')
     expect(src).toContain('Required fields')
   })
+  it('marks required field titles with an asterisk span', () => {
+    expect(src).toContain('Country <span className="required">*</span>')
+    expect(src).toContain('Age Group <span className="required">*</span>')
+    expect(src).toContain('Upload VA Data <span className="required">*</span>')
+  })
 })
 
 describe('Upload label & example script link (issue #73 items #6, #9)', () => {
@@ -50,6 +55,14 @@ describe('Timings removed & algorithm order (issue #73 item #2)', () => {
     const eava = src.indexOf('sample_eava_neonate.csv')
     const insilico = src.indexOf('sample_insilicova_neonate.csv')
     const interva = src.indexOf('sample_interva_neonate.csv')
+    expect(eava).toBeLessThan(insilico)
+    expect(insilico).toBeLessThan(interva)
+  })
+  it('orders algorithm options EAVA, InSilicoVA, InterVA in the CustomSelect option lists', () => {
+    const eava = src.indexOf("{ value: 'EAVA', label: 'EAVA' }")
+    const insilico = src.indexOf("{ value: 'InSilicoVA', label: 'InSilicoVA' }")
+    const interva = src.indexOf("{ value: 'InterVA', label: 'InterVA' }")
+    expect(eava).toBeGreaterThan(-1)
     expect(eava).toBeLessThan(insilico)
     expect(insilico).toBeLessThan(interva)
   })

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -257,7 +257,7 @@ export default function JobForm({ onJobSubmitted }) {
                 { value: 'Mozambique', label: 'Mozambique' },
                 { value: 'Sierra Leone', label: 'Sierra Leone' },
                 { value: 'South Africa', label: 'South Africa' },
-                { value: 'other', label: 'Other' }
+                { value: 'other', label: 'All the countries' }
               ]}
             />
           </div>

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -238,7 +238,7 @@ export default function JobForm({ onJobSubmitted }) {
               options={outputTypeOptions('individual')}
             />
           ) : (
-            <div className="output-type-locked">Cause Distribution</div>
+            <div className="output-type-locked">{outputTypeOptions(inputType)[0].label}</div>
           )}
         </div>
 

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -2,11 +2,15 @@ import { useState, useEffect } from 'react';
 import { submitJob, submitDemoJob, getJobStatus, getJobLog } from '../api/client';
 import ProgressIndicator from './ProgressIndicator';
 import CustomSelect from './CustomSelect';
+import { INPUT_TYPES, outputTypeOptions, deriveJobType, jobTypeToSelectors } from '../utils/jobTypeMapping';
 
 let nextUploadId = 1;
 
 export default function JobForm({ onJobSubmitted }) {
-  const [jobType, setJobType] = useState('vacalibration');
+  const initialSelectors = jobTypeToSelectors('vacalibration');
+  const [inputType, setInputType] = useState(initialSelectors.inputType);
+  const [outputType, setOutputType] = useState(initialSelectors.outputType);
+  const jobType = deriveJobType(inputType, outputType);
   const [algorithms, setAlgorithms] = useState(['InterVA']);  // Array instead of single value
   const [ageGroup, setAgeGroup] = useState('neonate');
   const [country, setCountry] = useState('Mozambique');
@@ -52,6 +56,11 @@ export default function JobForm({ onJobSubmitted }) {
 
     return () => clearInterval(interval);
   }, [activeJob]);
+
+  // When Input Type changes, snap Output Type to the first valid option for it.
+  useEffect(() => {
+    setOutputType(outputTypeOptions(inputType)[0].value);
+  }, [inputType]);
 
   // Sync algorithms state when switching between single/multi mode.
   useEffect(() => {
@@ -210,16 +219,25 @@ export default function JobForm({ onJobSubmitted }) {
 
       <form onSubmit={handleSubmit}>
         <div className="form-group">
-          <label>Job Type</label>
+          <label>Input Type <span className="required">*</span></label>
           <CustomSelect
-            value={jobType}
-            onChange={setJobType}
-            options={[
-              { value: 'pipeline', label: 'Full Pipeline (openVA + Calibration)' },
-              { value: 'openva', label: 'openVA Only' },
-              { value: 'vacalibration', label: 'Calibration Only' }
-            ]}
+            value={inputType}
+            onChange={setInputType}
+            options={INPUT_TYPES}
           />
+        </div>
+
+        <div className="form-group">
+          <label>Output Type <span className="required">*</span></label>
+          {inputType === 'individual' ? (
+            <CustomSelect
+              value={outputType}
+              onChange={setOutputType}
+              options={outputTypeOptions('individual')}
+            />
+          ) : (
+            <div className="output-type-locked">Cause Distribution</div>
+          )}
         </div>
 
         {/* Country: needed for vacalibration and pipeline, not for openva */}

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -216,7 +216,8 @@ export default function JobForm({ onJobSubmitted }) {
 
   return (
     <div className="job-form">
-      <h2>Submit New Job</h2>
+      <h2>Submit Job</h2>
+      <p className="required-legend"><span className="required">*</span> Required fields</p>
 
       <form onSubmit={handleSubmit}>
         <div className="form-group">
@@ -244,7 +245,7 @@ export default function JobForm({ onJobSubmitted }) {
         {/* Country: needed for vacalibration and pipeline, not for openva */}
         {jobType !== 'openva' && (
           <div className="form-group">
-            <label>Country</label>
+            <label>Country <span className="required">*</span></label>
             <CustomSelect
               value={country}
               onChange={setCountry}
@@ -263,7 +264,7 @@ export default function JobForm({ onJobSubmitted }) {
         )}
 
         <div className="form-group">
-          <label>Age Group</label>
+          <label>Age Group <span className="required">*</span></label>
           <CustomSelect
             value={ageGroup}
             onChange={setAgeGroup}
@@ -277,14 +278,14 @@ export default function JobForm({ onJobSubmitted }) {
         {/* Algorithm Selection - split by job type */}
         {jobType === 'openva' && (
           <div className="form-group">
-            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithm</label>
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithm <span className="required">*</span></label>
             <CustomSelect
               value={algorithms[0] || 'InterVA'}
               onChange={handleAlgorithmSelect}
               options={[
-                { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
-                { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
-                { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+                { value: 'EAVA', label: 'EAVA' },
+                { value: 'InSilicoVA', label: 'InSilicoVA' },
+                { value: 'InterVA', label: 'InterVA' }
               ]}
             />
             {validationError && <small className="validation-error">{validationError}</small>}
@@ -294,9 +295,9 @@ export default function JobForm({ onJobSubmitted }) {
         {jobType === 'pipeline' && (
           <div className="form-group">
             <label>
-              Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''}
+              Computer-Coded Verbal Autopsy (CCVA) Algorithm{ensemble ? 's' : ''} <span className="required">*</span>
               {ensemble && (
-                <span className="required"> * Select at least 2 for ensemble</span>
+                <span className="required"> Select at least 2 for ensemble</span>
               )}
             </label>
 
@@ -316,10 +317,10 @@ export default function JobForm({ onJobSubmitted }) {
                 <label className="checkbox-label">
                   <input
                     type="checkbox"
-                    checked={algorithms.includes('InterVA')}
-                    onChange={() => handleAlgorithmToggle('InterVA')}
+                    checked={algorithms.includes('EAVA')}
+                    onChange={() => handleAlgorithmToggle('EAVA')}
                   />
-                  InterVA (fastest, ~30sec)
+                  EAVA
                 </label>
                 <label className="checkbox-label">
                   <input
@@ -327,31 +328,25 @@ export default function JobForm({ onJobSubmitted }) {
                     checked={algorithms.includes('InSilicoVA')}
                     onChange={() => handleAlgorithmToggle('InSilicoVA')}
                   />
-                  InSilicoVA (most accurate, ~2-3min)
+                  InSilicoVA
                 </label>
                 <label className="checkbox-label">
                   <input
                     type="checkbox"
-                    checked={algorithms.includes('EAVA')}
-                    onChange={() => handleAlgorithmToggle('EAVA')}
+                    checked={algorithms.includes('InterVA')}
+                    onChange={() => handleAlgorithmToggle('InterVA')}
                   />
-                  EAVA (deterministic, ~1min)
+                  InterVA
                 </label>
-                {algorithms.length > 1 && (
-                  <small className="form-hint warning">
-                    Running {algorithms.length} algorithms will take approximately{' '}
-                    {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}
-                  </small>
-                )}
               </div>
             ) : (
               <CustomSelect
                 value={algorithms[0] || 'InterVA'}
                 onChange={handleAlgorithmSelect}
                 options={[
-                  { value: 'InterVA', label: 'InterVA (fastest, ~30sec)' },
-                  { value: 'InSilicoVA', label: 'InSilicoVA (most accurate, ~2-3min)' },
-                  { value: 'EAVA', label: 'EAVA (deterministic, ~1min)' }
+                  { value: 'EAVA', label: 'EAVA' },
+                  { value: 'InSilicoVA', label: 'InSilicoVA' },
+                  { value: 'InterVA', label: 'InterVA' }
                 ]}
               />
             )}
@@ -362,16 +357,16 @@ export default function JobForm({ onJobSubmitted }) {
 
         {jobType === 'vacalibration' && (
           <div className="form-group">
-            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithms *</label>
+            <label>Computer-Coded Verbal Autopsy (CCVA) Algorithms <span className="required">*</span></label>
 
             <div className="algorithm-checkboxes">
               <label className="checkbox-label">
                 <input
                   type="checkbox"
-                  checked={algorithms.includes('InterVA')}
-                  onChange={() => handleAlgorithmToggle('InterVA')}
+                  checked={algorithms.includes('EAVA')}
+                  onChange={() => handleAlgorithmToggle('EAVA')}
                 />
-                InterVA (fastest, ~30sec)
+                EAVA
               </label>
               <label className="checkbox-label">
                 <input
@@ -379,15 +374,15 @@ export default function JobForm({ onJobSubmitted }) {
                   checked={algorithms.includes('InSilicoVA')}
                   onChange={() => handleAlgorithmToggle('InSilicoVA')}
                 />
-                InSilicoVA (most accurate, ~2-3min)
+                InSilicoVA
               </label>
               <label className="checkbox-label">
                 <input
                   type="checkbox"
-                  checked={algorithms.includes('EAVA')}
-                  onChange={() => handleAlgorithmToggle('EAVA')}
+                  checked={algorithms.includes('InterVA')}
+                  onChange={() => handleAlgorithmToggle('InterVA')}
                 />
-                EAVA (deterministic, ~1min)
+                InterVA
               </label>
             </div>
 
@@ -410,7 +405,6 @@ export default function JobForm({ onJobSubmitted }) {
               ) : (
                 <small className="form-hint">
                   Runs per-algorithm calibration plus an additional combined ensemble result.
-                  {' '}Estimated runtime: {algorithms.length === 2 ? '2-4 minutes' : '4-6 minutes'}.
                 </small>
               )}
             </div>
@@ -422,13 +416,14 @@ export default function JobForm({ onJobSubmitted }) {
         {/* Vacalibration-specific parameters */}
         {(jobType === 'vacalibration' || jobType === 'pipeline') && (
           <div className="form-group">
+            <label>Uncertainty in CCVA misclassification</label>
             <label className="checkbox-label">
               <input
                 type="checkbox"
                 checked={calibModelType === 'Mmatprior'}
                 onChange={(e) => setCalibModelType(e.target.checked ? 'Mmatprior' : 'Mmatfixed')}
               />
-              {' '}Propagate uncertainty in CCVA misclassification
+              {' '}Propagate
             </label>
             <small className="form-hint">
               Controls whether to propagate uncertainty in{' '}
@@ -445,7 +440,7 @@ export default function JobForm({ onJobSubmitted }) {
 
         {jobType === 'vacalibration' ? (
           <div className="form-group">
-            <label>VA Data Files (one CSV per selected algorithm)</label>
+            <label>Upload VA Data <span className="required">*</span></label>
             {uploads.map((upload, index) => (
               <div key={upload.id} className="upload-row">
                 <span className="upload-algo-label">{upload.algorithm}</span>
@@ -460,18 +455,29 @@ export default function JobForm({ onJobSubmitted }) {
             <small className="form-hint">
               Upload one CSV file per selected algorithm. Required columns: ID, cause.
             </small>
+            <small className="form-hint">
+              See the{' '}
+              <a
+                href="https://github.com/sandy-pramanik/vacalibration"
+                target="_blank"
+                rel="noopener noreferrer"
+              >
+                vacalibration example code
+              </a>
+              {' '}for how to prepare, run, and save input data.
+            </small>
             <div className="sample-download">
               <div className="sample-links">
                 <span>Sample CSV (neonate, 1190 records):</span>
-                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
-                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
                 <a href={`${import.meta.env.BASE_URL}sample_eava_neonate.csv`} download>EAVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_insilicova_neonate.csv`} download>InSilicoVA</a>
+                <a href={`${import.meta.env.BASE_URL}sample_interva_neonate.csv`} download>InterVA</a>
               </div>
             </div>
           </div>
         ) : (
           <div className="form-group">
-            <label>VA Data File (CSV)</label>
+            <label>VA Data File (CSV) <span className="required">*</span></label>
             <input
               type="file"
               accept=".csv"

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -6,10 +6,11 @@ import { INPUT_TYPES, outputTypeOptions, deriveJobType, jobTypeToSelectors } fro
 
 let nextUploadId = 1;
 
+const INITIAL_SELECTORS = jobTypeToSelectors('vacalibration');
+
 export default function JobForm({ onJobSubmitted }) {
-  const initialSelectors = jobTypeToSelectors('vacalibration');
-  const [inputType, setInputType] = useState(initialSelectors.inputType);
-  const [outputType, setOutputType] = useState(initialSelectors.outputType);
+  const [inputType, setInputType] = useState(INITIAL_SELECTORS.inputType);
+  const [outputType, setOutputType] = useState(INITIAL_SELECTORS.outputType);
   const jobType = deriveJobType(inputType, outputType);
   const [algorithms, setAlgorithms] = useState(['InterVA']);  // Array instead of single value
   const [ageGroup, setAgeGroup] = useState('neonate');

--- a/frontend/src/components/JobForm.test.js
+++ b/frontend/src/components/JobForm.test.js
@@ -25,7 +25,8 @@ describe('JobForm button labels (issue #26)', () => {
 
 describe('Uncertainty propagation control (issue #68 supersedes #25)', () => {
   it('label is the new CCVA wording, not the old matrix wording', () => {
-    expect(jobFormSrc).toContain('Propagate uncertainty in CCVA misclassification')
+    // Issue #73 item #8 splits the #68 label into a heading + "Propagate" checkbox.
+    expect(jobFormSrc).toContain('Uncertainty in CCVA misclassification')
     expect(jobFormSrc).not.toContain('Propagate uncertainty in misclassification matrix')
     expect(jobFormSrc).not.toContain('Uncertainty Propagation')
   })

--- a/frontend/src/components/JobList.jsx
+++ b/frontend/src/components/JobList.jsx
@@ -1,6 +1,7 @@
 import { useState, useEffect, useCallback } from 'react';
 import { listJobs, getJobLog } from '../api/client';
 import ProgressIndicator from './ProgressIndicator';
+import { formatTimestamp } from '../utils/datetime';
 
 const JOBS_PER_PAGE = 10;
 
@@ -125,7 +126,7 @@ export default function JobList({ onSelectJob, refreshTrigger }) {
               <td className="job-id" title={job.job_id}>{job.job_id.slice(0, 8)}...</td>
               <td>{job.type}</td>
               <td>{getStatusBadge(job)}</td>
-              <td>{new Date(job.created_at).toLocaleString()}</td>
+              <td>{formatTimestamp(job.created_at)}</td>
             </tr>
           ))}
         </tbody>

--- a/frontend/src/components/Timestamps.issue73.test.js
+++ b/frontend/src/components/Timestamps.issue73.test.js
@@ -1,0 +1,22 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const detailSrc = readFileSync(resolve(__dir, 'JobDetail.jsx'), 'utf-8')
+const listSrc = readFileSync(resolve(__dir, 'JobList.jsx'), 'utf-8')
+
+describe('Timestamps use the shared timezone-labeled formatter (issue #73)', () => {
+  it('JobDetail imports and uses formatTimestamp for the time rows', () => {
+    expect(detailSrc).toContain("from '../utils/datetime'")
+    expect(detailSrc).toContain('formatTimestamp(status.created_at)')
+    expect(detailSrc).toContain('formatTimestamp(status.started_at)')
+    expect(detailSrc).toContain('formatTimestamp(status.completed_at)')
+  })
+  it('JobList imports and uses formatTimestamp for the created column', () => {
+    expect(listSrc).toContain("from '../utils/datetime'")
+    expect(listSrc).toContain('formatTimestamp(job.created_at)')
+    expect(listSrc).not.toContain('new Date(job.created_at).toLocaleString()')
+  })
+})

--- a/frontend/src/pages/LandingPage.jsx
+++ b/frontend/src/pages/LandingPage.jsx
@@ -8,8 +8,7 @@ export default function LandingPage() {
         <div className="landing-hero-glow landing-hero-glow--top" />
         <div className="landing-hero-glow landing-hero-glow--bottom" />
         <div className="landing-hero-content">
-          <h1 className="landing-hero-title">COMSA</h1>
-          <p className="landing-hero-subtitle">Verbal Autopsy Calibration Platform</p>
+          <h1 className="landing-hero-title">Verbal Autopsy Calibration Platform</h1>
           <p className="landing-hero-desc">
             Bayesian calibration of cause-of-death classifications using the openVA and vacalibration R packages
           </p>

--- a/frontend/src/utils/datetime.js
+++ b/frontend/src/utils/datetime.js
@@ -1,0 +1,14 @@
+import { parseTimestamp } from './progress.js';
+
+/**
+ * Format a job timestamp in the viewer's local time WITH an explicit timezone
+ * label, so it is unambiguous which zone is shown (issue #73, item #5).
+ * Accepts ISO strings, tz-less R UTC strings, and the R [epoch_seconds] array
+ * format (parsing is delegated to parseTimestamp).
+ */
+export function formatTimestamp(value) {
+  if (value === null || value === undefined || value === '') return '-';
+  const d = parseTimestamp(value);
+  if (Number.isNaN(d.getTime())) return '-';
+  return d.toLocaleString(undefined, { timeZoneName: 'short' });
+}

--- a/frontend/src/utils/datetime.test.js
+++ b/frontend/src/utils/datetime.test.js
@@ -1,0 +1,33 @@
+import { describe, it, expect } from 'vitest'
+import { formatTimestamp } from './datetime.js'
+
+describe('formatTimestamp (issue #73)', () => {
+  it('returns a dash for empty values', () => {
+    expect(formatTimestamp(null)).toBe('-')
+    expect(formatTimestamp(undefined)).toBe('-')
+    expect(formatTimestamp('')).toBe('-')
+  })
+
+  it('includes a timezone label in the formatted output', () => {
+    const out = formatTimestamp('2026-06-02T15:04:00Z')
+    expect(out).not.toBe('-')
+    expect(out).not.toBe('2026-06-02T15:04:00Z')
+    expect(out.length).toBeGreaterThan(0)
+  })
+
+  it('handles the R array epoch-seconds format', () => {
+    const epoch = new Date('2026-06-02T15:04:00Z').getTime() / 1000
+    const out = formatTimestamp([epoch])
+    expect(out).not.toBe('-')
+  })
+
+  it('parses a tz-less R string as UTC (delegates to parseTimestamp)', () => {
+    const a = formatTimestamp('2026-06-02 15:04:00')
+    const b = formatTimestamp('2026-06-02T15:04:00Z')
+    expect(a).toBe(b)
+  })
+
+  it('returns a dash for unparseable input', () => {
+    expect(formatTimestamp('not-a-date')).toBe('-')
+  })
+})

--- a/frontend/src/utils/datetime.test.js
+++ b/frontend/src/utils/datetime.test.js
@@ -13,6 +13,8 @@ describe('formatTimestamp (issue #73)', () => {
     expect(out).not.toBe('-')
     expect(out).not.toBe('2026-06-02T15:04:00Z')
     expect(out.length).toBeGreaterThan(0)
+    // Prove a timezone token (e.g. "UTC", "EDT", "GMT+8") is actually present.
+    expect(out).toMatch(/[A-Za-z]{2,5}$|GMT[+-]\d|[+-]\d{2}:?\d{2}$/)
   })
 
   it('handles the R array epoch-seconds format', () => {

--- a/frontend/src/utils/jobTypeMapping.js
+++ b/frontend/src/utils/jobTypeMapping.js
@@ -1,0 +1,40 @@
+/**
+ * Maps the issue #73 "Input Type" / "Output Type" selectors onto the backend
+ * job_type string the API already understands ('openva' | 'pipeline' |
+ * 'vacalibration'). Pure functions — single source of truth for the cascade.
+ */
+
+export const INPUT_TYPES = [
+  { value: 'individual', label: 'Individual VA Records' },
+  { value: 'ccva_output', label: 'Output from CCVA' },
+];
+
+const TOP_CAUSE = { value: 'top_cause', label: 'Individual Top Cause of Death' };
+const DISTRIBUTION = { value: 'distribution', label: 'Cause Distribution' };
+
+/** Output Type options depend on the chosen Input Type. */
+export function outputTypeOptions(inputType) {
+  if (inputType === 'individual') return [TOP_CAUSE, DISTRIBUTION];
+  return [DISTRIBUTION]; // 'ccva_output' is locked to a single option
+}
+
+/** Derive the backend job_type from the two selectors. */
+export function deriveJobType(inputType, outputType) {
+  if (inputType === 'individual') {
+    return outputType === 'top_cause' ? 'openva' : 'pipeline';
+  }
+  return 'vacalibration';
+}
+
+/** Inverse mapping: which selectors produce a given job_type. */
+export function jobTypeToSelectors(jobType) {
+  switch (jobType) {
+    case 'openva':
+      return { inputType: 'individual', outputType: 'top_cause' };
+    case 'pipeline':
+      return { inputType: 'individual', outputType: 'distribution' };
+    case 'vacalibration':
+    default:
+      return { inputType: 'ccva_output', outputType: 'distribution' };
+  }
+}

--- a/frontend/src/utils/jobTypeMapping.test.js
+++ b/frontend/src/utils/jobTypeMapping.test.js
@@ -1,0 +1,44 @@
+import { describe, it, expect } from 'vitest'
+import {
+  INPUT_TYPES,
+  outputTypeOptions,
+  deriveJobType,
+  jobTypeToSelectors,
+} from './jobTypeMapping.js'
+
+describe('jobTypeMapping (issue #73)', () => {
+  it('offers two input types', () => {
+    expect(INPUT_TYPES.map((o) => o.value)).toEqual(['individual', 'ccva_output'])
+  })
+
+  it('Individual VA Records offers top-cause and distribution outputs', () => {
+    expect(outputTypeOptions('individual').map((o) => o.value)).toEqual([
+      'top_cause',
+      'distribution',
+    ])
+  })
+
+  it('Output from CCVA locks output to a single distribution option', () => {
+    expect(outputTypeOptions('ccva_output').map((o) => o.value)).toEqual(['distribution'])
+  })
+
+  it('derives job_type for every valid combination', () => {
+    expect(deriveJobType('individual', 'top_cause')).toBe('openva')
+    expect(deriveJobType('individual', 'distribution')).toBe('pipeline')
+    expect(deriveJobType('ccva_output', 'distribution')).toBe('vacalibration')
+  })
+
+  it('falls back to vacalibration for the locked input regardless of output', () => {
+    expect(deriveJobType('ccva_output', 'top_cause')).toBe('vacalibration')
+  })
+
+  it('inverts a job_type back into selector values', () => {
+    expect(jobTypeToSelectors('openva')).toEqual({ inputType: 'individual', outputType: 'top_cause' })
+    expect(jobTypeToSelectors('pipeline')).toEqual({ inputType: 'individual', outputType: 'distribution' })
+    expect(jobTypeToSelectors('vacalibration')).toEqual({ inputType: 'ccva_output', outputType: 'distribution' })
+  })
+
+  it('defaults unknown job_type to the vacalibration selectors', () => {
+    expect(jobTypeToSelectors('???')).toEqual({ inputType: 'ccva_output', outputType: 'distribution' })
+  })
+})

--- a/frontend/src/utils/progress.js
+++ b/frontend/src/utils/progress.js
@@ -190,7 +190,7 @@ export function parseProgress(logs) {
   return { ...NULL_RESULT };
 }
 
-function parseTimestamp(value) {
+export function parseTimestamp(value) {
   if (Array.isArray(value)) return new Date(value[0] * 1000);
   if (typeof value !== 'string') return new Date(value);
   // ISO strings carrying an explicit timezone (Z or ±hh:mm) parse correctly as-is.


### PR DESCRIPTION
## Summary

Implements all 10 items from issue #73 — a frontend-only refinement of the job submission form so required inputs are obvious and the job's input/output is stated plainly. **No backend changes.**

- **Input/Output Type cascade (#7):** the single "Job Type" dropdown becomes two cascading selects — **Input Type** (`Individual VA Records` | `Output from CCVA`) and **Output Type** (cascades; locked to `Cause Distribution` for CCVA output). These map onto the existing backend `job_type` (`openva`/`pipeline`/`vacalibration`) via a new pure util (`utils/jobTypeMapping.js`); `jobType` is now derived, so all existing job-type-keyed logic is unchanged. Default landing state stays `vacalibration`.
- **Required markers (#4):** red `*` on required field titles + a `* Required fields` legend under the heading.
- **Labels (#1, #6):** panel heading `Submit New Job` → `Submit Job` (submit button intentionally stays `Calibrate`); upload label → `Upload VA Data`.
- **Timings & order (#2):** removed all algorithm timing text; algorithms reordered to EAVA, InSilicoVA, InterVA everywhere (selectors, checkboxes, sample links).
- **MCMC heading (#3):** "MCMC Specifics" toggle restyled to match other input titles.
- **Uncertainty block (#8):** restructured into a `Uncertainty in CCVA misclassification` heading + a `Propagate` checkbox.
- **Timestamps (#5):** Job Detail and Job List now show local time **with an explicit timezone label**, via a shared `utils/datetime.js` formatter (reuses existing UTC-aware parsing).
- **Example script (#9):** link to https://github.com/sandy-pramanik/vacalibration below the upload area.

Spec: `docs/superpowers/specs/2026-06-02-input-panel-presentation-issue-73-design.md`
Plan: `docs/superpowers/plans/2026-06-02-input-panel-presentation-issue-73.md`

## Test Plan

- [x] Full frontend suite: **208 tests / 26 files pass** (`cd frontend && npm test`), including backend-dependent integration tests
- [x] New coverage: `jobTypeMapping.test.js` (cascade→job_type), `datetime.test.js` (tz-labeled formatting), `JobForm.issue73.*` (cascade behavior, labels, asterisks, order), `Timestamps.issue73.test.js`
- [x] Production build clean (`npm run build`)
- [x] Lint clean on all changed files (2 pre-existing errors in untouched `AuthContext.jsx`)
- [x] Backend untouched (empty diff vs master)
- [ ] Manual smoke: confirm cascade, locked Output Type, asterisks, reordered algorithms, restyled MCMC heading, and tz-labeled timestamps in the running app

Closes #73

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

## Release Notes

* **New Features**
  * Replaced single job type selector with cascading "Input Type" and "Output Type" dropdowns for more flexible job configuration.
  * Added timezone labels to all timestamps in job detail and list views.

* **UI/UX Improvements**
  * Updated form labels for clarity ("Upload VA Data," "Submit Job").
  * Added required-field asterisks and legend styling.
  * Reordered algorithm options (EAVA, InSilicoVA, InterVA) for consistency.
  * Removed unnecessary timing hints from algorithm selection.
  * Restyled MCMC toggle for better visibility.
  * Updated hero title on landing page.

* **Documentation**
  * Added comprehensive implementation and design specifications for UI improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->