### PR TITLE
chore(test): add PR test CI + env-configurable backend port

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -1,0 +1,34 @@
+name: test
+
+on:
+  pull_request:
+  push:
+    branches: [master]
+
+jobs:
+  frontend:
+    runs-on: ubuntu-latest
+    defaults:
+      run:
+        working-directory: frontend
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: actions/setup-node@v4
+        with:
+          node-version: 20
+          cache: npm
+          cache-dependency-path: frontend/package-lock.json
+
+      - run: npm ci
+
+      # Fast gate: frontend unit tests + production build.
+      # The backend integration test (src/api/integration.test.js) and the
+      # Playwright E2E suite both need a running R plumber backend on :8000,
+      # which is out of scope for this CI job. They are run locally/manually
+      # against a live backend, not silently skipped here.
+      - name: Unit tests (excluding backend integration test)
+        run: npx vitest run --exclude '**/api/integration.test.js'
+
+      - name: Production build
+        run: npm run build

--- a/backend/run.R
+++ b/backend/run.R
@@ -7,4 +7,4 @@ source("init_validation.R")
 
 # Load and run the API
 pr <- plumber::plumb("plumber.R")
-pr$run(host = "0.0.0.0", port = 8000)
+pr$run(host = "0.0.0.0", port = as.integer(Sys.getenv("PORT", "8000")))

--- a/frontend/playwright.config.js
+++ b/frontend/playwright.config.js
@@ -7,6 +7,8 @@ export default defineConfig({
     baseURL: 'http://localhost:5173/comsa-dashboard/',
   },
   webServer: {
+    // Backend URL is read by the frontend from VITE_API_BASE_URL (see src/api/client.js).
+    // Set it in this process's env (e.g. VITE_API_BASE_URL=http://localhost:8001) to point E2E at an alt port.
     command: 'npm run dev',
     url: 'http://localhost:5173/comsa-dashboard/',
     reuseExistingServer: true,

--- a/frontend/src/api/integration.test.js
+++ b/frontend/src/api/integration.test.js
@@ -2,7 +2,7 @@ import { describe, it, expect, beforeAll, afterAll } from 'vitest'
 import { spawn } from 'child_process'
 import { resolve } from 'path'
 
-const API_BASE = 'http://localhost:8000'
+const API_BASE = process.env.VITE_API_BASE || 'http://localhost:8000'
 let backendProcess = null
 
 async function isBackendUp() {
@@ -27,10 +27,13 @@ beforeAll(async () => {
   if (await isBackendUp()) return
 
   const backendDir = resolve(import.meta.dirname, '../../../backend')
+  // Keep auto-started backend on the same port as API_BASE (default 8000)
+  const port = new URL(API_BASE).port || '8000'
   backendProcess = spawn('Rscript', ['run.R'], {
     cwd: backendDir,
     stdio: 'ignore',
     detached: false,
+    env: { ...process.env, PORT: port },
   })
   backendProcess.on('error', () => { backendProcess = null })
 


### PR DESCRIPTION
## Why

The repo has **no test CI** today — the only workflow is `deploy.yml` (deploy on push to master), and PR checks are AI review bots only. Frontend unit tests and the build were never gated on PRs. This adds a fast PR/push gate.

It also makes the backend port and test targets **env-configurable**, so the suite can run against an alternate port when `:8000` is occupied (e.g. by an unrelated SSH tunnel in local dev).

## Changes

- **`backend/run.R`** — port now reads `PORT` env var: `port = as.integer(Sys.getenv("PORT", "8000"))` (host unchanged). Verified: `PORT=8001 Rscript run.R` serves on :8001.
- **`frontend/src/api/integration.test.js`** — target is now `process.env.VITE_API_BASE || 'http://localhost:8000'`. No silent skip — it still fails loudly if the backend is unreachable. Also passes the derived `PORT` through to the auto-started backend so the spawn stays consistent with `API_BASE`.
- **`frontend/playwright.config.js`** — documented that the frontend reads the backend URL from `VITE_API_BASE_URL` (see `src/api/client.js`); Vite's dev server inherits it from the environment, so E2E can target an alt port via `VITE_API_BASE_URL=http://localhost:8001` with no config rewrite.
- **`.github/workflows/test.yml`** — new workflow on `pull_request` + `push` to `master`. One job (ubuntu-latest, Node 20, npm cache): `npm ci` → `npx vitest run --exclude '**/api/integration.test.js'` → `npm run build`. The integration test and Playwright E2E both need a live R backend and are intentionally **out of scope** for this fast gate (documented in a comment — not a silent skip).

## Verification (run locally)

| Step | Result |
|---|---|
| Backend started on :8001 (`PORT=8001`) | ✅ `/health` → `{"status":"ok"}` |
| Integration tests on :8001 (`VITE_API_BASE=http://localhost:8001`) | ✅ 3/3 pass (idle backend) |
| CI-equivalent unit run (`vitest --exclude` integration) | ✅ **205 passed** (25 files) |
| Production build (`npm run build`) | ✅ built in 1.35s |
| E2E (`demo-gallery.spec.js`) on :8001 | ⚠️ Pre-existing failures, unrelated to this change (see below) |

**Integration test timing note:** A first run showed `GET /jobs` timing out at vitest's default 5s. This is a single-threaded-plumber artifact — the `POST /jobs/demo` test kicks off a real calibration job that blocks a concurrent `GET /jobs`. With the backend idle (or `--testTimeout=20000`), all 3 pass. Not a regression from this change.

**E2E note:** The Playwright `demo-gallery.spec.js` tests fail because the app now renders a **Login/Register landing page** (auth system landed after these specs were written) instead of the expected "Demo Gallery" tab. The frontend connected to :8001 fine and rendered live backend stats (7 Countries / 3 Algorithms / 15 Cause Types) — so this is stale-test rot, not a connectivity issue and not caused by these changes. Updating the E2E specs to log in first is out of scope here.

🤖 Generated with [Claude Code](https://claude.com/claude-code)