### PR TITLE
fix(#90): surface the misclassification estimates used for calibration

### DIFF
--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -211,38 +211,11 @@ run_vacalibration <- function(job) {
     }
   }
 
-  # Extract misclassification matrix (normalize Dirichlet params to probabilities)
-  mmat <- if (!is.null(result$Mmat.asDirich)) normalize_mmat(result$Mmat.asDirich)
-          else if (!is.null(result$Mmat.fixed)) result$Mmat.fixed  # already normalized
-          else NULL
-
-  misclass_matrix <- NULL
-  if (!is.null(mmat)) {
-    dnames <- dimnames(mmat)
-
-    if (length(dim(mmat)) == 3) {
-      # 3D: [algorithm, CHAMPS, VA]
-      misclass_matrix <- list()
-      for (i in seq_len(dim(mmat)[1])) {
-        algo_name <- dnames[[1]][i]
-        algo_matrix <- mmat[i, , , drop = TRUE]
-        misclass_matrix[[algo_name]] <- list(
-          matrix = lapply(seq_len(nrow(algo_matrix)), function(row) round(algo_matrix[row, ], 4)),
-          champs_causes = dnames[[2]],
-          va_causes = dnames[[3]]
-        )
-      }
-    } else if (length(dim(mmat)) == 2) {
-      # 2D: [CHAMPS, VA] for single algorithm
-      algo_name <- if (length(algo_names) == 1) algo_names[1] else "combined"
-      misclass_matrix <- list()
-      misclass_matrix[[algo_name]] <- list(
-        matrix = lapply(seq_len(nrow(mmat)), function(row) round(mmat[row, ], 4)),
-        champs_causes = dnames[[1]],
-        va_causes = dnames[[2]]
-      )
-    }
-  }
+  # Extract the misclassification matrix used for calibration (issue #90).
+  misclass_matrix <- extract_misclass_matrix(
+    result,
+    single_algo_name = if (length(algo_names) == 1) algo_names[1] else "combined"
+  )
 
   # Save outputs (output_dir already created above)
 

--- a/backend/jobs/processor.R
+++ b/backend/jobs/processor.R
@@ -205,36 +205,11 @@ run_pipeline <- function(job) {
     }
   }
 
-  # Extract misclassification matrix (normalize Dirichlet params to probabilities)
-  mmat <- if (!is.null(calib_result$Mmat.asDirich)) normalize_mmat(calib_result$Mmat.asDirich)
-          else if (!is.null(calib_result$Mmat.fixed)) calib_result$Mmat.fixed  # already normalized
-          else NULL
-
-  misclass_matrix <- NULL
-  if (!is.null(mmat)) {
-    dnames <- dimnames(mmat)
-
-    if (length(dim(mmat)) == 3) {
-      misclass_matrix <- list()
-      for (i in seq_len(dim(mmat)[1])) {
-        algo_name <- dnames[[1]][i]
-        algo_matrix <- mmat[i, , , drop = TRUE]
-        misclass_matrix[[algo_name]] <- list(
-          matrix = lapply(seq_len(nrow(algo_matrix)), function(row) round(algo_matrix[row, ], 4)),
-          champs_causes = dnames[[2]],
-          va_causes = dnames[[3]]
-        )
-      }
-    } else if (length(dim(mmat)) == 2) {
-      algo_name <- if (length(algorithms) == 1) normalize_algo_name(algorithms[1]) else "combined"
-      misclass_matrix <- list()
-      misclass_matrix[[algo_name]] <- list(
-        matrix = lapply(seq_len(nrow(mmat)), function(row) round(mmat[row, ], 4)),
-        champs_causes = dnames[[1]],
-        va_causes = dnames[[2]]
-      )
-    }
-  }
+  # Extract the misclassification matrix used for calibration (issue #90).
+  misclass_matrix <- extract_misclass_matrix(
+    calib_result,
+    single_algo_name = if (length(algorithms) == 1) normalize_algo_name(algorithms[1]) else "combined"
+  )
 
   # Save outputs
   output_dir <- file.path("data", "outputs", job$id)

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -461,3 +461,49 @@ normalize_mmat <- function(mmat) {
   }
   mmat
 }
