### PR TITLE
fix(results): CSMF chart full-width above table + full export (#78)

### DIFF
--- a/frontend/e2e/demo-gallery.spec.js
+++ b/frontend/e2e/demo-gallery.spec.js
@@ -129,10 +129,8 @@ test('Demo Gallery: vacalibration demo with calibrated results', async ({ page }
     expect(pos).not.toBe('absolute');
   }
 
-  // Issue #39: Side-by-side panels must be top-aligned
-  const panels = page.locator('.results-side-by-side .results-panel');
-  expect(await panels.count()).toBe(2);
-  const topLeft = await panels.nth(0).evaluate(el => el.getBoundingClientRect().top);
-  const topRight = await panels.nth(1).evaluate(el => el.getBoundingClientRect().top);
-  expect(Math.abs(topLeft - topRight)).toBeLessThan(5);
+  // Issue #78: CSMF chart is full-width above the consolidated comparison table
+  const figureTop = await page.locator('.csmf-figure').evaluate(el => el.getBoundingClientRect().top);
+  const tableTop = await page.locator('.csmf-table.consolidated').evaluate(el => el.getBoundingClientRect().top);
+  expect(figureTop).toBeLessThan(tableTop);
 });

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1663,25 +1663,6 @@ footer {
   font-weight: 700;
 }
 
-/* Side-by-side layout: Matrix + CSMF Chart */
-.results-side-by-side {
-  display: flex;
-  align-items: flex-start;
-  gap: 2rem;
-  margin: 1.5rem 0;
-}
-
-.results-side-by-side .results-panel {
-  flex: 1;
-  min-width: 0;
-}
-
-.results-side-by-side .misclass-section {
-  margin-top: 0;
-  padding-top: 0;
-  border-top: none;
-}
-
 /* Responsive adjustments */
 @media (max-width: 768px) {
   .misclass-table {
@@ -1709,10 +1690,6 @@ footer {
 
   .matrix-description {
     font-size: 0.825rem;
-  }
-
-  .results-side-by-side {
-    flex-direction: column;
   }
 }
 

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -287,28 +287,22 @@ function CalibratedResults({ results, jobId }) {
         )}
       </div>
 
-      {/* Side-by-side: Misclassification Matrix + CSMF Chart */}
-      <div className="results-side-by-side">
-        {/* Left: Misclassification Matrix */}
-        <div className="results-panel">
-          {results.misclassification_matrix && (
-            <MisclassificationMatrix matrixData={results.misclassification_matrix} jobId={jobId} causeDisplayNames={displayNames} causeOrder={results.cause_order} />
-          )}
-        </div>
+      {/* Misclassification Matrix (full width) */}
+      {results.misclassification_matrix && (
+        <MisclassificationMatrix matrixData={results.misclassification_matrix} jobId={jobId} causeDisplayNames={displayNames} causeOrder={results.cause_order} />
+      )}
 
-        {/* Right: CSMF Chart */}
-        <div className="results-panel">
-          <div className="section-header">
-            <h3>Cause-Specific Mortality Fractions (CSMF) Chart</h3>
-            <div className="export-buttons">
-              <button onClick={() => exportToPNG(chartRef, generateFilename('csmf_chart', algorithmsDisplay, jobId, 'png'))} className="export-btn" title="Export as PNG">PNG ↓</button>
-              <button onClick={() => exportToPDF(chartRef, generateFilename('csmf_chart', algorithmsDisplay, jobId, 'pdf'))} className="export-btn" title="Export as PDF">PDF ↓</button>
-            </div>
-          </div>
-          <div ref={chartRef}>
-            <CSMFChart results={results} causeDisplayNames={displayNames} />
-          </div>
+      {/* CSMF Chart (full width, above the comparison table so all facets —
+          incl. Ensemble when running multiple CCVAs — stay viewable; issue #78) */}
+      <div className="section-header">
+        <h3>Cause-Specific Mortality Fractions (CSMF) Chart</h3>
+        <div className="export-buttons">
+          <button onClick={() => exportToPNG(chartRef, generateFilename('csmf_chart', algorithmsDisplay, jobId, 'png'))} className="export-btn" title="Export as PNG">PNG ↓</button>
+          <button onClick={() => exportToPDF(chartRef, generateFilename('csmf_chart', algorithmsDisplay, jobId, 'pdf'))} className="export-btn" title="Export as PDF">PDF ↓</button>
         </div>
+      </div>
+      <div ref={chartRef}>
+        <CSMFChart results={results} causeDisplayNames={displayNames} />
       </div>
 
       {/* Consolidated CSMF table: each algorithm x {Uncalibrated, Calibrated} */}

--- a/frontend/src/components/JobDetail.test.js
+++ b/frontend/src/components/JobDetail.test.js
@@ -49,6 +49,20 @@ describe('Consolidated CSMF table (issue #72)', () => {
   })
 })
 
