### PR TITLE
fix(#88): align CCVA algorithm order between selection and upload rows

### DIFF
--- a/frontend/src/components/JobForm.issue88.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue88.behavior.test.jsx
@@ -1,0 +1,50 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * Issue #88: the upload rows must follow the same fixed display order as the
+ * selection panel (EAVA -> InSilicoVA -> InterVA), NOT the order the user
+ * happened to check the algorithm checkboxes.
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest'
+import { render, fireEvent } from '@testing-library/react'
+import { screen } from '@testing-library/dom'
+import JobForm from './JobForm'
+
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+}))
+
+const renderForm = () => render(<JobForm onJobSubmitted={() => {}} />)
+const getAlgoCheckbox = (name) =>
+  screen.getByLabelText(new RegExp(`^${name}\\b`, 'i'))
+
+const uploadRowAlgos = (container) =>
+  Array.from(container.querySelectorAll('.upload-row .upload-algo-label')).map(
+    (el) => el.textContent.trim()
+  )
+
+describe('Upload-row order matches selection-panel order (issue #88)', () => {
+  beforeEach(() => vi.clearAllMocks())
+
+  it('orders rows EAVA -> InterVA even when InterVA was selected first', () => {
+    // Default state is ['InterVA']; checking EAVA appends it (click order
+    // [InterVA, EAVA]). The rows must still render EAVA before InterVA.
+    const { container } = renderForm()
+    fireEvent.click(getAlgoCheckbox('EAVA'))
+
+    expect(uploadRowAlgos(container)).toEqual(['EAVA', 'InterVA'])
+  })
+
+  it('orders all three rows EAVA -> InSilicoVA -> InterVA regardless of check order', () => {
+    // Start from default InterVA, then check InSilicoVA, then EAVA — click
+    // order [InterVA, InSilicoVA, EAVA]. Rows must be in canonical order.
+    const { container } = renderForm()
+    fireEvent.click(getAlgoCheckbox('InSilicoVA'))
+    fireEvent.click(getAlgoCheckbox('EAVA'))
+
+    expect(uploadRowAlgos(container)).toEqual(['EAVA', 'InSilicoVA', 'InterVA'])
+  })
+})

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -10,6 +10,15 @@ let nextUploadId = 1;
 // issue #79 — they did not run smoothly in this interface.)
 const JOB_TYPE = 'vacalibration';
 
+// Fixed display order for the CCVA algorithms, matching the selection-panel
+// checkbox order. Upload rows are sorted by this so the two lists always agree
+// regardless of the order the user checked the boxes (issue #88).
+const ALGORITHM_DISPLAY_ORDER = ['EAVA', 'InSilicoVA', 'InterVA'];
+const algoOrderIndex = (algo) => {
+  const i = ALGORITHM_DISPLAY_ORDER.indexOf(algo);
+  return i === -1 ? ALGORITHM_DISPLAY_ORDER.length : i;
+};
+
 // Broad causes accepted for calibration, per age group (issue #92). Standard
 // algorithm-specific cause names are auto-mapped to these; any cause that maps
 // to none of them is reported as an error, not silently dropped.
@@ -69,10 +78,12 @@ export default function JobForm({ onJobSubmitted }) {
   // source of truth; preserve files already attached to a kept algorithm).
   useEffect(() => {
     setUploads(prev =>
-      algorithms.map(algo => {
-        const existing = prev.find(u => u.algorithm === algo);
-        return existing || { id: nextUploadId++, algorithm: algo, file: null };
-      })
+      [...algorithms]
+        .sort((a, b) => algoOrderIndex(a) - algoOrderIndex(b))
+        .map(algo => {
+          const existing = prev.find(u => u.algorithm === algo);
+          return existing || { id: nextUploadId++, algorithm: algo, file: null };
+        })
     );
   }, [algorithms]);
 

--- a/frontend/src/components/JobForm.test.js
+++ b/frontend/src/components/JobForm.test.js
@@ -48,8 +48,10 @@ describe('Checkbox-driven ensemble uploads', () => {
   })
 
   it('auto-generates upload rows from checked algorithms', () => {
-    // Effect syncs uploads from algorithms array (checkboxes are source of truth)
-    expect(jobFormSrc).toContain('algorithms.map(algo =>')
+    // Effect syncs uploads from algorithms array (checkboxes are source of truth),
+    // sorted into the fixed display order (issue #88).
+    expect(jobFormSrc).toContain('.sort((a, b) => algoOrderIndex(a) - algoOrderIndex(b))')
+    expect(jobFormSrc).toContain('.map(algo =>')
     expect(jobFormSrc).toContain("prev.find(u => u.algorithm === algo)")
   })
 


### PR DESCRIPTION
Closes #88 (split out from #77).

## Problem
After #79 the Calibrate form auto-generates one upload row per selected algorithm, but the rows followed the order the algorithms were **checked**, not the fixed **EAVA → InSilicoVA → InterVA** order shown in the selection panel — so the two lists could disagree.

## Fix
Frontend-only (`JobForm.jsx`). Introduced a shared `ALGORITHM_DISPLAY_ORDER` constant and sort the upload rows by it in the upload-row sync effect. Existing-file preservation (kept files stay attached to their algorithm) is unchanged.

## Tests
- New `JobForm.issue88.behavior.test.jsx` (2 tests): verifies rows render in canonical order regardless of check order (e.g. check InterVA-then-EAVA → rows show EAVA before InterVA; all three → EAVA, InSilicoVA, InterVA).
- Updated the brittle source-string assertion in `JobForm.test.js` to match the new sorted source.
- All 56 JobForm tests pass; 214/217 frontend tests pass (the 3 failures are pre-existing backend integration tests unrelated to this change — a non-COMSA service is occupying :8000 in this env).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Algorithm upload rows now display in a consistent, canonical order: EAVA, InSilicoVA, InterVA.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->