### PR TITLE
fix(#83): support independent multi-algorithm calibration (ensemble OFF)

### DIFF
--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -197,19 +197,9 @@ run_vacalibration <- function(job) {
   calibrated_low <- as.list(round(result$pcalib_postsumm[primary, "lowcredI", ], 4))
   calibrated_high <- as.list(round(result$pcalib_postsumm[primary, "upcredI", ], 4))
 
-  # Per-algorithm breakdown (for ensemble mode)
-  per_algorithm <- NULL
-  if (ensemble_val && length(result_labels) > 1) {
-    per_algorithm <- list()
-    for (label in result_labels) {
-      per_algorithm[[label]] <- list(
-        uncalibrated_csmf   = as.list(round(result$p_uncalib[label, ], 4)),
-        calibrated_csmf     = as.list(round(result$pcalib_postsumm[label, "postmean", ], 4)),
-        calibrated_ci_lower = as.list(round(result$pcalib_postsumm[label, "lowcredI", ], 4)),
-        calibrated_ci_upper = as.list(round(result$pcalib_postsumm[label, "upcredI", ], 4))
-      )
-    }
-  }
+  # Per-algorithm breakdown: every algorithm's calibration, for both ensemble
+  # and independent multi-algorithm runs (issue #83).
+  per_algorithm <- build_per_algorithm(result)
 
   # Extract the misclassification matrix used for calibration (issue #90).
   misclass_matrix <- extract_misclass_matrix(

--- a/backend/jobs/processor.R
+++ b/backend/jobs/processor.R
@@ -191,19 +191,9 @@ run_pipeline <- function(job) {
   calibrated_low <- as.list(round(calib_result$pcalib_postsumm[primary, "lowcredI", ], 4))
   calibrated_high <- as.list(round(calib_result$pcalib_postsumm[primary, "upcredI", ], 4))
 
-  # Per-algorithm breakdown (for ensemble mode)
-  per_algorithm <- NULL
-  if (ensemble_val && length(result_labels) > 1) {
-    per_algorithm <- list()
-    for (label in result_labels) {
-      per_algorithm[[label]] <- list(
-        uncalibrated_csmf   = as.list(round(calib_result$p_uncalib[label, ], 4)),
-        calibrated_csmf     = as.list(round(calib_result$pcalib_postsumm[label, "postmean", ], 4)),
-        calibrated_ci_lower = as.list(round(calib_result$pcalib_postsumm[label, "lowcredI", ], 4)),
-        calibrated_ci_upper = as.list(round(calib_result$pcalib_postsumm[label, "upcredI", ], 4))
-      )
-    }
-  }
+  # Per-algorithm breakdown: every algorithm's calibration, for both ensemble
+  # and independent multi-algorithm runs (issue #83).
+  per_algorithm <- build_per_algorithm(calib_result)
 
   # Extract the misclassification matrix used for calibration (issue #90).
   misclass_matrix <- extract_misclass_matrix(

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -507,3 +507,25 @@ extract_misclass_matrix <- function(result, single_algo_name = "combined") {
 
   misclass_matrix
 }
+
+# Build the per-algorithm CSMF breakdown shown in the results view. It is
+# populated whenever the calibration produced more than one labeled result —
+# i.e. multiple algorithms and/or an "ensemble" row — so an INDEPENDENT
+# multi-algorithm run surfaces every algorithm's calibration even with
+# "Combine algorithms?" off (issue #83). Returns a named list (one entry per
+# label) or NULL for a single-label (single-algorithm, no ensemble) run.
+build_per_algorithm <- function(result) {
+  result_labels <- dimnames(result$pcalib_postsumm)[[1]]
+  if (length(result_labels) <= 1) return(NULL)
+
+  per_algorithm <- list()
+  for (label in result_labels) {
+    per_algorithm[[label]] <- list(
+      uncalibrated_csmf   = as.list(round(result$p_uncalib[label, ], 4)),
+      calibrated_csmf     = as.list(round(result$pcalib_postsumm[label, "postmean", ], 4)),
+      calibrated_ci_lower = as.list(round(result$pcalib_postsumm[label, "lowcredI", ], 4)),
+      calibrated_ci_upper = as.list(round(result$pcalib_postsumm[label, "upcredI", ], 4))
+    )
+  }
+  per_algorithm
+}

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -326,8 +326,10 @@ function(req) {
   upload_dir <- file.path("data", "uploads", job_id)
   dir.create(upload_dir, recursive = TRUE, showWarnings = FALSE)
 
-  if (ensemble_bool && job_type == "vacalibration") {
-    # Multi-file ensemble: save per-algorithm files
+  if (job_type == "vacalibration" && length(algorithms) > 1) {
+    # Multi-algorithm vacalibration: save one file per algorithm, regardless of
+    # ensemble. Each runs an independent calibration; ensemble (when on) adds the
+    # combined run on top (issue #83).
     algo_file_map <- list(
       interva = file_interva,
       insilicova = file_insilicova,

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -52,16 +52,18 @@ async function fetchJson(url, options = {}) {
 export async function submitJob({ uploads, jobType, algorithms, ageGroup, country, calibModelType, ensemble, nMCMC, nBurn, nThin }) {
   const formData = new FormData();
 
-  // Multi-file: ensemble vacalibration sends per-algorithm file keys
+  // A vacalibration job with 2+ uploaded files sends one keyed file per
+  // algorithm (`file_<algo>`), so the backend can run N independent
+  // calibrations — with or without the additional ensemble run (issue #83).
+  // A single file (single-algorithm vacalibration, or pipeline/openVA) is sent
+  // as the plain `file` field.
+  const filesWithAlgo = (uploads || []).filter(u => u.file && u.algorithm);
   const hasFiles = uploads && uploads.some(u => u.file);
-  if (hasFiles && ensemble && jobType === 'vacalibration') {
-    uploads.forEach(({ algorithm, file }) => {
-      if (file && algorithm) {
-        formData.append(`file_${algorithm.toLowerCase()}`, file);
-      }
+  if (jobType === 'vacalibration' && filesWithAlgo.length > 1) {
+    filesWithAlgo.forEach(({ algorithm, file }) => {
+      formData.append(`file_${algorithm.toLowerCase()}`, file);
     });
   } else if (hasFiles) {
-    // Single file for non-ensemble or pipeline
     const firstFile = uploads.find(u => u.file)?.file;
     if (firstFile) formData.append('file', firstFile);
   }

--- a/frontend/src/api/client.test.js
+++ b/frontend/src/api/client.test.js
@@ -134,4 +134,39 @@ describe('submitJob multi-file support (issue #27)', () => {
     expect(formData.get('file')).toBeTruthy();
     expect(formData.get('file_interva')).toBeNull();
   });
+
+  it('sends per-algorithm file keys for multi-file vacalibration even when ensemble is OFF (issue #83)', async () => {
+    // Independent multi-algorithm calibration: each algorithm keeps its own file
+    // regardless of "Combine algorithms?". Previously only the first file was
+    // sent, silently dropping the rest.
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ job_id: 'test-789', status: 'pending' })
+    });
+    globalThis.fetch = mockFetch;
+
+    const { submitJob } = await import('./client.js');
+    await submitJob({
+      uploads: [
+        { algorithm: 'InterVA', file: new File(['a'], 'interva.csv') },
+        { algorithm: 'InSilicoVA', file: new File(['b'], 'insilicova.csv') }
+      ],
+      jobType: 'vacalibration',
+      algorithms: ['InterVA', 'InSilicoVA'],
+      ageGroup: 'neonate',
+      country: 'Mozambique',
+      calibModelType: 'Mmatprior',
+      ensemble: false,
+      nMCMC: 5000,
+      nBurn: 2000,
+      nThin: 1
+    });
+
+    const [url, options] = mockFetch.mock.calls[0];
+    const formData = options.body;
+    expect(formData.get('file_interva')).toBeTruthy();
+    expect(formData.get('file_insilicova')).toBeTruthy();
+    expect(formData.get('file')).toBeNull();      // no single-file fallback
+    expect(url).toContain('ensemble=false');
+  });
 })

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -273,7 +273,11 @@ function CalibratedResults({ results, jobId }) {
   const csmfTableRef = useRef(null);
 
   const algorithmsDisplay = formatAlgorithmList(results.algorithm);
-  const isEnsemble = Array.isArray(results.algorithm) && results.algorithm.length > 1;
+  const algoCount = Array.isArray(results.algorithm) ? results.algorithm.length : 1;
+  // Distinguish a true ensemble run from independent multi-algorithm calibration
+  // (2+ algorithms with "Combine algorithms?" off) — issue #83.
+  const isEnsemble = results.ensemble === true || results.ensemble === 'true';
+  const isIndependentMulti = algoCount > 1 && !isEnsemble;
   const tableData = buildCsmfTableRows(results);
 
   // Combined PDF report (issue #91): inputs + misclassification figure + CSMF
@@ -304,7 +308,12 @@ function CalibratedResults({ results, jobId }) {
         <p><strong>Country:</strong> {results.country === 'other' ? 'All the countries' : results.country}</p>
         {isEnsemble && (
           <p className="ensemble-indicator">
-            <strong>✓ Ensemble Mode:</strong> Results calibrated across {results.algorithm.length} algorithms
+            <strong>✓ Ensemble Mode:</strong> Includes a combined ensemble across {algoCount} algorithms
+          </p>
+        )}
+        {isIndependentMulti && (
+          <p className="ensemble-indicator">
+            <strong>✓ Independent calibration:</strong> {algoCount} algorithms calibrated separately
           </p>
         )}
       </div>

--- a/frontend/src/components/JobDetail.test.js
+++ b/frontend/src/components/JobDetail.test.js
@@ -97,3 +97,17 @@ describe('Combined PDF report (issue #91)', () => {
     expect(jobDetailSrc).toContain("generateFilename('calibration_report'")
   })
 })
+
+describe('Ensemble vs independent multi-algorithm indicator (issue #83)', () => {
+  it('bases the ensemble indicator on the actual ensemble flag, not algorithm count', () => {
+    // Previously isEnsemble was `results.algorithm.length > 1`, which mislabeled
+    // an independent (ensemble-OFF) multi-algorithm run as "Ensemble Mode".
+    expect(jobDetailSrc).toContain("results.ensemble === true")
+    expect(jobDetailSrc).not.toMatch(/isEnsemble\s*=\s*Array\.isArray\(results\.algorithm\)\s*&&\s*results\.algorithm\.length\s*>\s*1/)
+  })
+
+  it('shows a distinct "Independent calibration" indicator for multi-algo without ensemble', () => {
+    expect(jobDetailSrc).toContain('isIndependentMulti')
+    expect(jobDetailSrc).toContain('Independent calibration')
+  })
+})

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -972,6 +972,34 @@ if (exists("result_ens2") && !is.null(result_ens2)) {
        !is.null(mm90e) && setequal(names(mm90e), c("interva", "insilicova")))
 }
 
+# =============================================================================
+# 12d. INDEPENDENT MULTI-ALGORITHM CALIBRATION -- ensemble OFF (issue #83)
+# =============================================================================
+# With 2+ algorithms and ensemble OFF, vacalibration runs N INDEPENDENT
+# calibrations (no "ensemble" row). build_per_algorithm() must still surface
+# every algorithm so none of the uploaded files is effectively dropped.
+section("12d. Independent multi-algorithm calibration, ensemble OFF (issue #83)")
+
+result_indep <- tryCatch(
+  vacalibration(va_data = list(interva = interva_broad_e, insilicova = insilico_broad_e),
+                age_group = "neonate", country = "Mozambique", missmat_type = "prior",
+                ensemble = FALSE, nMCMC = 400, nBurn = 200, verbose = FALSE),
+  error = function(e) { cat("  ERROR:", e$message, "\n"); NULL })
+
+test("ensemble-OFF multi-algo returns a result (issue #83)", !is.null(result_indep))
+if (!is.null(result_indep)) {
+  labels_indep <- dimnames(result_indep$pcalib_postsumm)[[1]]
+  test("ensemble-OFF result has NO ensemble row (independent calibrations)",
+       !("ensemble" %in% labels_indep) && setequal(labels_indep, c("interva", "insilicova")))
+
+  pa_indep <- build_per_algorithm(result_indep)
+  test("build_per_algorithm surfaces BOTH algorithms when ensemble is OFF (issue #83)",
+       !is.null(pa_indep) && setequal(names(pa_indep), c("interva", "insilicova")))
+  test("each algorithm's calibrated CSMF sums to ~1",
+       !is.null(pa_indep) &&
+       all(vapply(pa_indep, function(a) abs(sum(unlist(a$calibrated_csmf)) - 1) < 0.02, logical(1))))
+}
+
 } # end if (!input_only)
 
 # =============================================================================
@@ -1117,6 +1145,54 @@ test("processor.R calls extract_misclass_matrix (issue #90)",
 test("no path still reads the dead v2.0 Mmat.asDirich/Mmat.fixed as the primary field (issue #90)",
      !any(grepl("Mmat\\.asDirich", vacalib_src90)) && !any(grepl("Mmat\\.asDirich", processor_src90)) &&
      !any(grepl("Mmat\\.fixed", vacalib_src90)) && !any(grepl("Mmat\\.fixed", processor_src90)))
+
+# =============================================================================
+# 14c. build_per_algorithm() helper -- multi-algo surfaces all (issue #83)
+# =============================================================================
+# Fast, MCMC-free unit tests of the per-algorithm breakdown helper: a
+# multi-label result yields one entry per label (so an independent ensemble-OFF
+# run shows every algorithm), and a single-label result yields NULL.
+section("14c. build_per_algorithm() helper (issue #83)")
+
+test("build_per_algorithm is defined in utils.R", is.function(build_per_algorithm))
+
+mk_result <- function(labels) {
+  stats <- c("postmean", "lowcredI", "upcredI")
+  causes <- c("a", "b")
+  list(
+    pcalib_postsumm = array(0.5, dim = c(length(labels), 3, 2),
+                            dimnames = list(labels, stats, causes)),
+    p_uncalib = matrix(0.5, nrow = length(labels), ncol = 2,
+                       dimnames = list(labels, causes))
+  )
+}
+
+pa_multi <- build_per_algorithm(mk_result(c("interva", "insilicova")))
+test("multi-label result yields one entry per algorithm (issue #83)",
+     !is.null(pa_multi) && setequal(names(pa_multi), c("interva", "insilicova")))
+test("each per-algorithm entry carries calibrated + uncalibrated CSMF + CIs",
+     all(c("uncalibrated_csmf", "calibrated_csmf", "calibrated_ci_lower", "calibrated_ci_upper")
+         %in% names(pa_multi[["interva"]])))
+test("single-label result yields NULL (no per-algorithm breakdown)",
+     is.null(build_per_algorithm(mk_result("interva"))))
+
+# Backend wiring: both calibration paths use the shared helper (issue #83).
+vacalib_src83 <- readLines(file.path(backend_dir, "jobs", "algorithms", "vacalibration.R"))
+processor_src83 <- readLines(file.path(backend_dir, "jobs", "processor.R"))
+test("vacalibration.R calls build_per_algorithm (issue #83)",
+     any(grepl("build_per_algorithm", vacalib_src83)))
+test("processor.R calls build_per_algorithm (issue #83)",
+     any(grepl("build_per_algorithm", processor_src83)))
+test("per-algorithm breakdown is no longer gated on ensemble_val (issue #83)",
+     !any(grepl("ensemble_val && length\\(result_labels\\)", vacalib_src83)) &&
+     !any(grepl("ensemble_val && length\\(result_labels\\)", processor_src83)))
+
+# Transport: plumber saves per-algorithm files for any multi-algo vacalibration,
+# not only when ensemble is on (issue #83).
+plumber_src83 <- readLines(file.path(backend_dir, "plumber.R"))
+test("plumber.R saves per-algorithm files for multi-algo vacalibration regardless of ensemble (issue #83)",
+     any(grepl('job_type == "vacalibration" && length\\(algorithms\\) > 1', plumber_src83)) &&
+     !any(grepl('ensemble_bool && job_type == "vacalibration"', plumber_src83)))
 
 section("15. Cause Display Map (Issue #29)")
 


### PR DESCRIPTION
Closes #83.

## Decision
Per the issue's **revised recommendation** (2026-06-17), this implements **option 2 (independent multi-algorithm calibration)**, not option 1. Option 1 (force ensemble on for 2+ algorithms) would reverse the algorithms-first model the package author established in #65 / PR #66+#67: *select one or more algorithms → each runs its own calibration; "Combine algorithms?" additionally runs an ensemble.*

## Root cause
PR #66 moved **only the frontend** to algorithms-first UX. The file-transport in `client.js` and `plumber.R` was never updated off the old "per-algorithm files only when ensemble" rule, so selecting 2+ algorithms with ensemble **OFF** silently dropped all but the first uploaded file. (Confirmed independent of #90 earlier — the matrix is present even in this state; the files just never arrived.)

## Changes (the three coordinated parts of option 2)
1. **Transport out** — `client.js`: send per-algorithm `file_<algo>` keys for any vacalibration job with **2+ files**, regardless of `ensemble` (a single file still uses the plain `file` field).
2. **Transport in** — `plumber.R`: save per-algorithm files for **multi-algorithm** vacalibration, regardless of `ensemble`.
3. **Surface all N** — new shared **`build_per_algorithm()`** (utils.R), used by both `run_vacalibration` and `run_pipeline`, populates the per-algorithm breakdown whenever the result has >1 label (was gated on `ensemble_val`). Without this, an ensemble-OFF run reached the backend and ran N calibrations but the UI showed only the first.
4. **Correct labeling** — `JobDetail` now distinguishes a true ensemble run from independent multi-algorithm calibration using the actual `results.ensemble` flag (was inferred from algorithm count, which mislabeled independent runs as "Ensemble Mode").

The backend `vacalibration(ensemble=FALSE)` call already runs N independent calibrations (no "ensemble" row) — verified directly. The demo/sample path already loads per-algorithm sample data, so it benefits too.

## Tests
- `client.test.js`: multi-file vacalibration with ensemble **OFF** now sends `file_interva` + `file_insilicova` (no single-file fallback). Existing single-file→`file` test still passes.
- R suite **section 12d** (real v2.2 run): ensemble-OFF 2-algo has no ensemble row and `build_per_algorithm` surfaces **both** algorithms, each CSMF summing to ~1.
- R suite **section 14c**: `build_per_algorithm` unit tests + wiring guards (both paths call it; gate no longer on `ensemble_val`; plumber transport condition updated).
- `JobDetail.test.js`: indicator keyed on the ensemble flag, distinct "Independent calibration" indicator.
- Frontend **225 pass** (3 pre-existing `integration.test.js` failures unrelated — foreign service on :8000); R full suite **304/304** on vacalibration 2.2; `vite build` clean.

🤖 Generated with [Claude Code](https://claude.com/claude-code)