### PR TITLE
fix: reject duplicate record IDs before calibration

### DIFF
--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -357,6 +357,24 @@ validate_causes <- function(causes, age_group) {
 # (issue #92)
 assert_all_causes_mapped <- function(input_data, va_broad, age_group) {
   ids <- as.character(input_data$ID)
+
+  # Duplicate record IDs are malformed input: cause_map()'s internal
+  # dcast(ID ~ cause) collapses rows sharing an ID into one, which either
+  # undercounts (silent denominator shrink -> distorted CSMFs) or produces a
+  # multi-cause row that crashes vacalibration with an empty error. The set
+  # comparison below is blind to duplicate-count loss, so reject duplicates up
+  # front. We cannot tell an accidental double-entry (merge would be correct)
+  # from two distinct deaths sharing an ID (merge loses one), so fail loudly and
+  # let the user fix the IDs — same principle as the unrecognized-cause guard.
+  dup_ids <- unique(ids[duplicated(ids)])
+  if (length(dup_ids) > 0) {
+    shown <- paste(utils::head(dup_ids, 5), collapse = ", ")
+    more <- if (length(dup_ids) > 5) sprintf(" (and %d more)", length(dup_ids) - 5) else ""
+    stop(sprintf(
+      "Input contains %d duplicate record ID(s): %s%s. Each record must have a unique ID; duplicate IDs are silently merged during cause mapping, which distorts the calculated CSMFs. Please de-duplicate the IDs and re-upload.",
+      length(dup_ids), shown, more), call. = FALSE)
+  }
+
   mapped_ids <- rownames(va_broad)[rowSums(va_broad) > 0]
   dropped_ids <- setdiff(ids, mapped_ids)
   if (length(dropped_ids) == 0) return(invisible(TRUE))

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -371,7 +371,7 @@ assert_all_causes_mapped <- function(input_data, va_broad, age_group) {
     shown <- paste(utils::head(dup_ids, 5), collapse = ", ")
     more <- if (length(dup_ids) > 5) sprintf(" (and %d more)", length(dup_ids) - 5) else ""
     stop(sprintf(
-      "Input contains %d duplicate record ID(s): %s%s. Each record must have a unique ID; duplicate IDs are silently merged during cause mapping, which distorts the calculated CSMFs. Please de-duplicate the IDs and re-upload.",
+      "Input contains %d duplicate record ID(s): %s%s. Each record must have a unique ID — duplicate IDs can be silently merged during cause mapping, which shrinks the denominator and distorts the calculated CSMFs. Please de-duplicate the IDs and re-upload.",
       length(dup_ids), shown, more), call. = FALSE)
   }
 

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -1591,6 +1591,60 @@ test("processor.R calls assert_all_causes_mapped in the pipeline path (issue #92
      any(grepl("assert_all_causes_mapped", processor_lines)))
 
 # =============================================================================
+# 27. Reject Duplicate Record IDs
+# =============================================================================
+section("27. Reject Duplicate Record IDs")
+
+# cause_map()'s internal dcast(ID ~ cause) collapses rows sharing an ID into ONE
+# row: a same-cause duplicate is undercounted (silent denominator shrink /
+# distorted CSMF) and a different-cause duplicate becomes a multi-cause row that
+# crashes vacalibration with an empty error. assert_all_causes_mapped()'s set
+# comparison is blind to duplicate-count loss, so a duplicate-ID guard must
+# reject it up front — same "fail loudly, never silently shrink the denominator"
+# rule as issue #92.
+
+# (a) specific causes, duplicate ID + SAME cause (silent-undercount path)
+dup_same <- data.frame(ID = c("r1", "r1", "r2", "r3"),
+  cause = c("Prematurity", "Prematurity", "Birth asphyxia", "Neonatal sepsis"),
+  stringsAsFactors = FALSE)
+dup_same_broad <- safe_cause_map(df = fix_causes_for_vacalibration(dup_same), age_group = "neonate")
+err_dup_a <- tryCatch({ assert_all_causes_mapped(dup_same, dup_same_broad, "neonate"); NA_character_ },
+                      error = function(e) conditionMessage(e))
+test("assert_all_causes_mapped errors on a same-cause duplicate ID",
+     is.character(err_dup_a) && !is.na(err_dup_a))
+test("duplicate-ID error names the offending ID and is actionable",
+     is.character(err_dup_a) && grepl("r1", err_dup_a) && grepl("duplicate", err_dup_a, ignore.case = TRUE))
+
+# (b) specific causes, duplicate ID + DIFFERENT cause (empty-crash path)
+dup_diff <- data.frame(ID = c("r1", "r1", "r2", "r3"),
+  cause = c("Prematurity", "Birth asphyxia", "Neonatal sepsis", "Neonatal sepsis"),
+  stringsAsFactors = FALSE)
+dup_diff_broad <- safe_cause_map(df = fix_causes_for_vacalibration(dup_diff), age_group = "neonate")
+err_dup_b <- tryCatch({ assert_all_causes_mapped(dup_diff, dup_diff_broad, "neonate"); NA_character_ },
+                      error = function(e) conditionMessage(e))
+test("assert_all_causes_mapped errors on a different-cause duplicate ID",
+     is.character(err_dup_b) && !is.na(err_dup_b))
+
+# (c) broad-format duplicate ID: build_broad_matrix keeps both rows so the count
+# is correct, but duplicate IDs are still malformed input — reject uniformly so
+# the same file behaves consistently regardless of cause format.
+dup_broad <- data.frame(ID = c("r1", "r1", "r2", "r3"),
+  cause = c("prematurity", "prematurity", "ipre", "sepsis_meningitis_inf"),
+  stringsAsFactors = FALSE)
+err_dup_c <- tryCatch({ assert_all_causes_mapped(dup_broad, build_broad_matrix(dup_broad, "neonate"), "neonate"); NA_character_ },
+                      error = function(e) conditionMessage(e))
+test("assert_all_causes_mapped errors on a duplicate ID in broad-format input",
+     is.character(err_dup_c) && !is.na(err_dup_c))
+
+# (d) regression: unique IDs must still pass (clean data is never rejected)
+uniq_df <- data.frame(ID = c("r1", "r2", "r3", "r4"),
+  cause = c("Prematurity", "Prematurity", "Birth asphyxia", "Neonatal sepsis"),
+  stringsAsFactors = FALSE)
+uniq_broad <- safe_cause_map(df = fix_causes_for_vacalibration(uniq_df), age_group = "neonate")
+test("assert_all_causes_mapped still passes when all IDs are unique",
+     isTRUE(assert_all_causes_mapped(uniq_df, uniq_broad, "neonate")))
+
+# =============================================================================
 # SUMMARY
 # =============================================================================
 cat(sprintf("\n========================================\n"))


### PR DESCRIPTION
## Problem

`vacalibration::cause_map()` reshapes input with `reshape2::dcast(ID ~ cause, fun.aggregate = function(x) as.integer(length(x) > 0))`, which **collapses every row sharing a record ID into one row**. A duplicate ID therefore produces one of two silent failures:

- **Same cause twice** → the death is counted once instead of twice. The denominator shrinks and the reported CSMFs are wrong, with **no error or warning**.
- **Different causes** → the merged row becomes a multi-cause row (`rowSum = 2`), which trips vacalibration's `singlecause.check` and **crashes the job with an empty error message**.

The existing `assert_all_causes_mapped()` guard (issue #92) only compares ID **sets** (`setdiff`), so it is blind to duplicate-count loss and passes this input through.

### Reproduced (vacalibration v2.2, faithful end-to-end)

| Input | Route | Result |
|-------|-------|--------|
| specific causes, dup ID same cause | `safe_cause_map`/dcast | `p_uncalib` prematurity **0.333** vs intended **0.50**, silent (assert PASS) |
| specific causes, dup ID different cause | `safe_cause_map`/dcast | multi-cause row → vacalibration crashes with empty error, assert still PASS |
| broad-format, dup ID | `build_broad_matrix` | count correct, but same file behaves differently by cause-format |

Well-formed data is **not affected** — all 8 bundled sample CSVs have unique IDs, so demos and normal analyses are unchanged. The bug requires a malformed upload with duplicate IDs.

## Fix

Add a duplicate-ID guard at the top of `assert_all_causes_mapped()` (already called on every path that builds `va_broad`: both upload paths in `vacalibration.R` and the pipeline path in `processor.R`). It fails loudly, listing the offending IDs.

Rejecting uniformly — rather than silently de-duplicating — is the only defensible choice: the tool cannot distinguish an accidental double-entry (merge would be correct) from two distinct deaths sharing an ID (merge loses one), so it stops and lets the user decide. This is the same *"never silently shrink the denominator, fail loudly"* principle behind the issue #92 unrecognized-cause guard.

## Tests

New **section 27** in `tests/test_vacalibration_backend.R`: same-cause duplicate, different-cause duplicate, broad-format duplicate, and a unique-ID regression (clean data must still pass). Written test-first (confirmed red), then implemented (green).

Full R suite: **309/309 passing**.

🤖 Generated with [Claude Code](https://claude.com/claude-code)