### PR TITLE
fix(results): consolidated CSMF table overlap for 1-59m (#80 part 2)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2717,6 +2717,20 @@ main:has(.landing-page) {
 .csmf-table.consolidated tr.ensemble-row td { background: #eef2ff; }
 .csmf-table.consolidated tr.ensemble-row .algo-cell { background: #e0e7ff; }
 
+/* The consolidated table has one column per cause — up to 9 for the 1-59m
+   (child) age group. The base .csmf-table fixed 40%/20% column widths assume a
+   ~3-column layout and force the many child columns to overlap. Let columns
+   size to their content and wrap long cause headers instead. (issue #80) */
+.csmf-table.consolidated { table-layout: auto; font-size: 0.8rem; }
+.csmf-table.consolidated th:first-child,
+.csmf-table.consolidated th:nth-child(n+2) { width: auto; }
+.csmf-table.consolidated th,
+.csmf-table.consolidated td {
+  padding: 0.5rem 0.6rem;
+  white-space: normal;
+  overflow-wrap: break-word;
+}
+
 /* Misclassification small-multiples */
 .matrix-small-multiples { display: flex; flex-wrap: wrap; gap: 16px; overflow-x: auto; }
 .matrix-small-multiples .algorithm-matrix { flex: 0 1 auto; }

--- a/frontend/src/issue80.css.test.js
+++ b/frontend/src/issue80.css.test.js
@@ -1,0 +1,24 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const css = readFileSync(resolve(__dir, 'App.css'), 'utf-8')
+
+// Issue #80 part 2: the consolidated CSMF table overlapped for the 1-59m (child)
+// age group because the base .csmf-table forces table-layout:fixed with 40%/20%
+// column widths — fine for ~3 columns, broken for the 11 columns child produces.
+describe('Consolidated CSMF table column layout (issue #80)', () => {
+  it('overrides the consolidated table to auto layout so columns size to content', () => {
+    expect(css).toMatch(/\.csmf-table\.consolidated\s*\{[^}]*table-layout:\s*auto/)
+  })
+
+  it('resets the base fixed 40%/20% column widths to auto for the consolidated table', () => {
+    expect(css).toMatch(/\.csmf-table\.consolidated th:first-child[\s\S]{0,120}width:\s*auto/)
+  })
+
+  it('allows long cause headers to wrap instead of overlapping', () => {
+    expect(css).toMatch(/\.csmf-table\.consolidated th,[\s\S]{0,160}overflow-wrap:\s*break-word/)
+  })
+})


### PR DESCRIPTION
Addresses **point 2** of #80 (text overlap in the 1-59m results table). Point 1 is handled by a clarifying comment on the issue (see below).

## Problem
The consolidated CSMF table renders one column per cause — **9 for the child (1-59m) age group** vs 6 for neonate. The base `.csmf-table` uses `table-layout: fixed` with `th:first-child { width: 40% }` and `th:nth-child(n+2) { width: 20% }`. Those widths suit the ~3-column simple table, but for the 11-column child layout (Algorithm + Type + 9 causes) they sum to 240%, forcing columns far narrower than their content so the calibrated `x% (lo–hi)` cells overlap/cram.

## Fix
Override the `.consolidated` variant to `table-layout: auto` with `width: auto` columns and wrapping headers, so columns size to content.

## Verification
- Rendered a browser mock of the 9-cause child table with the real CSS: **before** = each calibrated cell crammed into 3 overlapping lines; **after** = clean, auto-sized columns that wrap naturally.
- `issue80.css.test.js` (3 source-assertions on the override); `npm run build` clean.

## Point 1 is NOT in this PR
"Calibrated == uncalibrated for 1-59m EAVA/InterVA" did **not reproduce** — running child calibration on the sample data changed values by up to ~11% (Mozambique) / ~9% (Bangladesh). The dashboard also reads the two series from different package fields (`p_uncalib` vs `pcalib_postsumm[,"postmean",]`), so it's not a display duplication. Left a comment on #80 asking for the country / data source to diagnose, rather than guess-fixing a non-reproducible report.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Improved consolidated table layout to prevent header and content overlap by enabling flexible column sizing and text wrapping.

* **Tests**
  * Added tests to verify consolidated table layout improvements.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->