### PR TITLE
fix: blank home page on direct URL (router basename trailing slash)

### DIFF
--- a/frontend/src/main.basename.test.js
+++ b/frontend/src/main.basename.test.js
@@ -1,0 +1,37 @@
+import { describe, it, expect } from 'vitest'
+import { readFileSync } from 'fs'
+import { resolve, dirname } from 'path'
+import { fileURLToPath } from 'url'
+import { createMemoryRouter } from 'react-router-dom'
+
+const __dir = dirname(fileURLToPath(import.meta.url))
+const mainSrc = readFileSync(resolve(__dir, 'main.jsx'), 'utf-8')
+const basename = mainSrc.match(/basename="([^"]*)"/)?.[1]
+
+describe('Router basename (direct-URL home page bug)', () => {
+  it('main.jsx sets a basename', () => {
+    expect(basename).toBeTruthy()
+  })
+
+  it('basename has no trailing slash (React Router convention)', () => {
+    expect(basename).toBe('/comsa-dashboard')
+  })
+
+  // On basename mismatch the router doesn't return zero matches — it
+  // synthesizes a 404 error state, so assert on state.errors.
+  it('matches the home route when the URL has no trailing slash', () => {
+    const router = createMemoryRouter(
+      [{ path: '/', element: null }],
+      { basename, initialEntries: ['/comsa-dashboard'] }
+    )
+    expect(router.state.errors).toBeNull()
+  })
+
+  it('still matches deep routes like /login', () => {
+    const router = createMemoryRouter(
+      [{ path: '/login', element: null }],
+      { basename, initialEntries: ['/comsa-dashboard/login'] }
+    )
+    expect(router.state.errors).toBeNull()
+  })
+})

--- a/frontend/src/main.jsx
+++ b/frontend/src/main.jsx
@@ -7,7 +7,7 @@ import App from './App.jsx'
 
 createRoot(document.getElementById('root')).render(
   <StrictMode>
-    <BrowserRouter basename="/comsa-dashboard/">
+    <BrowserRouter basename="/comsa-dashboard">
       <AuthProvider>
         <App />
       </AuthProvider>


### PR DESCRIPTION
## Problem
Navigating directly to `https://dev.sites.idies.jhu.edu/comsa-dashboard` (no trailing slash) showed a blank page, while refreshing an already-open page and deep links like `/comsa-dashboard/login` worked.

## Root cause
`main.jsx` set `<BrowserRouter basename="/comsa-dashboard/">` with a trailing slash. React Router's `stripBasename()` requires the pathname to start with the basename, so `/comsa-dashboard` ≠ `/comsa-dashboard/` → no route matches → router renders a synthetic 404 (blank page). Server-side was verified fine (200 + correct index.html for all path variants).

## Fix
Remove the trailing slash: `basename="/comsa-dashboard"`. One-line change.

## Tests
- New `frontend/src/main.basename.test.js` (4 tests): asserts basename has no trailing slash and behaviorally verifies via `createMemoryRouter` that `/comsa-dashboard` and `/comsa-dashboard/login` both resolve with `state.errors === null` (the router synthesizes a 404 match on basename mismatch, so `matches.length` alone is not a valid assertion).
- Full frontend suite: 232/232 pass (integration tests run against real R backend).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Corrected the app’s routing base path to remove an extra trailing slash, improving navigation under the configured subpath.
  * Ensures both the home page and deeper routes continue to load properly when accessed with the base path included.

* **Tests**
  * Added coverage for the routing base path configuration and matching behavior to prevent regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->