+
+# Build the misclassification matrix shown in the results view (issue #90):
+# P(VA cause | CHAMPS cause), one entry per algorithm.
+#
+# vacalibration v2.2 returns the matrix actually used in calibration as
+# `Mmat_tomodel` (documented in ?vacalibration: "This is used for calibration"),
+# arranged algorithm x CHAMPS cause x VA cause. It is Dirichlet counts in prior
+# mode and normalized probabilities in fixed mode; normalize_mmat row-normalizes
+# both to probabilities. (Pre-2.2 used Mmat.asDirich/Mmat.fixed, which no longer
+# exist — reading those silently produced NULL, which is why the matrix stopped
+# appearing.)
+#
+# `single_algo_name` is the label used only for a 2D (single-algorithm) result
+# that carries no algorithm dimname. Returns a named list (one entry per
+# algorithm) or NULL when the result has no misclassification matrix.
+extract_misclass_matrix <- function(result, single_algo_name = "combined") {
+  mmat <- normalize_mmat(result$Mmat_tomodel)
+  if (is.null(mmat)) return(NULL)
+
+  dnames <- dimnames(mmat)
+  misclass_matrix <- list()
+
+  if (length(dim(mmat)) == 3) {
+    # 3D: [algorithm, CHAMPS, VA]
+    for (i in seq_len(dim(mmat)[1])) {
+      algo_name <- dnames[[1]][i]
+      algo_matrix <- mmat[i, , , drop = TRUE]
+      misclass_matrix[[algo_name]] <- list(
+        matrix = lapply(seq_len(nrow(algo_matrix)), function(row) round(algo_matrix[row, ], 4)),
+        champs_causes = dnames[[2]],
+        va_causes = dnames[[3]]
+      )
+    }
+  } else if (length(dim(mmat)) == 2) {
+    # 2D: [CHAMPS, VA] for a single algorithm
+    misclass_matrix[[single_algo_name]] <- list(
+      matrix = lapply(seq_len(nrow(mmat)), function(row) round(mmat[row, ], 4)),
+      champs_causes = dnames[[1]],
+      va_causes = dnames[[2]]
+    )
+  } else {
+    return(NULL)
+  }
+
+  misclass_matrix
+}

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -463,10 +463,10 @@ if (file.exists(rds_interva)) {
     test("Credible interval upper <= 1",
          all(calib_high <= 1 + 1e-6))
 
-    # -- Misclassification matrix --
-    test("Result has Mmat.asDirich", !is.null(result_interva$Mmat.asDirich))
-    mmat <- result_interva$Mmat.asDirich
-    test("Mmat.asDirich is a matrix or array", is.numeric(mmat))
+    # -- Misclassification matrix (v2.2 field; issue #90) --
+    test("Result has Mmat_tomodel", !is.null(result_interva$Mmat_tomodel))
+    mmat <- result_interva$Mmat_tomodel
+    test("Mmat_tomodel is a matrix or array", is.numeric(mmat))
     if (length(dim(mmat)) == 2) {
       test("2D Mmat has 6 rows (CHAMPS causes)", nrow(mmat) == 6)
       test("2D Mmat all values >= 0", all(mmat >= 0))
@@ -499,7 +499,6 @@ result_csv <- tryCatch(
     ensemble = TRUE,
     nMCMC = 5000,
     nBurn = 2000,
-    plot_it = FALSE,
     verbose = FALSE
   ),
   error = function(e) { cat("  ERROR:", e$message, "\n"); NULL }
@@ -536,7 +535,6 @@ result_eava <- tryCatch(
     ensemble = TRUE,
     nMCMC = 5000,
     nBurn = 2000,
-    plot_it = FALSE,
     verbose = FALSE
   ),
   error = function(e) { cat("  ERROR:", e$message, "\n"); NULL }
@@ -596,8 +594,8 @@ if (!is.null(result_interva)) {
   test("Summary calibrated_upper >= calibrated_mean",
        all(summary_df$calibrated_upper >= summary_df$calibrated_mean - 1e-4))
 
-  # Misclassification matrix output
-  mmat <- result_interva$Mmat.asDirich
+  # Misclassification matrix output (v2.2 field; issue #90)
+  mmat <- result_interva$Mmat_tomodel
   if (!is.null(mmat) && length(dim(mmat)) == 2) {
     dnames <- dimnames(mmat)
     mmat_df <- as.data.frame(round(mmat, 4))
@@ -715,7 +713,6 @@ result_ens2 <- tryCatch(
     ensemble = TRUE,
     nMCMC = 5000,
     nBurn = 2000,
-    plot_it = FALSE,
     verbose = FALSE
   ),
   error = function(e) { cat("  ERROR:", e$message, "\n"); NULL }
@@ -759,9 +756,9 @@ if (!is.null(result_ens2)) {
          abs(sum(algo_mean) - 1) < 0.01)
   }
 
-  # Mmat.asDirich should be 3D: [algo, champs_cause, va_cause]
-  mmat_ens2 <- result_ens2$Mmat.asDirich
-  test("Ensemble Mmat.asDirich is 3D", length(dim(mmat_ens2)) == 3)
+  # Mmat_tomodel should be 3D: [algo, champs_cause, va_cause] (v2.2 field; issue #90)
+  mmat_ens2 <- result_ens2$Mmat_tomodel
+  test("Ensemble Mmat_tomodel is 3D", length(dim(mmat_ens2)) == 3)
   if (length(dim(mmat_ens2)) == 3) {
     test("Mmat 3D dim[1] = 2 (algorithms)", dim(mmat_ens2)[1] == 2)
     test("Mmat 3D dim[2] = 6 (CHAMPS causes)", dim(mmat_ens2)[2] == 6)
@@ -793,7 +790,6 @@ result_ens3 <- tryCatch(
     ensemble = TRUE,
     nMCMC = 5000,
     nBurn = 2000,
-    plot_it = FALSE,
     verbose = FALSE
   ),
   error = function(e) { cat("  ERROR:", e$message, "\n"); NULL }
@@ -823,9 +819,9 @@ if (!is.null(result_ens3)) {
          abs(sum(postsumm3[rn, "postmean", ]) - 1) < 0.01)
   }
 
-  # Mmat.asDirich: 3D with dim[1]=3
-  mmat_ens3 <- result_ens3$Mmat.asDirich
-  test("3-algo Mmat.asDirich is 3D with dim[1]=3",
+  # Mmat_tomodel: 3D with dim[1]=3 (v2.2 field; issue #90)
+  mmat_ens3 <- result_ens3$Mmat_tomodel
+  test("3-algo Mmat_tomodel is 3D with dim[1]=3",
        length(dim(mmat_ens3)) == 3 && dim(mmat_ens3)[1] == 3)
 }
 
@@ -933,6 +929,48 @@ if (file.exists(new_csv)) {
   }
 }
 
+# =============================================================================
+# 12c. MISCLASSIFICATION MATRIX EXTRACTION -- v2.2 field (issue #90)
+# =============================================================================
+# vacalibration v2.2 renamed the misclassification output to `Mmat_tomodel`
+# (documented: "This is used for calibration"). The v2.0 names Mmat.asDirich /
+# Mmat.fixed no longer exist, so the backend's old extraction silently produced
+# NULL and the results view never showed the matrix. These tests run a REAL v2.2
+# calibration and lock the field + the shared extract_misclass_matrix() helper.
+section("12c. Misclassification Matrix Extraction (issue #90)")
+
+res90 <- tryCatch(
+  vacalibration(va_data = list(interva = interva_broad_e), age_group = "neonate",
+                country = "Mozambique", missmat_type = "prior", ensemble = FALSE,
+                nMCMC = 400, nBurn = 200, verbose = FALSE),
+  error = function(e) { cat("  ERROR:", e$message, "\n"); NULL })
+
+test("vacalibration result exposes Mmat_tomodel (v2.2 field, issue #90)",
+     !is.null(res90) && !is.null(res90$Mmat_tomodel))
+test("old v2.0 field names are absent (documents the #90 root cause)",
+     !is.null(res90) && is.null(res90$Mmat.asDirich) && is.null(res90$Mmat.fixed))
+
+mm90 <- if (!is.null(res90)) extract_misclass_matrix(res90, "interva") else NULL
+test("extract_misclass_matrix returns a non-NULL matrix for a real v2.2 result (issue #90)",
+     !is.null(mm90) && length(mm90) >= 1)
+if (!is.null(mm90)) {
+  algo1 <- mm90[[1]]
+  test("extracted matrix has matrix/champs_causes/va_causes",
+       all(c("matrix", "champs_causes", "va_causes") %in% names(algo1)))
+  test("extracted matrix rows are normalized to ~1 (P(VA | CHAMPS))",
+       all(abs(vapply(algo1$matrix, sum, numeric(1)) - 1) < 0.01))
+  test("extracted matrix uses the 6 neonate broad causes",
+       setequal(algo1$champs_causes, neonate_broad_causes) &&
+       setequal(algo1$va_causes, neonate_broad_causes))
+}
+
+# Ensemble: one matrix per algorithm (reuse result_ens2 from section 11).
+if (exists("result_ens2") && !is.null(result_ens2)) {
+  mm90e <- extract_misclass_matrix(result_ens2, "combined")
+  test("ensemble extraction yields one matrix per algorithm (issue #90)",
+       !is.null(mm90e) && setequal(names(mm90e), c("interva", "insilicova")))
+}
+
 } # end if (!input_only)
 
 # =============================================================================
@@ -1026,20 +1064,57 @@ test("normalize_mmat 3D: all values between 0 and 1",
 # Test that NULL input returns NULL
 test("normalize_mmat handles NULL input", is.null(normalize_mmat(NULL)))
 
-# Validate with actual vacalibration output (if full tests ran)
-if (exists("result_interva") && !is.null(result_interva$Mmat.asDirich)) {
-  mmat_raw <- result_interva$Mmat.asDirich
+# Validate with actual vacalibration output (if full tests ran). v2.2 field; issue #90.
+if (exists("result_interva") && !is.null(result_interva$Mmat_tomodel)) {
+  mmat_raw <- result_interva$Mmat_tomodel
   mmat_norm <- normalize_mmat(mmat_raw)
   if (length(dim(mmat_norm)) == 2) {
-    test("Real Mmat.asDirich normalized: rows sum to 1",
+    test("Real Mmat_tomodel normalized: rows sum to 1",
          all(abs(rowSums(mmat_norm) - 1) < 1e-6))
   } else if (length(dim(mmat_norm)) == 3) {
     sums_ok <- all(sapply(seq_len(dim(mmat_norm)[1]), function(k) {
       all(abs(rowSums(mmat_norm[k, , ]) - 1) < 1e-6)
     }))
-    test("Real Mmat.asDirich normalized: rows sum to 1", sums_ok)
+    test("Real Mmat_tomodel normalized: rows sum to 1", sums_ok)
   }
 }
+
+# =============================================================================
+# 14b. extract_misclass_matrix() helper -- field preference + shape (issue #90)
+# =============================================================================
+# Fast, MCMC-free unit tests of the shared extraction helper (also runs in
+# --input-only mode): verifies it reads the v2.2 `Mmat_tomodel` field, prefers
+# it over the legacy fallbacks, normalizes rows, and is NULL-safe.
+section("14b. extract_misclass_matrix() helper (issue #90)")
+
+test("extract_misclass_matrix is defined in utils.R", is.function(extract_misclass_matrix))
+
+# Synthetic 3D Dirichlet-count array [1 algo x 2 CHAMPS x 2 VA] -> normalized.
+syn_dn <- list("interva", c("a", "b"), c("a", "b"))
+mmat_tomodel <- array(c(8, 2, 2, 8), dim = c(1, 2, 2), dimnames = syn_dn)  # algo-major
+res_syn <- list(Mmat_tomodel = mmat_tomodel)
+mm_syn <- extract_misclass_matrix(res_syn, "interva")
+test("reads Mmat_tomodel and returns one entry per algorithm",
+     !is.null(mm_syn) && setequal(names(mm_syn), "interva"))
+test("normalizes rows to sum to 1",
+     !is.null(mm_syn) && all(abs(vapply(mm_syn[["interva"]]$matrix, sum, numeric(1)) - 1) < 1e-9))
+test("preserves CHAMPS/VA cause labels",
+     identical(mm_syn[["interva"]]$champs_causes, c("a", "b")) &&
+     identical(mm_syn[["interva"]]$va_causes, c("a", "b")))
+
+# NULL-safety: no Mmat_tomodel -> NULL, no crash.
+test("returns NULL when the result has no Mmat_tomodel field",
+     is.null(extract_misclass_matrix(list(p_uncalib = 1), "x")))
+
+# Backend wiring: both calibration paths use the shared helper (issue #90).
+vacalib_src90 <- readLines(file.path(backend_dir, "jobs", "algorithms", "vacalibration.R"))
+processor_src90 <- readLines(file.path(backend_dir, "jobs", "processor.R"))
+test("vacalibration.R calls extract_misclass_matrix (issue #90)",
+     any(grepl("extract_misclass_matrix", vacalib_src90)))
+test("processor.R calls extract_misclass_matrix (issue #90)",
+     any(grepl("extract_misclass_matrix", processor_src90)))
+test("no path still reads the dead v2.0 Mmat.asDirich/Mmat.fixed as the primary field (issue #90)",
+     !any(grepl("Mmat\\.asDirich", vacalib_src90)) && !any(grepl("Mmat\\.asDirich", processor_src90)))
 
 section("15. Cause Display Map (Issue #29)")
 

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -466,7 +466,8 @@ if (file.exists(rds_interva)) {
     # -- Misclassification matrix (v2.2 field; issue #90) --
     test("Result has Mmat_tomodel", !is.null(result_interva$Mmat_tomodel))
     mmat <- result_interva$Mmat_tomodel
-    test("Mmat_tomodel is a matrix or array", is.numeric(mmat))
+    test("Mmat_tomodel is a matrix or array",
+         (is.matrix(mmat) || is.array(mmat)) && length(dim(mmat)) %in% c(2, 3))
     if (length(dim(mmat)) == 2) {
       test("2D Mmat has 6 rows (CHAMPS causes)", nrow(mmat) == 6)
       test("2D Mmat all values >= 0", all(mmat >= 0))
@@ -1114,7 +1115,8 @@ test("vacalibration.R calls extract_misclass_matrix (issue #90)",
 test("processor.R calls extract_misclass_matrix (issue #90)",
      any(grepl("extract_misclass_matrix", processor_src90)))
 test("no path still reads the dead v2.0 Mmat.asDirich/Mmat.fixed as the primary field (issue #90)",
-     !any(grepl("Mmat\\.asDirich", vacalib_src90)) && !any(grepl("Mmat\\.asDirich", processor_src90)))
+     !any(grepl("Mmat\\.asDirich", vacalib_src90)) && !any(grepl("Mmat\\.asDirich", processor_src90)) &&
+     !any(grepl("Mmat\\.fixed", vacalib_src90)) && !any(grepl("Mmat\\.fixed", processor_src90)))
 
 section("15. Cause Display Map (Issue #29)")
 


### PR DESCRIPTION
Closes #90 (split out from #77).

## Root cause
The misclassification matrix never appeared in the results — in **every** mode, not just the reported one. The backend read the **v2.0** result fields `Mmat.asDirich` / `Mmat.fixed`, but **vacalibration v2.2 renamed them**. Both are `NULL` on v2.2, so `misclass_matrix` was always `NULL`, `result_obj$misclassification_matrix` was never set, and the frontend's `{results.misclassification_matrix && …}` gate hid the whole section.

The v2.2 migration had updated the *calibration call* (`missmat_type`) but missed this *output field*. Verified by upgrading to vacalibration **2.2** locally (the version the Dockerfile installs) and probing a real result:
- v2.2 exposes `Mmat_input` / `Mmat_study` / **`Mmat_tomodel`** — and `?vacalibration` documents `Mmat_tomodel` verbatim as *"This is used for calibration."*
- `result$Mmat.asDirich` and `result$Mmat.fixed` are both `NULL` on v2.2.

## Fix
- New shared **`extract_misclass_matrix()`** in `utils.R` reads `Mmat_tomodel` (Dirichlet counts in prior mode, probabilities in fixed mode) and row-normalizes to `P(VA | CHAMPS)`. Replaces the ~30-line block that was **duplicated verbatim** in both backend paths (so they can't drift again).
- Wired `run_vacalibration()` and `run_pipeline()` to the helper.
- Frontend already renders the matrix when present — **no frontend change needed**.

## Also: completes the v2.2 test migration
The R suite isn't in CI (only CodeRabbit + frontend run), so these latent v2.2 breakages went unnoticed. Fixed so the suite is green on the deployed version:
- Dropped the removed `plot_it` argument from 4 test calls (v2.2 removed it; the real backend never passed it, so production was unaffected).
- Renamed stale `Mmat.asDirich` assertions to `Mmat_tomodel`.

## Tests
- New **section 12c** (real v2.2 calibration): `Mmat_tomodel` exposed, old names absent, extraction non-NULL, one matrix per ensemble algorithm, rows normalized to 1.
- New **section 14b** (input-only, MCMC-free): helper field-read, normalization, NULL-safety, and source-assertions that both paths call the helper and no path reads the dead field.
- **Full suite against vacalibration 2.2: 292/292 pass.**

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Refactor**
  * Refactored misclassification matrix extraction to improve code maintainability and consistency across single-algorithm and ensemble calibration scenarios.
  * Centralized matrix normalization workflow for better data consistency.

* **Tests**
  * Expanded test coverage for misclassification matrix handling, including normalization validation, field compatibility checks, and end-to-end extraction workflows.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->