+describe('CSMF chart full-width above table (issue #78)', () => {
+  it('no longer wraps the chart in the half-width side-by-side panel', () => {
+    expect(jobDetailSrc).not.toContain('results-side-by-side')
+  })
+
+  it('renders the CSMF chart above the consolidated comparison table', () => {
+    const chart = jobDetailSrc.indexOf('Cause-Specific Mortality Fractions (CSMF) Chart')
+    const table = jobDetailSrc.indexOf('CSMF Comparison')
+    expect(chart).toBeGreaterThan(-1)
+    expect(table).toBeGreaterThan(-1)
+    expect(chart).toBeLessThan(table)
+  })
+})
+
 describe('Redundant downloads removed (issue #72)', () => {
   it('removes the bulk "Download Files" section', () => {
     expect(jobDetailSrc).not.toContain('Download Files')

--- a/frontend/src/utils/export.js
+++ b/frontend/src/utils/export.js
@@ -101,6 +101,31 @@ export function exportMisclassMatrix(matrixData, algoName, jobId) {
 }
 
 /**
+ * Render an element to a canvas, capturing its FULL scrollable size rather than
+ * just the visible viewport. Horizontally-scrolling content (e.g. the CSMF
+ * facet row, which overflows when there are 3 CCVAs + Ensemble) is un-clipped
+ * in the cloned DOM so every facet is exported, not just the visible ones.
+ * (issue #78)
+ */
+async function captureElement(element) {
+  const html2canvas = (await import('html2canvas')).default;
+  return html2canvas(element, {
+    backgroundColor: '#ffffff',
+    scale: 2, // Higher resolution
+    logging: false,
+    width: element.scrollWidth,
+    height: element.scrollHeight,
+    windowWidth: element.scrollWidth,
+    onclone: (clonedDoc) => {
+      clonedDoc.querySelectorAll('.csmf-facets').forEach((node) => {
+        node.style.overflow = 'visible';
+        node.style.width = 'max-content';
+      });
+    },
+  });
+}
+
+/**
  * Export element to PNG image (async, requires html2canvas)
  */
 export async function exportToPNG(elementRef, filename) {
@@ -110,14 +135,7 @@ export async function exportToPNG(elementRef, filename) {
   }
 
   try {
-    // Dynamic import to avoid loading html2canvas until needed
-    const html2canvas = (await import('html2canvas')).default;
-
-    const canvas = await html2canvas(elementRef.current, {
-      backgroundColor: '#ffffff',
-      scale: 2, // Higher resolution
-      logging: false
-    });
+    const canvas = await captureElement(elementRef.current);
 
     canvas.toBlob((blob) => {
       if (blob) {
@@ -165,14 +183,9 @@ export async function exportToPDF(elementRef, filename) {
   }
 
   try {
-    const html2canvas = (await import('html2canvas')).default;
     const { jsPDF } = await import('jspdf');
 
-    const canvas = await html2canvas(elementRef.current, {
-      backgroundColor: '#ffffff',
-      scale: 2,
-      logging: false
-    });
+    const canvas = await captureElement(elementRef.current);
 
     const imgData = canvas.toDataURL('image/png');
     const imgWidth = canvas.width;

--- a/frontend/src/utils/export.test.js
+++ b/frontend/src/utils/export.test.js
@@ -1,5 +1,8 @@
 import { describe, it, expect, vi } from 'vitest'
-import { generateFilename, exportToPDF } from './export.js'
+import { generateFilename, exportToPDF, exportToPNG } from './export.js'
+
+const { html2canvasMock } = vi.hoisted(() => ({ html2canvasMock: vi.fn() }))
+vi.mock('html2canvas', () => ({ default: html2canvasMock }))
 
 describe('generateFilename', () => {
   it('generates standard filename', () => {
@@ -64,6 +67,35 @@ describe('generateFilename', () => {
     const result = generateFilename('chart', 'InterVA', 'abcd1234', 'png')
     expect(result).toBe('chart_InterVA_abcd1234_20240615.png')
     vi.useRealTimers()
+  })
+})
+
+describe('full-width capture (issue #78)', () => {
+  it('captures the full element scrollWidth, not just the visible width', async () => {
+    html2canvasMock.mockReset()
+    html2canvasMock.mockResolvedValue({ toBlob: (cb) => cb(null) })
+
+    const el = { scrollWidth: 1234, scrollHeight: 567 }
+    await exportToPNG({ current: el }, 'csmf_chart.png')
+
+    expect(html2canvasMock).toHaveBeenCalledTimes(1)
+    const opts = html2canvasMock.mock.calls[0][1]
+    expect(opts.width).toBe(1234)
+    expect(opts.height).toBe(567)
+    expect(opts.windowWidth).toBe(1234)
+  })
+
+  it('un-clips the overflowing CSMF facet row in the cloned DOM', async () => {
+    html2canvasMock.mockReset()
+    html2canvasMock.mockResolvedValue({ toBlob: (cb) => cb(null) })
+
+    await exportToPNG({ current: { scrollWidth: 800, scrollHeight: 400 } }, 'csmf_chart.png')
+    const { onclone } = html2canvasMock.mock.calls[0][1]
+
+    const facets = { style: {} }
+    onclone({ querySelectorAll: (sel) => (sel === '.csmf-facets' ? [facets] : []) })
+    expect(facets.style.overflow).toBe('visible')
+    expect(facets.style.width).toBe('max-content')
   })
 })
 


### PR DESCRIPTION
Closes #78.

Two problems when running all three CCVAs (3 algorithms + Ensemble):

## 1. Chart cut off → moved full-width above the table
The CSMF chart lived in a half-width `results-side-by-side` panel next to the misclassification matrix, so the rightmost facets (incl. Ensemble) were clipped. The chart is now a **full-width section above** the consolidated comparison table; the matrix stacks full-width above it. Removed the now-unused `.results-side-by-side` CSS.

## 2. Export only captured the visible part → full-width capture
`exportToPNG`/`exportToPDF` ran html2canvas at the element's visible size, so the horizontally-overflowing facet row (`.csmf-facets { overflow-x: auto }`) was clipped and Ensemble dropped from the image. Export now:
- captures the full `scrollWidth`/`scrollHeight` (`width`/`windowWidth` options), and
- un-clips `.csmf-facets` in the **cloned** DOM via `onclone` (overflow visible, width max-content) — live DOM untouched.

Extracted a shared `captureElement()` helper for PNG + PDF.

## Tests
- `JobDetail.test.js`: chart renders above the comparison table; `results-side-by-side` gone.
- `export.test.js`: behavioral tests mocking html2canvas — asserts full-`scrollWidth` capture and that `onclone` un-clips `.csmf-facets`.
- Updated the e2e issue-#39 side-by-side assertion to a chart-above-table check using the current `.csmf-figure` selector (the old block also used pre-existing stale `.csmf-chart` selectors; only the side-by-side assertion my change invalidated was updated).

**209/209 non-integration unit tests pass; `npm run build` clean.** The 3 `:8000` integration tests are environment-blocked (unrelated SSH tunnel) and fail identically on `master`.

> Note: the e2e suite needs the backend on :8000 and couldn't be run in this environment (port held by an unrelated SSH tunnel).

🤖 Generated with [Claude Code](https://claude.com/claude-code)