### PR TITLE
Fix vacalibration package-dataset calibration + pre-submit cause preview

### DIFF
--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -68,6 +68,11 @@ run_vacalibration <- function(job) {
                             length(unique(input_data$cause)), "unique causes"))
       add_log(job$id, paste("Causes:", paste(unique(input_data$cause), collapse = ", ")))
 
+      # Exclude undetermined-cause deaths ("Unspecified") up front, matching
+      # vacalibration::cause_map()'s own behavior, so the #92 guard doesn't
+      # reject them as unmapped (logged loudly, not a silent drop).
+      input_data <- drop_undetermined_causes(input_data, job$id)
+
       if (is_broad_format(input_data$cause, job$age_group)) {
         add_log(job$id, "Causes already in broad format, skipping cause_map()")
         va_broad <- build_broad_matrix(input_data, job$age_group)
@@ -122,6 +127,11 @@ run_vacalibration <- function(job) {
     add_log(job$id, paste("Loaded", nrow(input_data), "records with",
                           length(unique(input_data$cause)), "unique causes"))
     add_log(job$id, paste("Causes:", paste(unique(input_data$cause), collapse = ", ")))
+
+    # Exclude undetermined-cause deaths ("Unspecified") up front, matching
+    # vacalibration::cause_map()'s own behavior, so the #92 guard doesn't
+    # reject them as unmapped (logged loudly, not a silent drop).
+    input_data <- drop_undetermined_causes(input_data, job$id)
 
     if (is_broad_format(input_data$cause, job$age_group)) {
       add_log(job$id, "Causes already in broad format, skipping cause_map()")

--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -72,6 +72,9 @@ run_vacalibration <- function(job) {
       # vacalibration::cause_map()'s own behavior, so the #92 guard doesn't
       # reject them as unmapped (logged loudly, not a silent drop).
       input_data <- drop_undetermined_causes(input_data, job$id)
+      if (nrow(input_data) == 0L) {
+        stop(sprintf("No calibratable records remain in %s after excluding undetermined causes (e.g. 'Unspecified'). Nothing can be calibrated.", basename(fpath)), call. = FALSE)
+      }
 
       if (is_broad_format(input_data$cause, job$age_group)) {
         add_log(job$id, "Causes already in broad format, skipping cause_map()")
@@ -132,6 +135,9 @@ run_vacalibration <- function(job) {
     # vacalibration::cause_map()'s own behavior, so the #92 guard doesn't
     # reject them as unmapped (logged loudly, not a silent drop).
     input_data <- drop_undetermined_causes(input_data, job$id)
+    if (nrow(input_data) == 0L) {
+      stop("No calibratable records remain after excluding undetermined causes (e.g. 'Unspecified'). Every uploaded record had an undetermined cause, so nothing can be calibrated.", call. = FALSE)
+    }
 
     if (is_broad_format(input_data$cause, job$age_group)) {
       add_log(job$id, "Causes already in broad format, skipping cause_map()")

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -190,6 +190,74 @@ drop_undetermined_causes <- function(df, job_id = NULL) {
   df[!is_undet, , drop = FALSE]
 }
 
+# Classify a single cause into its broad category by probing the SAME mapping
+# units the job path uses. Returns the broad cause name, or NA if the cause maps
+# to nothing (unrecognized). cause_map() throws on unrecognized causes, so this
+# probes one cause at a time and treats a throw / all-zero row as unrecognized.
+classify_cause <- function(cause, age_group) {
+  df <- data.frame(ID = "__probe__", cause = cause, stringsAsFactors = FALSE)
+  m <- tryCatch(
+    if (is_broad_format(df$cause, age_group)) build_broad_matrix(df, age_group)
+    else safe_cause_map(fix_causes_for_vacalibration(df), age_group),
+    error = function(e) NULL)
+  if (is.null(m) || !("__probe__" %in% rownames(m))) return(NA_character_)
+  row <- m["__probe__", ]
+  if (sum(row) == 0) return(NA_character_)
+  colnames(m)[which(row == 1)[1]]
+}
+
+# Build a pre-submit mapping report for uploaded data, WITHOUT running MCMC.
+# Mirrors the job path: undetermined causes are excluded (matching cause_map),
+# each remaining unique cause is classified, and unrecognized causes are reported
+# (never silently dropped). See
+# docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
+preview_cause_mapping <- function(input_data, age_group) {
+  if ("cause1" %in% names(input_data) && !"cause" %in% names(input_data)) {
+    names(input_data)[names(input_data) == "cause1"] <- "cause"
+  }
+  if (!all(c("ID", "cause") %in% names(input_data))) {
+    stop("Input must have 'ID' and 'cause' columns (or 'ID' and 'cause1').", call. = FALSE)
+  }
+  input_data$ID <- as.character(input_data$ID)
+  total_records <- nrow(input_data)
+
+  # Undetermined exclusions (dropped by vacalibration::cause_map by design)
+  undet_mask <- tolower(trimws(input_data$cause)) %in% UNDETERMINED_CAUSES
+  undet_tab <- table(input_data$cause[undet_mask])
+  excluded_undetermined <- lapply(names(undet_tab), function(cn)
+    list(cause = cn, count = as.integer(undet_tab[[cn]])))
+
+  kept <- input_data[!undet_mask, , drop = FALSE]
+  counts <- table(kept$cause)
+  expected <- get_broad_causes(age_group)
+
+  mapping <- list()
+  unrecognized <- list()
+  denom <- 0L
+  for (cn in names(counts)) {
+    broad <- classify_cause(cn, age_group)
+    n <- as.integer(counts[[cn]])
+    if (is.na(broad)) {
+      s <- suggest_closest(normalize_cause(cn), expected)
+      unrecognized[[length(unrecognized) + 1L]] <-
+        list(cause = cn, count = n, suggestion = if (is.na(s)) NULL else s)
+    } else {
+      mapping[[length(mapping) + 1L]] <-
+        list(input_cause = cn, broad_cause = broad, count = n)
+      denom <- denom + n
+    }
+  }
+
+  list(
+    total_records = total_records,
+    calibrated_denominator = denom,
+    excluded_undetermined = excluded_undetermined,
+    unrecognized = unrecognized,
+    mapping = mapping,
+    has_errors = length(unrecognized) > 0
+  )
+}
+
 # Safe wrapper around cause_map that handles missing broad cause categories
 # The vacalibration::cause_map function has a bug where it fails if not all
 # 6 broad categories (for neonate) or 9 categories (for child) are present

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -180,12 +180,13 @@ UNDETERMINED_CAUSES <- c("unspecified")
 # error and reject the whole dataset. The exclusion is logged loudly (not a
 # silent drop), so it still honors the no-silent-drop rule from issues #77/#89.
 drop_undetermined_causes <- function(df, job_id = NULL) {
-  is_undet <- tolower(trimws(df$cause)) %in% UNDETERMINED_CAUSES
+  trimmed <- trimws(df$cause)
+  is_undet <- tolower(trimmed) %in% UNDETERMINED_CAUSES
   n <- sum(is_undet)
   if (n > 0 && !is.null(job_id)) {
     add_log(job_id, sprintf(
       "Excluding %d record(s) with an undetermined cause (%s) from calibration, consistent with the vacalibration methodology (these deaths have no assigned cause and cannot be calibrated).",
-      n, paste(sort(unique(df$cause[is_undet])), collapse = ", ")))
+      n, paste(sort(unique(trimmed[is_undet])), collapse = ", ")))
   }
   df[!is_undet, , drop = FALSE]
 }
@@ -221,14 +222,21 @@ preview_cause_mapping <- function(input_data, age_group) {
   input_data$ID <- as.character(input_data$ID)
   total_records <- nrow(input_data)
 
+  # Normalize cause labels for reporting: trim whitespace so "Unspecified" and
+  # "Unspecified " aren't split across buckets, and give NA/blank causes a
+  # visible label so they are reported as unrecognized instead of silently
+  # vanishing (table() drops NA by default). This keeps
+  # total_records == excluded + calibrated + unrecognized.
+  cause_disp <- trimws(input_data$cause)
+  cause_disp[is.na(cause_disp) | cause_disp == ""] <- "(missing)"
+
   # Undetermined exclusions (dropped by vacalibration::cause_map by design)
-  undet_mask <- tolower(trimws(input_data$cause)) %in% UNDETERMINED_CAUSES
-  undet_tab <- table(input_data$cause[undet_mask])
+  undet_mask <- tolower(cause_disp) %in% UNDETERMINED_CAUSES
+  undet_tab <- table(cause_disp[undet_mask])
   excluded_undetermined <- lapply(names(undet_tab), function(cn)
     list(cause = cn, count = as.integer(undet_tab[[cn]])))
 
-  kept <- input_data[!undet_mask, , drop = FALSE]
-  counts <- table(kept$cause)
+  counts <- table(cause_disp[!undet_mask])
   expected <- get_broad_causes(age_group)
 
   mapping <- list()
@@ -307,17 +315,22 @@ safe_cause_map <- function(df, age_group) {
   # Combine with actual data
   df_with_dummies <- rbind(df, dummy_df)
 
-  # Call cause_map. A dummy that is NOT a recognized specific-cause name renames
-  # to NA inside cause_map, model.matrix() drops that column, and cause_map()
-  # throws a cryptic "non-conformable arguments". Translate that into a
-  # developer-facing diagnostic that names the age group and dummies, so the
-  # real cause (a bad dummy) is obvious instead of buried in matrix algebra.
+  # Call cause_map. A dummy (or user cause) that is NOT a recognized specific-cause
+  # name renames to NA inside cause_map, model.matrix() drops that column, and
+  # cause_map() throws a cryptic "non-conformable arguments". Translate ONLY that
+  # specific failure into a developer-facing diagnostic; propagate any other error
+  # unchanged so genuine failures aren't misattributed to the dummies.
   result <- tryCatch(
     vacalibration::cause_map(df = df_with_dummies, age_group = age_group),
-    error = function(e) stop(sprintf(
-      "safe_cause_map internal error: cause_map() failed for age_group='%s' (%s). This usually means a dummy cause is not a recognized specific-cause name for this age group. Dummies: %s",
-      age_group, conditionMessage(e), paste(dummy_causes, collapse = ", ")),
-      call. = FALSE)
+    error = function(e) {
+      if (grepl("non-conformable", conditionMessage(e), fixed = TRUE)) {
+        stop(sprintf(
+          "safe_cause_map internal error: cause_map() failed for age_group='%s' (%s). This usually means a cause is not a recognized specific-cause name for this age group. Dummies: %s",
+          age_group, conditionMessage(e), paste(dummy_causes, collapse = ", ")),
+          call. = FALSE)
+      }
+      stop(e)
+    }
   )
 
   # Remove dummy rows from result

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -167,6 +167,29 @@ fix_causes_for_vacalibration <- function(df) {
   return(df)
 }
 
+# Cause labels for deaths with no determined cause. vacalibration::cause_map()
+# drops "Unspecified" by design (subset(df, cause != "Unspecified")) because
+# these deaths cannot be calibrated, so calibrating the package's own datasets
+# (e.g. comsamoz_CCVAoutput, whose EAVA neonate table has 250 "Unspecified"
+# records) excludes them from the denominator. Matched case-insensitively.
+UNDETERMINED_CAUSES <- c("unspecified")
+
+# Drop records whose cause is an undetermined label (see UNDETERMINED_CAUSES),
+# reproducing what vacalibration::cause_map() does internally. Without this,
+# assert_all_causes_mapped() (issue #92) would flag these intended drops as an
+# error and reject the whole dataset. The exclusion is logged loudly (not a
+# silent drop), so it still honors the no-silent-drop rule from issues #77/#89.
+drop_undetermined_causes <- function(df, job_id = NULL) {
+  is_undet <- tolower(trimws(df$cause)) %in% UNDETERMINED_CAUSES
+  n <- sum(is_undet)
+  if (n > 0 && !is.null(job_id)) {
+    add_log(job_id, sprintf(
+      "Excluding %d record(s) with an undetermined cause (%s) from calibration, consistent with the vacalibration methodology (these deaths have no assigned cause and cannot be calibrated).",
+      n, paste(sort(unique(df$cause[is_undet])), collapse = ", ")))
+  }
+  df[!is_undet, , drop = FALSE]
+}
+
 # Safe wrapper around cause_map that handles missing broad cause categories
 # The vacalibration::cause_map function has a bug where it fails if not all
 # 6 broad categories (for neonate) or 9 categories (for child) are present
@@ -185,14 +208,20 @@ safe_cause_map <- function(df, age_group) {
     )
   } else if (tolower(age_group) == "child") {
     # Child requires: malaria, pneumonia, diarrhea, severe_malnutrition, hiv, injury, other, other_infections, nn_causes
+    # Every dummy MUST be a real child specific-cause name from cause_map()'s
+    # internal lists. An unrecognized dummy renames to NA, model.matrix() drops
+    # that column, and cause_map() crashes with "non-conformable arguments" --
+    # the opposite of what this workaround is for. "diarrhoeal diseases" (British
+    # spelling) and "stroke" replace the previously-invalid "diarrheal diseases"
+    # and "other" (the child map, unlike the neonate map, has no literal "other").
     dummy_causes <- c(
       "malaria",                  # → malaria
       "pneumonia",                # → pneumonia
-      "diarrheal diseases",       # → diarrhea
+      "diarrhoeal diseases",      # → diarrhea
       "severe malnutrition",      # → severe_malnutrition
       "hiv/aids related death",   # → hiv
       "road traffic accident",    # → injury
-      "other",                    # → other
+      "stroke",                   # → other
       "measles",                  # → other_infections
       "congenital malformation"   # → nn_causes
     )
@@ -210,12 +239,34 @@ safe_cause_map <- function(df, age_group) {
   # Combine with actual data
   df_with_dummies <- rbind(df, dummy_df)
 
-  # Call cause_map
-  result <- vacalibration::cause_map(df = df_with_dummies, age_group = age_group)
+  # Call cause_map. A dummy that is NOT a recognized specific-cause name renames
+  # to NA inside cause_map, model.matrix() drops that column, and cause_map()
+  # throws a cryptic "non-conformable arguments". Translate that into a
+  # developer-facing diagnostic that names the age group and dummies, so the
+  # real cause (a bad dummy) is obvious instead of buried in matrix algebra.
+  result <- tryCatch(
+    vacalibration::cause_map(df = df_with_dummies, age_group = age_group),
+    error = function(e) stop(sprintf(
+      "safe_cause_map internal error: cause_map() failed for age_group='%s' (%s). This usually means a dummy cause is not a recognized specific-cause name for this age group. Dummies: %s",
+      age_group, conditionMessage(e), paste(dummy_causes, collapse = ", ")),
+      call. = FALSE)
+  )
 
   # Remove dummy rows from result
   dummy_ids <- dummy_df$ID
   result <- result[!rownames(result) %in% dummy_ids, , drop = FALSE]
+
+  # Post-condition: the dummies exist precisely so every broad category is
+  # present. If one is missing, a dummy silently failed to map (e.g. cause_map
+  # succeeded-but-dropped rather than throwing) -- fail loudly here rather than
+  # letting a short/misshaped matrix reach vacalibration().
+  expected <- get_broad_causes(age_group)
+  missing <- setdiff(expected, colnames(result))
+  if (length(missing) > 0) {
+    stop(sprintf(
+      "safe_cause_map internal error: broad categories missing after mapping for age_group='%s': %s. A dummy cause likely failed to map to its intended category.",
+      age_group, paste(missing, collapse = ", ")), call. = FALSE)
+  }
 
   return(result)
 }

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -409,20 +409,25 @@ function(req) {
   dir.create(tmp_dir, recursive = TRUE, showWarnings = FALSE)
   on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
 
+  # Per-file failures become a per-algorithm error report (not a top-level exit),
+  # so the frontend can render each file's problem in its own panel and, because
+  # the report carries has_errors=TRUE, block submission until it is fixed.
   reports <- list()
   for (algo in names(file_map)) {
     path <- file.path(tmp_dir, paste0(algo, ".csv"))
     if (!save_uploaded_file(file_map[[algo]], path)) {
-      return(list(error = paste("Failed to read uploaded file for:", algo)))
+      reports[[algo]] <- list(error = paste("Failed to read uploaded file for:", algo), has_errors = TRUE)
+      next
     }
     df <- tryCatch(read.csv(path, stringsAsFactors = FALSE),
                    error = function(e) NULL)
     if (is.null(df)) {
-      return(list(error = paste("Could not parse CSV for:", algo)))
+      reports[[algo]] <- list(error = paste("Could not parse CSV for:", algo), has_errors = TRUE)
+      next
     }
     reports[[algo]] <- tryCatch(
       preview_cause_mapping(df, age_group),
-      error = function(e) list(error = conditionMessage(e)))
+      error = function(e) list(error = conditionMessage(e), has_errors = TRUE))
   }
   list(reports = reports)
 }

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -385,6 +385,48 @@ function(req) {
   )
 }
 
+#* Preview cause mapping for uploaded file(s) without creating a job
+#* @post /jobs/preview
+function(req) {
+  age_group <- req$args$age_group
+  if (is.null(age_group) || length(age_group) == 0) age_group <- "neonate"
+
+  # Collect uploaded files keyed by algorithm (mirror POST /jobs arg names)
+  file_map <- list(
+    interva     = req$args$file_interva,
+    insilicova  = req$args$file_insilicova,
+    eava        = req$args$file_eava
+  )
+  file_map <- file_map[!vapply(file_map, is.null, logical(1))]
+  if (length(file_map) == 0 && !is.null(req$args$file)) {
+    file_map <- list(uploaded = req$args$file)
+  }
+  if (length(file_map) == 0) {
+    return(list(error = "No file provided for preview"))
+  }
+
+  tmp_dir <- file.path(tempdir(), paste0("preview_", uuid::UUIDgenerate()))
+  dir.create(tmp_dir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+
+  reports <- list()
+  for (algo in names(file_map)) {
+    path <- file.path(tmp_dir, paste0(algo, ".csv"))
+    if (!save_uploaded_file(file_map[[algo]], path)) {
+      return(list(error = paste("Failed to read uploaded file for:", algo)))
+    }
+    df <- tryCatch(read.csv(path, stringsAsFactors = FALSE),
+                   error = function(e) NULL)
+    if (is.null(df)) {
+      return(list(error = paste("Could not parse CSV for:", algo)))
+    }
+    reports[[algo]] <- tryCatch(
+      preview_cause_mapping(df, age_group),
+      error = function(e) list(error = conditionMessage(e)))
+  }
+  list(reports = reports)
+}
+
 #* Get job status
 #* @param job_id:str Job ID
 #* @get /jobs/<job_id>/status

--- a/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
+++ b/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
@@ -1,0 +1,584 @@
+# Cause-Mapping Preview Implementation Plan
+
+> **For agentic workers:** REQUIRED SUB-SKILL: Use superpowers:subagent-driven-development (recommended) or superpowers:executing-plans to implement this plan task-by-task. Steps use checkbox (`- [ ]`) syntax for tracking.
+
+**Goal:** Show the user, before job submission, how their uploaded causes map to broad categories — which records are excluded, which causes are unrecognized (with suggestions), and the true calibrated denominator — using the same backend R helpers the real job uses.
+
+**Architecture:** A backend R helper (`preview_cause_mapping`) classifies each unique uploaded cause by probing the existing mapping units, and returns a plain report. A thin `POST /jobs/preview` endpoint runs it per uploaded file (no job row, no MCMC). The frontend calls it on file attach and renders a per-algorithm preview panel that blocks Submit on unrecognized causes and warns on undetermined exclusions.
+
+**Tech Stack:** R (plumber), React (vitest), existing helpers in `backend/jobs/utils.R`.
+
+## Global Constraints
+
+- Simplest code and structure; no over-engineering; no feature creep (per CLAUDE.md).
+- The frontend must NOT re-implement cause mapping — all mapping comes from the backend.
+- Never silently drop records: undetermined exclusions and unrecognized causes must both be surfaced.
+- `UNDETERMINED_CAUSES <- c("unspecified")` (case-insensitive) is the undetermined label set.
+- Neonate broad causes: `congenital_malformation, pneumonia, sepsis_meningitis_inf, ipre, other, prematurity`. Child: `malaria, pneumonia, diarrhea, severe_malnutrition, hiv, injury, other, other_infections, nn_causes`.
+
+---
+
+### Task 1: Backend cause classification + preview report
+
+**Files:**
+- Modify: `backend/jobs/utils.R` (add `classify_cause`, `preview_cause_mapping` near the other cause helpers)
+- Test: `tests/test_vacalibration_backend.R` (new section "2e", runs in `--input-only`)
+
+**Interfaces:**
+- Consumes (existing): `UNDETERMINED_CAUSES`, `is_broad_format`, `build_broad_matrix`, `safe_cause_map`, `fix_causes_for_vacalibration`, `get_broad_causes`, `normalize_cause`, `suggest_closest`.
+- Produces:
+  - `classify_cause(cause, age_group)` → broad cause name (chr) or `NA_character_`.
+  - `preview_cause_mapping(input_data, age_group)` → list with fields: `total_records` (int), `calibrated_denominator` (int), `excluded_undetermined` (list of `{cause, count}`), `unrecognized` (list of `{cause, count, suggestion}`; `suggestion` is chr or `NULL`), `mapping` (list of `{input_cause, broad_cause, count}`), `has_errors` (logical).
+
+- [ ] **Step 1: Write the failing tests**
+
+Add before the `# 3. INPUT DATA VALIDATION -- Backend RDS sample data` section header:
+
+```r
+# =============================================================================
+# 2e. INPUT DATA VALIDATION -- preview_cause_mapping report
+# =============================================================================
+section("2e. preview_cause_mapping report")
+
+# EAVA neonate package data: 250 Unspecified excluded, rest recognized.
+eava_prev <- as.data.frame(comsamoz_CCVAoutput$neonate$eava)
+eava_prev$ID <- as.character(eava_prev$ID)
+rep_eava <- preview_cause_mapping(eava_prev, "neonate")
+test("preview: total_records is full upload count", rep_eava$total_records == 1190)
+test("preview: 250 Unspecified excluded",
+     length(rep_eava$excluded_undetermined) == 1 &&
+     rep_eava$excluded_undetermined[[1]]$cause == "Unspecified" &&
+     rep_eava$excluded_undetermined[[1]]$count == 250)
+test("preview: no unrecognized causes in clean package data",
+     length(rep_eava$unrecognized) == 0 && isFALSE(rep_eava$has_errors))
+test("preview: calibrated denominator excludes Unspecified (940)",
+     rep_eava$calibrated_denominator == 940)
+test("preview: mapping rows sum to the calibrated denominator",
+     sum(vapply(rep_eava$mapping, function(m) m$count, integer(1))) == 940)
+
+# A deliberately misspelled cause must be flagged unrecognized with a suggestion.
+bad_df <- data.frame(ID = as.character(1:5),
+                     cause = c("Prematurity", "Pnemonia", "Pnemonia", "Neonatal sepsis", "Birth asphyxia"),
+                     stringsAsFactors = FALSE)
+rep_bad <- preview_cause_mapping(bad_df, "neonate")
+test("preview: misspelled cause is unrecognized and blocks (has_errors)",
+     rep_bad$has_errors &&
+     any(vapply(rep_bad$unrecognized, function(u) u$cause == "Pnemonia" && u$count == 2, logical(1))))
+test("preview: unrecognized cause carries a spelling suggestion",
+     any(vapply(rep_bad$unrecognized,
+                function(u) u$cause == "Pnemonia" && !is.null(u$suggestion) && nzchar(u$suggestion),
+                logical(1))))
+
+# Consistency: preview's recognized denominator == job-path mapped rows, for
+# every bundled dataset (both age groups, all algorithms). This is the anti-drift
+# guarantee: the preview must agree with what the real job will calibrate.
+for (age in c("neonate", "child")) {
+  for (alg in c("interva", "insilicova", "eava")) {
+    d <- as.data.frame(comsamoz_CCVAoutput[[age]][[alg]])
+    if ("cause1" %in% names(d) && !"cause" %in% names(d)) names(d)[names(d) == "cause1"] <- "cause"
+    d$ID <- as.character(d$ID)
+    rep <- preview_cause_mapping(d, age)
+    dropped <- drop_undetermined_causes(d)
+    vb <- if (is_broad_format(dropped$cause, age)) build_broad_matrix(dropped, age)
+          else safe_cause_map(fix_causes_for_vacalibration(dropped), age)
+    job_denom <- sum(rowSums(vb) > 0)
+    test(sprintf("preview denominator matches job path for %s/%s", age, alg),
+         rep$calibrated_denominator == job_denom)
+  }
+}
+```
+
+- [ ] **Step 2: Run the tests to verify they fail**
+
+Run: `cd /Users/ericliu/projects5/comsa_dashboard && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"`
+Expected: FAIL — `could not find function "preview_cause_mapping"`.
+
+- [ ] **Step 3: Implement the helpers**
+
+In `backend/jobs/utils.R`, after `drop_undetermined_causes` (and before `safe_cause_map`), add:
+
+```r
+# Classify a single cause into its broad category by probing the SAME mapping
+# units the job path uses. Returns the broad cause name, or NA if the cause maps
+# to nothing (unrecognized). cause_map() throws on unrecognized causes, so this
+# probes one cause at a time and treats a throw / all-zero row as unrecognized.
+classify_cause <- function(cause, age_group) {
+  df <- data.frame(ID = "__probe__", cause = cause, stringsAsFactors = FALSE)
+  m <- tryCatch(
+    if (is_broad_format(df$cause, age_group)) build_broad_matrix(df, age_group)
+    else safe_cause_map(fix_causes_for_vacalibration(df), age_group),
+    error = function(e) NULL)
+  if (is.null(m) || !("__probe__" %in% rownames(m))) return(NA_character_)
+  row <- m["__probe__", ]
+  if (sum(row) == 0) return(NA_character_)
+  colnames(m)[which(row == 1)[1]]
+}
+
+# Build a pre-submit mapping report for uploaded data, WITHOUT running MCMC.
+# Mirrors the job path: undetermined causes are excluded (matching cause_map),
+# each remaining unique cause is classified, and unrecognized causes are reported
+# (never silently dropped). See docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
+preview_cause_mapping <- function(input_data, age_group) {
+  if ("cause1" %in% names(input_data) && !"cause" %in% names(input_data)) {
+    names(input_data)[names(input_data) == "cause1"] <- "cause"
+  }
+  if (!all(c("ID", "cause") %in% names(input_data))) {
+    stop("Input must have 'ID' and 'cause' columns (or 'ID' and 'cause1').", call. = FALSE)
+  }
+  input_data$ID <- as.character(input_data$ID)
+  total_records <- nrow(input_data)
+
+  # Undetermined exclusions (dropped by vacalibration::cause_map by design)
+  undet_mask <- tolower(trimws(input_data$cause)) %in% UNDETERMINED_CAUSES
+  undet_tab <- table(input_data$cause[undet_mask])
+  excluded_undetermined <- lapply(names(undet_tab), function(cn)
+    list(cause = cn, count = as.integer(undet_tab[[cn]])))
+
+  kept <- input_data[!undet_mask, , drop = FALSE]
+  counts <- table(kept$cause)
+  expected <- get_broad_causes(age_group)
+
+  mapping <- list()
+  unrecognized <- list()
+  denom <- 0L
+  for (cn in names(counts)) {
+    broad <- classify_cause(cn, age_group)
+    n <- as.integer(counts[[cn]])
+    if (is.na(broad)) {
+      s <- suggest_closest(normalize_cause(cn), expected)
+      unrecognized[[length(unrecognized) + 1L]] <-
+        list(cause = cn, count = n, suggestion = if (is.na(s)) NULL else s)
+    } else {
+      mapping[[length(mapping) + 1L]] <-
+        list(input_cause = cn, broad_cause = broad, count = n)
+      denom <- denom + n
+    }
+  }
+
+  list(
+    total_records = total_records,
+    calibrated_denominator = denom,
+    excluded_undetermined = excluded_undetermined,
+    unrecognized = unrecognized,
+    mapping = mapping,
+    has_errors = length(unrecognized) > 0
+  )
+}
+```
+
+- [ ] **Step 4: Run the tests to verify they pass**
+
+Run: `cd /Users/ericliu/projects5/comsa_dashboard && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"; echo "---"; Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "Tests: "`
+Expected: all `2e.` lines PASS; overall `Failed: 0`.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add backend/jobs/utils.R tests/test_vacalibration_backend.R
+git commit -m "feat: preview_cause_mapping report helper for pre-submit cause preview"
+```
+
+---
+
+### Task 2: Backend POST /jobs/preview endpoint
+
+**Files:**
+- Modify: `backend/plumber.R` (add endpoint after `POST /jobs`, before `GET /jobs/<job_id>/status`)
+
+**Interfaces:**
+- Consumes: `preview_cause_mapping` (Task 1), `save_uploaded_file` (existing, `backend/plumber.R:19`).
+- Produces: `POST /jobs/preview` → JSON `{ reports: { <algo>: <report> } }`, or `{ error: <msg> }`. Accepts the same multipart args as `POST /jobs`: `age_group`, and `file` (single) or `file_interva`/`file_insilicova`/`file_eava` (multi).
+
+- [ ] **Step 1: Add the endpoint**
+
+In `backend/plumber.R`, immediately before the `#* Get job status` block, add:
+
+```r
+#* Preview cause mapping for uploaded file(s) without creating a job
+#* @post /jobs/preview
+function(req) {
+  age_group <- req$args$age_group
+  if (is.null(age_group) || length(age_group) == 0) age_group <- "neonate"
+
+  # Collect uploaded files keyed by algorithm (mirror POST /jobs arg names)
+  file_map <- list(
+    interva     = req$args$file_interva,
+    insilicova  = req$args$file_insilicova,
+    eava        = req$args$file_eava
+  )
+  file_map <- file_map[!vapply(file_map, is.null, logical(1))]
+  if (length(file_map) == 0 && !is.null(req$args$file)) {
+    file_map <- list(uploaded = req$args$file)
+  }
+  if (length(file_map) == 0) {
+    return(list(error = "No file provided for preview"))
+  }
+
+  tmp_dir <- file.path(tempdir(), paste0("preview_", uuid::UUIDgenerate()))
+  dir.create(tmp_dir, recursive = TRUE, showWarnings = FALSE)
+  on.exit(unlink(tmp_dir, recursive = TRUE), add = TRUE)
+
+  reports <- list()
+  for (algo in names(file_map)) {
+    path <- file.path(tmp_dir, paste0(algo, ".csv"))
+    if (!save_uploaded_file(file_map[[algo]], path)) {
+      return(list(error = paste("Failed to read uploaded file for:", algo)))
+    }
+    df <- tryCatch(read.csv(path, stringsAsFactors = FALSE),
+                   error = function(e) NULL)
+    if (is.null(df)) {
+      return(list(error = paste("Could not parse CSV for:", algo)))
+    }
+    reports[[algo]] <- tryCatch(
+      preview_cause_mapping(df, age_group),
+      error = function(e) list(error = conditionMessage(e)))
+  }
+  list(reports = reports)
+}
+```
+
+- [ ] **Step 2: Restart backend and verify with curl**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+lsof -ti:8000 | xargs kill 2>/dev/null; sleep 1
+(cd backend && Rscript run.R > /tmp/comsa_backend.log 2>&1 &); sleep 6
+curl -s -F "age_group=neonate" \
+  -F "file=@frontend/public/sample_eava_neonate.csv" \
+  http://localhost:8000/jobs/preview | head -c 600
+```
+Expected: JSON containing `"reports"` → `"uploaded"` → `total_records`, `calibrated_denominator`, `mapping`. (The frontend sample is already scrubbed of Unspecified, so `excluded_undetermined` is `[]` and `has_errors` is `false`.) If the response is `{"error":"Missing or invalid Authorization header"}`, the server has grace period off — re-run with a token from `POST /auth/login`.
+
+- [ ] **Step 3: Verify undetermined exclusion path via curl**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+printf 'ID,cause\n1,Prematurity\n2,Unspecified\n3,Neonatal sepsis\n' > /tmp/prev_unspec.csv
+curl -s -F "age_group=neonate" -F "file=@/tmp/prev_unspec.csv" \
+  http://localhost:8000/jobs/preview
+```
+Expected: `excluded_undetermined` lists `Unspecified` count 1; `calibrated_denominator` is 2; `has_errors` false.
+
+- [ ] **Step 4: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add backend/plumber.R
+git commit -m "feat: POST /jobs/preview endpoint for pre-submit cause mapping"
+```
+
+---
+
+### Task 3: Frontend API client previewMapping
+
+**Files:**
+- Modify: `frontend/src/api/client.js` (add `previewMapping`)
+- Test: `frontend/src/api/client.test.js` (add a case)
+
+**Interfaces:**
+- Consumes: `POST /jobs/preview`, existing `API_BASE`, `fetchJson` pattern, existing `submitJob` FormData convention (`file_<algo>` for multi, `file` for single).
+- Produces: `previewMapping({ uploads, ageGroup })` → resolves to `{ reports: { <algo>: report } }`. `uploads` is the JobForm array `[{ algorithm, file }]`.
+
+- [ ] **Step 1: Write the failing test**
+
+In `frontend/src/api/client.test.js`, add:
+
+```js
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { previewMapping } from './client';
+
+describe('previewMapping', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('posts one file per algorithm and returns reports', async () => {
+    const fetchMock = vi.spyOn(global, 'fetch').mockResolvedValue({
+      ok: true,
+      json: async () => ({ reports: { interva: { total_records: 3, has_errors: false } } }),
+    });
+    const file = new File(['ID,cause\n1,Prematurity\n'], 'interva.csv', { type: 'text/csv' });
+    const res = await previewMapping({
+      uploads: [{ algorithm: 'InterVA', file }],
+      ageGroup: 'neonate',
+    });
+    expect(res.reports.interva.total_records).toBe(3);
+    const [url, opts] = fetchMock.mock.calls[0];
+    expect(url).toContain('/jobs/preview');
+    expect(opts.method).toBe('POST');
+    expect(opts.body.get('file_interva')).toBeInstanceOf(File);
+    expect(opts.body.get('age_group')).toBe('neonate');
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/api/client.test.js -t previewMapping`
+Expected: FAIL — `previewMapping is not a function` / import error.
+
+- [ ] **Step 3: Implement previewMapping**
+
+In `frontend/src/api/client.js`, add (mirroring `submitJob`'s FormData convention):
+
+```js
+export async function previewMapping({ uploads, ageGroup }) {
+  const formData = new FormData();
+  formData.append('age_group', ageGroup);
+  const withFiles = uploads.filter((u) => u.file && u.algorithm);
+  if (withFiles.length === 1) {
+    formData.append('file', withFiles[0].file);
+    formData.append(`file_${withFiles[0].algorithm.toLowerCase()}`, withFiles[0].file);
+  } else {
+    withFiles.forEach((u) => {
+      formData.append(`file_${u.algorithm.toLowerCase()}`, u.file);
+    });
+  }
+  return fetchJson(`${API_BASE}/jobs/preview`, { method: 'POST', body: formData });
+}
+```
+
+Note: the single-file branch appends BOTH `file` and `file_<algo>` so the endpoint keys the report by the algorithm name in both single and multi cases.
+
+- [ ] **Step 4: Run the test to verify it passes**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/api/client.test.js -t previewMapping`
+Expected: PASS.
+
+- [ ] **Step 5: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add frontend/src/api/client.js frontend/src/api/client.test.js
+git commit -m "feat: previewMapping API client for cause preview"
+```
+
+---
+
+### Task 4: Frontend CausePreview panel + JobForm integration
+
+**Files:**
+- Create: `frontend/src/components/CausePreview.jsx`
+- Create: `frontend/src/components/CausePreview.test.jsx`
+- Modify: `frontend/src/components/JobForm.jsx` (fetch preview on file attach; block Submit on `has_errors`)
+
+**Interfaces:**
+- Consumes: `previewMapping` (Task 3), report shape from Task 1.
+- Produces: `CausePreview({ report, algorithmLabel })` React component. JobForm holds `previewReports` (map algo→report) and `previewHasErrors` (bool) state; Submit disabled when `previewHasErrors`.
+
+- [ ] **Step 1: Write the failing test for CausePreview**
+
+Create `frontend/src/components/CausePreview.test.jsx`:
+
+```jsx
+import { describe, it, expect } from 'vitest';
+import { render, screen } from '@testing-library/react';
+import CausePreview from './CausePreview';
+
+describe('CausePreview', () => {
+  it('shows denominator headline and excluded warning', () => {
+    render(<CausePreview algorithmLabel="EAVA" report={{
+      total_records: 1190, calibrated_denominator: 940,
+      excluded_undetermined: [{ cause: 'Unspecified', count: 250 }],
+      unrecognized: [], mapping: [{ input_cause: 'Preterm', broad_cause: 'prematurity', count: 164 }],
+      has_errors: false,
+    }} />);
+    expect(screen.getByText(/940 of 1190/)).toBeInTheDocument();
+    expect(screen.getByText(/250/)).toBeInTheDocument();
+    expect(screen.getByText(/Unspecified/)).toBeInTheDocument();
+  });
+
+  it('shows unrecognized causes with suggestion as an error', () => {
+    render(<CausePreview algorithmLabel="InterVA" report={{
+      total_records: 5, calibrated_denominator: 3,
+      excluded_undetermined: [],
+      unrecognized: [{ cause: 'Pnemonia', count: 2, suggestion: 'pneumonia' }],
+      mapping: [], has_errors: true,
+    }} />);
+    expect(screen.getByText(/Pnemonia/)).toBeInTheDocument();
+    expect(screen.getByText(/pneumonia/)).toBeInTheDocument();
+    expect(screen.getByText(/unrecognized/i)).toBeInTheDocument();
+  });
+});
+```
+
+- [ ] **Step 2: Run the test to verify it fails**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/components/CausePreview.test.jsx`
+Expected: FAIL — cannot resolve `./CausePreview`.
+
+- [ ] **Step 3: Implement CausePreview**
+
+Create `frontend/src/components/CausePreview.jsx`:
+
+```jsx
+// Renders the backend's cause-mapping report for one algorithm. Purely
+// presentational — all mapping decisions come from the backend report.
+export default function CausePreview({ report, algorithmLabel }) {
+  if (!report) return null;
+  if (report.error) {
+    return <div className="cause-preview error" role="alert">{algorithmLabel}: {report.error}</div>;
+  }
+  const { total_records, calibrated_denominator, excluded_undetermined = [],
+          unrecognized = [], mapping = [] } = report;
+  return (
+    <div className={`cause-preview${unrecognized.length ? ' has-errors' : ''}`}>
+      <p className="cause-preview-headline">
+        <strong>{algorithmLabel}:</strong> {calibrated_denominator} of {total_records} records will be calibrated.
+      </p>
+
+      {unrecognized.length > 0 && (
+        <div className="cause-preview-unrecognized" role="alert">
+          <p>{unrecognized.length} unrecognized cause(s) — fix these before submitting:</p>
+          <ul>
+            {unrecognized.map((u) => (
+              <li key={u.cause}>
+                “{u.cause}” ({u.count} records)
+                {u.suggestion ? <> — did you mean <em>{u.suggestion}</em>?</> : <> — no close match; relabel to a supported cause.</>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {excluded_undetermined.length > 0 && (
+        <p className="cause-preview-excluded" role="status">
+          Excluded (undetermined cause, per vacalibration methodology):{' '}
+          {excluded_undetermined.map((e) => `${e.cause} (${e.count})`).join(', ')}.
+        </p>
+      )}
+
+      {mapping.length > 0 && (
+        <table className="cause-preview-table">
+          <thead><tr><th>Your cause</th><th>Maps to</th><th>Records</th></tr></thead>
+          <tbody>
+            {mapping.map((m) => (
+              <tr key={m.input_cause}>
+                <td>{m.input_cause}</td><td>{m.broad_cause}</td><td>{m.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}
+```
+
+- [ ] **Step 4: Run the CausePreview test to verify it passes**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/components/CausePreview.test.jsx`
+Expected: PASS (both cases).
+
+- [ ] **Step 5: Write the failing JobForm integration test**
+
+Create `frontend/src/components/JobForm.preview.behavior.test.jsx`:
+
+```jsx
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+import JobForm from './JobForm';
+import * as client from '../api/client';
+
+describe('JobForm cause preview', () => {
+  beforeEach(() => { vi.restoreAllMocks(); });
+
+  it('disables Submit when the preview reports unrecognized causes', async () => {
+    vi.spyOn(client, 'previewMapping').mockResolvedValue({
+      reports: { interva: {
+        total_records: 5, calibrated_denominator: 3, excluded_undetermined: [],
+        unrecognized: [{ cause: 'Pnemonia', count: 2, suggestion: 'pneumonia' }],
+        mapping: [], has_errors: true,
+      } },
+    });
+    render(<JobForm onJobCreated={() => {}} />);
+    const file = new File(['ID,cause\n1,Pnemonia\n'], 'interva.csv', { type: 'text/csv' });
+    const input = document.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [file] } });
+    await waitFor(() => expect(screen.getByText(/Pnemonia/)).toBeInTheDocument());
+    expect(screen.getByRole('button', { name: /submit|calibrat|run/i })).toBeDisabled();
+  });
+});
+```
+
+Adjust the Submit-button name regex to the actual button label in `JobForm.jsx` before running.
+
+- [ ] **Step 6: Run it to verify it fails**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/components/JobForm.preview.behavior.test.jsx`
+Expected: FAIL — preview not wired; Submit still enabled.
+
+- [ ] **Step 7: Wire preview into JobForm**
+
+In `frontend/src/components/JobForm.jsx`:
+
+1. Import at top: `import CausePreview from './CausePreview';` and add `previewMapping` to the existing `../api/client` import.
+2. Add state near the other `useState` calls (around line 44):
+
+```jsx
+  const [previewReports, setPreviewReports] = useState({});
+  const previewHasErrors = Object.values(previewReports).some((r) => r && r.has_errors);
+```
+
+3. After `uploads`/`ageGroup` are defined, add an effect that fetches the preview whenever attached files or age group change:
+
+```jsx
+  useEffect(() => {
+    const withFiles = uploads.filter((u) => u.file && u.algorithm);
+    if (withFiles.length === 0) { setPreviewReports({}); return; }
+    let cancelled = false;
+    previewMapping({ uploads: withFiles, ageGroup })
+      .then((res) => { if (!cancelled) setPreviewReports(res.reports || {}); })
+      .catch(() => { if (!cancelled) setPreviewReports({}); });
+    return () => { cancelled = true; };
+  }, [uploads, ageGroup]);
+```
+
+4. Render the panels below the upload inputs (near the supported-causes hint, ~line 326):
+
+```jsx
+          {Object.entries(previewReports).map(([algo, report]) => (
+            <CausePreview key={algo} report={report}
+              algorithmLabel={algo.charAt(0).toUpperCase() + algo.slice(1)} />
+          ))}
+```
+
+5. Disable Submit when the preview has errors. Find the submit `<button>` and add `previewHasErrors` to its `disabled` expression, e.g. `disabled={loading || algorithms.length === 0 || previewHasErrors}`.
+
+- [ ] **Step 8: Run the JobForm test and the full frontend suite**
+
+Run: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run src/components/JobForm.preview.behavior.test.jsx src/components/CausePreview.test.jsx`
+Expected: PASS.
+Then: `cd frontend && VITE_API_BASE=http://localhost:8001 npx vitest run`
+Expected: whole suite green (no regressions in existing JobForm tests).
+
+- [ ] **Step 9: Commit**
+
+```bash
+cd /Users/ericliu/projects5/comsa_dashboard
+git add frontend/src/components/CausePreview.jsx frontend/src/components/CausePreview.test.jsx \
+        frontend/src/components/JobForm.jsx frontend/src/components/JobForm.preview.behavior.test.jsx
+git commit -m "feat: pre-submit cause-mapping preview panel in JobForm"
+```
+
+---
+
+## Self-Review
+
+**Spec coverage:**
+- Backend helper reusing existing units → Task 1 (`preview_cause_mapping`, `classify_cause`). ✓
+- Report fields (`total_records`, `calibrated_denominator`, `excluded_undetermined`, `unrecognized`+suggestion, `mapping`, `has_errors`) → Task 1 return value + tests. ✓
+- `POST /jobs/preview`, same multipart/auth, no job/DB/MCMC → Task 2. ✓
+- Frontend `previewMapping` + auto-fetch on attach → Tasks 3, 4 (Step 7.3). ✓
+- Block on unrecognized, warn on excluded → Task 4 (CausePreview + `previewHasErrors`). ✓
+- Anti-drift consistency test → Task 1 Step 1 (preview denominator == job path). ✓
+- Testing (backend report, misspelling, consistency; frontend render/block/warn) → Tasks 1, 4. ✓
+
+**Placeholder scan:** none — all steps contain concrete code/commands. The two "adjust to actual" notes (Submit-button regex in Task 4 Step 5; auth token in Task 2 Step 2) are explicit verification adjustments, not deferred work.
+
+**Type consistency:** report field names identical across Task 1 (producer), Task 4 (consumer), and all tests. `previewMapping({ uploads, ageGroup })` signature identical in Task 3 (def) and Task 4 (call). `classify_cause`/`preview_cause_mapping` names consistent throughout.
+
+## Out of scope
+- No client-side cause mapping.
+- No change to calibration algorithm/result shape.
+- No refactor of `run_vacalibration`'s mapping path.
+- Deleting the frontend's hardcoded `SUPPORTED_CAUSES` list (deferred; the dynamic preview supersedes it visually once a file is chosen).

--- a/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
+++ b/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
@@ -90,7 +90,7 @@ for (age in c("neonate", "child")) {
 
 - [ ] **Step 2: Run the tests to verify they fail**
 
-Run: `cd /Users/ericliu/projects5/comsa_dashboard && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"`
+Run: `cd "$(git rev-parse --show-toplevel)" && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"`
 Expected: FAIL — `could not find function "preview_cause_mapping"`.
 
 - [ ] **Step 3: Implement the helpers**
@@ -168,13 +168,13 @@ preview_cause_mapping <- function(input_data, age_group) {
 
 - [ ] **Step 4: Run the tests to verify they pass**
 
-Run: `cd /Users/ericliu/projects5/comsa_dashboard && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"; echo "---"; Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "Tests: "`
+Run: `cd "$(git rev-parse --show-toplevel)" && Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "2e\.|preview|FAIL"; echo "---"; Rscript tests/test_vacalibration_backend.R --input-only 2>&1 | grep -E "Tests: "`
 Expected: all `2e.` lines PASS; overall `Failed: 0`.
 
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 git add backend/jobs/utils.R tests/test_vacalibration_backend.R
 git commit -m "feat: preview_cause_mapping report helper for pre-submit cause preview"
 ```
@@ -241,7 +241,7 @@ function(req) {
 - [ ] **Step 2: Restart backend and verify with curl**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 lsof -ti:8000 | xargs kill 2>/dev/null; sleep 1
 (cd backend && Rscript run.R > /tmp/comsa_backend.log 2>&1 &); sleep 6
 curl -s -F "age_group=neonate" \
@@ -253,7 +253,7 @@ Expected: JSON containing `"reports"` → `"uploaded"` → `total_records`, `cal
 - [ ] **Step 3: Verify undetermined exclusion path via curl**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 printf 'ID,cause\n1,Prematurity\n2,Unspecified\n3,Neonatal sepsis\n' > /tmp/prev_unspec.csv
 curl -s -F "age_group=neonate" -F "file=@/tmp/prev_unspec.csv" \
   http://localhost:8000/jobs/preview
@@ -263,7 +263,7 @@ Expected: `excluded_undetermined` lists `Unspecified` count 1; `calibrated_denom
 - [ ] **Step 4: Commit**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 git add backend/plumber.R
 git commit -m "feat: POST /jobs/preview endpoint for pre-submit cause mapping"
 ```
@@ -347,7 +347,7 @@ Expected: PASS.
 - [ ] **Step 5: Commit**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 git add frontend/src/api/client.js frontend/src/api/client.test.js
 git commit -m "feat: previewMapping API client for cause preview"
 ```
@@ -554,7 +554,7 @@ Expected: whole suite green (no regressions in existing JobForm tests).
 - [ ] **Step 9: Commit**
 
 ```bash
-cd /Users/ericliu/projects5/comsa_dashboard
+cd "$(git rev-parse --show-toplevel)"
 git add frontend/src/components/CausePreview.jsx frontend/src/components/CausePreview.test.jsx \
         frontend/src/components/JobForm.jsx frontend/src/components/JobForm.preview.behavior.test.jsx
 git commit -m "feat: pre-submit cause-mapping preview panel in JobForm"

--- a/docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
+++ b/docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
@@ -1,0 +1,95 @@
+# Pre-submit cause-mapping preview
+
+Date: 2026-07-22
+Status: Approved (design)
+
+## Problem
+
+Uploading the vacalibration package's own bundled datasets failed only *after*
+job submission, with errors buried in the job log (e.g. EAVA neonate's 250
+"Unspecified" records tripping the `assert_all_causes_mapped` guard). Users had
+no way to see, before running, how their causes map to broad categories, which
+records will be excluded, or the true calibrated denominator. The frontend only
+showed a static, hardcoded `SUPPORTED_CAUSES` list (a duplicate of the backend
+broad-cause list) and never inspected the uploaded file.
+
+## Goal
+
+Show the user, before they submit, exactly how their uploaded causes will be
+handled: each cause → its broad category, which records are excluded (and why),
+which causes are unrecognized (with spelling suggestions), and the number of
+records that will actually be calibrated. Block submission on genuine errors;
+warn but allow on expected exclusions.
+
+## Principle
+
+The frontend never maps causes itself. It asks the backend, which uses the SAME
+R helpers the real calibration job uses. Single source of truth — no fourth copy
+of the cause taxonomy.
+
+## Backend
+
+### Helper: `preview_cause_mapping(input_data, age_group)` (`backend/jobs/utils.R`)
+
+Reuses existing units — `drop_undetermined_causes`, `is_broad_format`,
+`build_broad_matrix` / `safe_cause_map`, and `suggest_closest`. Runs the mapping
+only (no MCMC, no DB). Returns a list:
+
+- `total_records` — integer, rows in the uploaded file
+- `calibrated_denominator` — integer, records that map to a broad cause
+- `excluded_undetermined` — list of `{cause, count}` (the "Unspecified"-type drops)
+- `unrecognized` — list of `{cause, count, suggestion}` (causes mapping to nothing;
+  `suggestion` is the closest broad cause via `suggest_closest`, or null)
+- `mapping` — list of `{input_cause, broad_cause, count}` for recognized causes
+- `has_errors` — boolean, `length(unrecognized) > 0`
+
+"Unrecognized" = a cause that is neither an undetermined label nor maps to any
+broad category (i.e. would be dropped by `assert_all_causes_mapped` for a reason
+other than being undetermined).
+
+### Endpoint: `POST /jobs/preview` (`backend/plumber.R`)
+
+- Same multipart shape and auth as `POST /jobs` (one CSV per algorithm).
+- Applies the same `cause1`→`cause` rename and `ID`/`cause` column check as the
+  job path; on a bad file, returns a structured error (not a 500).
+- Runs `preview_cause_mapping` per file. Returns JSON: `{ reports: { <algo>: <report> } }`.
+- Creates NO job row, writes NO DB record, runs NO MCMC.
+
+## Frontend (`JobForm.jsx`, `api/client.js`)
+
+- `api/client.js`: add `previewMapping(files, ageGroup)` calling `POST /jobs/preview`.
+- On file attach (automatically, per algorithm), call `previewMapping` and render
+  a preview panel per algorithm:
+  - Headline: e.g. "940 of 1190 records will be calibrated; 250 'Unspecified' excluded."
+  - Table: `Your cause | Maps to | Records`.
+  - Unrecognized causes: red row with suggestion ("did you mean 'pneumonia'?");
+    their presence **disables Submit**.
+  - Undetermined exclusions: amber note; Submit stays enabled.
+- The dynamic preview replaces the static supported-cause hint once a file is
+  chosen. (Optional cleanup: endpoint returns the supported-cause list so the
+  hardcoded `SUPPORTED_CAUSES` duplicate can be deleted — deferred unless trivial.)
+
+## Anti-drift guarantee
+
+`run_vacalibration`'s mapping hot path is left untouched (now covered by the
+golden-dataset contract test). Instead, a test asserts `preview_cause_mapping`
+produces the SAME broad matrix as the job path for every bundled dataset — DRY-
+equivalent safety without rewriting the calibration path before handover.
+
+## Testing
+
+- Backend (`tests/test_vacalibration_backend.R`):
+  - `preview_cause_mapping` report correctness on golden data: excluded counts,
+    denominator, empty `unrecognized`.
+  - A deliberately-misspelled cause (e.g. "Pnemonia") appears in `unrecognized`
+    with a non-null suggestion and sets `has_errors = TRUE`.
+  - Consistency: `preview_cause_mapping` broad matrix == job-path broad matrix
+    for each `{age_group, algorithm}` bundled dataset.
+- Frontend (vitest): preview panel renders from a mocked report; Submit disabled
+  when `has_errors`; amber warning (Submit enabled) when only `excluded_undetermined`.
+
+## Out of scope
+
+- No client-side cause mapping.
+- No change to the calibration algorithm or result shape.
+- No refactor of `run_vacalibration`'s mapping path.

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -86,6 +86,25 @@ export async function submitJob({ uploads, jobType, algorithms, ageGroup, countr
   });
 }
 
+// Ask the backend how the uploaded causes will map BEFORE submitting a job.
+// Returns { reports: { <algo>: report } } with no job created and no MCMC run.
+// Mirrors submitJob's FormData convention; the single-file case sends both
+// `file` and `file_<algo>` so the report is keyed by algorithm either way.
+export async function previewMapping({ uploads, ageGroup }) {
+  const formData = new FormData();
+  formData.append('age_group', ageGroup);
+  const withFiles = (uploads || []).filter(u => u.file && u.algorithm);
+  if (withFiles.length === 1) {
+    formData.append('file', withFiles[0].file);
+    formData.append(`file_${withFiles[0].algorithm.toLowerCase()}`, withFiles[0].file);
+  } else {
+    withFiles.forEach(({ algorithm, file }) => {
+      formData.append(`file_${algorithm.toLowerCase()}`, file);
+    });
+  }
+  return fetchJson(`${API_BASE}/jobs/preview`, { method: 'POST', body: formData });
+}
+
 export async function submitDemoJob({ jobType, algorithms, ageGroup, country, calibModelType, ensemble, nMCMC, nBurn, nThin }) {
   const params = new URLSearchParams({
     job_type: jobType,

--- a/frontend/src/api/client.test.js
+++ b/frontend/src/api/client.test.js
@@ -170,3 +170,27 @@ describe('submitJob multi-file support (issue #27)', () => {
     expect(url).toContain('ensemble=false');
   });
 })
+
+describe('previewMapping', () => {
+  it('posts one file per algorithm and returns reports', async () => {
+    const mockFetch = vi.fn().mockResolvedValue({
+      ok: true, status: 200,
+      json: () => Promise.resolve({ reports: { interva: { total_records: 3, has_errors: false } } })
+    });
+    globalThis.fetch = mockFetch;
+
+    const { previewMapping } = await import('./client.js');
+    const file = new File(['ID,cause\n1,Prematurity\n'], 'interva.csv', { type: 'text/csv' });
+    const res = await previewMapping({
+      uploads: [{ algorithm: 'InterVA', file }],
+      ageGroup: 'neonate'
+    });
+
+    expect(res.reports.interva.total_records).toBe(3);
+    const [url, options] = mockFetch.mock.calls[0];
+    expect(url).toContain('/jobs/preview');
+    expect(options.method).toBe('POST');
+    expect(options.body.get('file_interva')).toBeInstanceOf(File);
+    expect(options.body.get('age_group')).toBe('neonate');
+  });
+})

--- a/frontend/src/components/CausePreview.jsx
+++ b/frontend/src/components/CausePreview.jsx
@@ -1,0 +1,54 @@
+// Renders the backend's cause-mapping report for one algorithm. Purely
+// presentational — all mapping decisions come from the backend report, so the
+// frontend never re-implements the cause taxonomy.
+export default function CausePreview({ report, algorithmLabel }) {
+  if (!report) return null;
+  if (report.error) {
+    return <div className="cause-preview error" role="alert">{algorithmLabel}: {report.error}</div>;
+  }
+  const { total_records, calibrated_denominator, excluded_undetermined = [],
+          unrecognized = [], mapping = [] } = report;
+  return (
+    <div className={`cause-preview${unrecognized.length ? ' has-errors' : ''}`}>
+      <p className="cause-preview-headline">
+        <strong>{algorithmLabel}:</strong> {calibrated_denominator} of {total_records} records will be calibrated.
+      </p>
+
+      {unrecognized.length > 0 && (
+        <div className="cause-preview-unrecognized" role="alert">
+          <p>{unrecognized.length} unrecognized cause(s) — fix these before submitting:</p>
+          <ul>
+            {unrecognized.map((u) => (
+              <li key={u.cause}>
+                “{u.cause}” ({u.count} records)
+                {u.suggestion
+                  ? <> — did you mean <em>{u.suggestion}</em>?</>
+                  : <> — no close match; relabel to a supported cause.</>}
+              </li>
+            ))}
+          </ul>
+        </div>
+      )}
+
+      {excluded_undetermined.length > 0 && (
+        <p className="cause-preview-excluded" role="status">
+          Excluded (undetermined cause, per vacalibration methodology):{' '}
+          {excluded_undetermined.map((e) => `${e.cause} (${e.count})`).join(', ')}.
+        </p>
+      )}
+
+      {mapping.length > 0 && (
+        <table className="cause-preview-table">
+          <thead><tr><th>Your cause</th><th>Maps to</th><th>Records</th></tr></thead>
+          <tbody>
+            {mapping.map((m) => (
+              <tr key={m.input_cause}>
+                <td>{m.input_cause}</td><td>{m.broad_cause}</td><td>{m.count}</td>
+              </tr>
+            ))}
+          </tbody>
+        </table>
+      )}
+    </div>
+  );
+}

--- a/frontend/src/components/CausePreview.test.jsx
+++ b/frontend/src/components/CausePreview.test.jsx
@@ -1,0 +1,34 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import CausePreview from './CausePreview';
+
+describe('CausePreview', () => {
+  it('shows denominator headline and excluded warning', () => {
+    const { container } = render(<CausePreview algorithmLabel="EAVA" report={{
+      total_records: 1190, calibrated_denominator: 940,
+      excluded_undetermined: [{ cause: 'Unspecified', count: 250 }],
+      unrecognized: [], mapping: [{ input_cause: 'Preterm', broad_cause: 'prematurity', count: 164 }],
+      has_errors: false,
+    }} />);
+    expect(container.textContent).toMatch(/940 of 1190/);
+    expect(container.textContent).toMatch(/Unspecified \(250\)/);
+    expect(container.querySelector('.cause-preview.has-errors')).toBeNull();
+  });
+
+  it('shows unrecognized causes with suggestion as an error', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={{
+      total_records: 5, calibrated_denominator: 3,
+      excluded_undetermined: [],
+      unrecognized: [{ cause: 'Pnemonia', count: 2, suggestion: 'pneumonia' }],
+      mapping: [], has_errors: true,
+    }} />);
+    expect(container.textContent).toMatch(/Pnemonia/);
+    expect(container.textContent).toMatch(/did you mean/i);
+    expect(container.textContent).toMatch(/pneumonia/);
+    expect(container.textContent).toMatch(/unrecognized/i);
+    expect(container.querySelector('.cause-preview.has-errors')).not.toBeNull();
+  });
+});

--- a/frontend/src/components/JobForm.behavior.test.jsx
+++ b/frontend/src/components/JobForm.behavior.test.jsx
@@ -11,6 +11,7 @@ vi.mock('../api/client', () => ({
   submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
   getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
   getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: vi.fn(() => Promise.resolve({ reports: {} })),
 }))
 
 const renderForm = () => render(<JobForm onJobSubmitted={() => {}} />)

--- a/frontend/src/components/JobForm.issue68.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue68.behavior.test.jsx
@@ -10,6 +10,7 @@ vi.mock('../api/client', () => ({
   submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
   getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
   getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: vi.fn(() => Promise.resolve({ reports: {} })),
 }))
 
 const uncertaintyCheckbox = () =>

--- a/frontend/src/components/JobForm.issue73.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue73.behavior.test.jsx
@@ -10,6 +10,7 @@ vi.mock('../api/client', () => ({
   submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
   getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
   getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: vi.fn(() => Promise.resolve({ reports: {} })),
 }))
 
 describe('Input Type / Output Type (issue #73, narrowed by #79)', () => {

--- a/frontend/src/components/JobForm.issue88.behavior.test.jsx
+++ b/frontend/src/components/JobForm.issue88.behavior.test.jsx
@@ -15,6 +15,7 @@ vi.mock('../api/client', () => ({
   submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
   getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
   getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: vi.fn(() => Promise.resolve({ reports: {} })),
 }))
 
 const renderForm = () => render(<JobForm onJobSubmitted={() => {}} />)

--- a/frontend/src/components/JobForm.issue92.test.jsx
+++ b/frontend/src/components/JobForm.issue92.test.jsx
@@ -13,6 +13,7 @@ vi.mock('../api/client', () => ({
   submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
   getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
   getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: vi.fn(() => Promise.resolve({ reports: {} })),
 }))
 
 const src = readFileSync(resolve(dirname(fileURLToPath(import.meta.url)), 'JobForm.jsx'), 'utf-8')

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -46,7 +46,11 @@ export default function JobForm({ onJobSubmitted }) {
   const [activeJob, setActiveJob] = useState(null);
   const [activeJobLog, setActiveJobLog] = useState([]);
   const [previewReports, setPreviewReports] = useState({});
-  const previewHasErrors = Object.values(previewReports).some(r => r && r.has_errors);
+  const [previewPending, setPreviewPending] = useState(false);
+  const [previewUnavailable, setPreviewUnavailable] = useState(false);
+  // Block on both an explicit has_errors flag and a structured per-file error
+  // (e.g. parse/column failure), so a preview error can never leave Submit live.
+  const previewHasErrors = Object.values(previewReports).some(r => r && (r.has_errors || r.error));
 
   // Poll active job status
   useEffect(() => {
@@ -95,11 +99,20 @@ export default function JobForm({ onJobSubmitted }) {
   // maps causes itself). Re-runs whenever attached files or age group change.
   useEffect(() => {
     const withFiles = uploads.filter(u => u.file && u.algorithm);
-    if (withFiles.length === 0) { setPreviewReports({}); return; }
+    if (withFiles.length === 0) {
+      setPreviewReports({}); setPreviewPending(false); setPreviewUnavailable(false);
+      return;
+    }
     let cancelled = false;
+    setPreviewPending(true);
+    setPreviewUnavailable(false);
     previewMapping({ uploads: withFiles, ageGroup })
-      .then(res => { if (!cancelled) setPreviewReports(res.reports || {}); })
-      .catch(() => { if (!cancelled) setPreviewReports({}); });
+      .then(res => { if (!cancelled) { setPreviewReports(res.reports || {}); setPreviewPending(false); } })
+      // Network/server failure is degraded gracefully: surface a non-blocking
+      // notice rather than silently clearing, but keep Submit live — the /jobs
+      // endpoint re-validates on submit, so a transient preview blip must not
+      // strand the user.
+      .catch(() => { if (!cancelled) { setPreviewReports({}); setPreviewPending(false); setPreviewUnavailable(true); } });
     return () => { cancelled = true; };
   }, [uploads, ageGroup]);
 
@@ -333,6 +346,12 @@ export default function JobForm({ onJobSubmitted }) {
               {upload.file && <span className="file-name">{upload.file.name}</span>}
             </div>
           ))}
+          {previewPending && <p className="cause-preview-pending" role="status">Checking cause mapping…</p>}
+          {previewUnavailable && (
+            <p className="cause-preview-unavailable" role="status">
+              Couldn't preview cause mapping (service unavailable). Your file will still be validated when you submit.
+            </p>
+          )}
           {Object.entries(previewReports).map(([algo, report]) => (
             <CausePreview key={algo} report={report}
               algorithmLabel={algo.charAt(0).toUpperCase() + algo.slice(1)} />
@@ -446,7 +465,7 @@ export default function JobForm({ onJobSubmitted }) {
         )}
 
         <div className="form-actions">
-          <button type="submit" disabled={loading || activeJob || uploads.some(u => !u.file) || previewHasErrors}>
+          <button type="submit" disabled={loading || activeJob || uploads.some(u => !u.file) || previewHasErrors || previewPending}>
             {loading ? 'Calibrating...' : activeJob ? 'Job Running...' : 'Calibrate'}
           </button>
           <button type="button" onClick={handleDemo} disabled={loading || activeJob}>

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -1,7 +1,8 @@
 import { useState, useEffect } from 'react';
-import { submitJob, submitDemoJob, getJobStatus, getJobLog } from '../api/client';
+import { submitJob, submitDemoJob, getJobStatus, getJobLog, previewMapping } from '../api/client';
 import ProgressIndicator from './ProgressIndicator';
 import CustomSelect from './CustomSelect';
+import CausePreview from './CausePreview';
 
 let nextUploadId = 1;
 
@@ -44,6 +45,8 @@ export default function JobForm({ onJobSubmitted }) {
   const [validationError, setValidationError] = useState(null);
   const [activeJob, setActiveJob] = useState(null);
   const [activeJobLog, setActiveJobLog] = useState([]);
+  const [previewReports, setPreviewReports] = useState({});
+  const previewHasErrors = Object.values(previewReports).some(r => r && r.has_errors);
 
   // Poll active job status
   useEffect(() => {
@@ -86,6 +89,19 @@ export default function JobForm({ onJobSubmitted }) {
         })
     );
   }, [algorithms]);
+
+  // Ask the backend how the uploaded causes will map, BEFORE submitting. The
+  // backend is the single source of truth for cause mapping (the frontend never
+  // maps causes itself). Re-runs whenever attached files or age group change.
+  useEffect(() => {
+    const withFiles = uploads.filter(u => u.file && u.algorithm);
+    if (withFiles.length === 0) { setPreviewReports({}); return; }
+    let cancelled = false;
+    previewMapping({ uploads: withFiles, ageGroup })
+      .then(res => { if (!cancelled) setPreviewReports(res.reports || {}); })
+      .catch(() => { if (!cancelled) setPreviewReports({}); });
+    return () => { cancelled = true; };
+  }, [uploads, ageGroup]);
 
   // Validation: at least one algorithm must be selected.
   useEffect(() => {
@@ -317,6 +333,10 @@ export default function JobForm({ onJobSubmitted }) {
               {upload.file && <span className="file-name">{upload.file.name}</span>}
             </div>
           ))}
+          {Object.entries(previewReports).map(([algo, report]) => (
+            <CausePreview key={algo} report={report}
+              algorithmLabel={algo.charAt(0).toUpperCase() + algo.slice(1)} />
+          ))}
           <small className="form-hint">
             Upload one CSV file per selected algorithm. Required columns: ID, cause.
           </small>
@@ -426,7 +446,7 @@ export default function JobForm({ onJobSubmitted }) {
         )}
 
         <div className="form-actions">
-          <button type="submit" disabled={loading || activeJob || uploads.some(u => !u.file)}>
+          <button type="submit" disabled={loading || activeJob || uploads.some(u => !u.file) || previewHasErrors}>
             {loading ? 'Calibrating...' : activeJob ? 'Job Running...' : 'Calibrate'}
           </button>
           <button type="button" onClick={handleDemo} disabled={loading || activeJob}>

--- a/frontend/src/components/JobForm.preview.behavior.test.jsx
+++ b/frontend/src/components/JobForm.preview.behavior.test.jsx
@@ -36,4 +36,28 @@ describe('JobForm cause preview', () => {
     const calibrateBtn = screen.getByRole('button', { name: /^calibrat/i });
     expect(calibrateBtn.disabled).toBe(true);
   });
+
+  it('disables Calibrate when a report is a structured error (no has_errors flag)', async () => {
+    previewMapping.mockResolvedValue({
+      reports: { interva: { error: "Input must have 'ID' and 'cause' columns" } },
+    });
+
+    render(<JobForm onJobSubmitted={() => {}} />);
+    const file = new File(['garbage'], 'interva.csv', { type: 'text/csv' });
+    fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText(/Input must have/)).toBeTruthy());
+    expect(screen.getByRole('button', { name: /^calibrat/i }).disabled).toBe(true);
+  });
+
+  it('keeps Calibrate enabled but shows a notice when the preview request fails', async () => {
+    previewMapping.mockRejectedValue(new Error('network down'));
+
+    render(<JobForm onJobSubmitted={() => {}} />);
+    const file = new File(['ID,cause\n1,Prematurity\n'], 'interva.csv', { type: 'text/csv' });
+    fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText(/service unavailable/i)).toBeTruthy());
+    expect(screen.getByRole('button', { name: /^calibrat/i }).disabled).toBe(false);
+  });
 });

--- a/frontend/src/components/JobForm.preview.behavior.test.jsx
+++ b/frontend/src/components/JobForm.preview.behavior.test.jsx
@@ -1,0 +1,39 @@
+/**
+ * @vitest-environment jsdom
+ */
+import { describe, it, expect, vi, beforeEach } from 'vitest';
+import { render, screen, fireEvent, waitFor } from '@testing-library/react';
+
+const previewMapping = vi.fn();
+vi.mock('../api/client', () => ({
+  submitJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  submitDemoJob: vi.fn(() => Promise.resolve({ job_id: 'stub' })),
+  getJobStatus: vi.fn(() => Promise.resolve({ status: 'completed' })),
+  getJobLog: vi.fn(() => Promise.resolve({ log: [] })),
+  previewMapping: (...args) => previewMapping(...args),
+}));
+
+import JobForm from './JobForm';
+
+describe('JobForm cause preview', () => {
+  beforeEach(() => { previewMapping.mockReset(); });
+
+  it('disables Calibrate when the preview reports unrecognized causes', async () => {
+    previewMapping.mockResolvedValue({
+      reports: { interva: {
+        total_records: 5, calibrated_denominator: 3, excluded_undetermined: [],
+        unrecognized: [{ cause: 'Pnemonia', count: 2, suggestion: 'pneumonia' }],
+        mapping: [], has_errors: true,
+      } },
+    });
+
+    render(<JobForm onJobSubmitted={() => {}} />);
+    const file = new File(['ID,cause\n1,Pnemonia\n'], 'interva.csv', { type: 'text/csv' });
+    const input = document.querySelector('input[type="file"]');
+    fireEvent.change(input, { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText(/Pnemonia/)).toBeTruthy());
+    const calibrateBtn = screen.getByRole('button', { name: /^calibrat/i });
+    expect(calibrateBtn.disabled).toBe(true);
+  });
+});

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -296,6 +296,22 @@ test("preview: unrecognized cause carries a spelling suggestion",
                 function(u) u$cause == "Pnemonia" && !is.null(u$suggestion) && nzchar(u$suggestion),
                 logical(1))))
 
+# Missing (NA) and blank causes must be REPORTED, not silently dropped (R's
+# table() drops NA by default). They surface as an unrecognized "(missing)"
+# bucket, and every record is accounted for in exactly one bucket.
+na_df <- data.frame(ID = as.character(1:4),
+                    cause = c("Prematurity", NA, "", "Neonatal sepsis"),
+                    stringsAsFactors = FALSE)
+rep_na <- preview_cause_mapping(na_df, "neonate")
+test("preview: NA/blank causes are accounted for (buckets reconcile to total)",
+     rep_na$total_records == 4 &&
+     (rep_na$calibrated_denominator +
+      sum(vapply(rep_na$excluded_undetermined, function(e) e$count, integer(1))) +
+      sum(vapply(rep_na$unrecognized, function(u) u$count, integer(1)))) == 4)
+test("preview: NA/blank causes surface as unrecognized (has_errors)",
+     rep_na$has_errors &&
+     any(vapply(rep_na$unrecognized, function(u) u$cause == "(missing)" && u$count == 2, logical(1))))
+
 # Consistency: preview's recognized denominator == job-path mapped rows, for
 # every bundled dataset (both age groups, all algorithms). This is the anti-drift
 # guarantee: the preview must agree with what the real job will calibrate.
@@ -311,6 +327,17 @@ for (age in c("neonate", "child")) {
     job_denom <- sum(rowSums(vb) > 0)
     test(sprintf("preview denominator matches job path for %s/%s", age, alg),
          rep$calibrated_denominator == job_denom)
+
+    # Stronger than the denominator: assert the per-broad-cause ASSIGNMENTS match
+    # the job path (a wrong cause->broad assignment with an unchanged total would
+    # otherwise slip past a denominator-only check). This is the "SAME broad
+    # matrix" guarantee the design doc claims.
+    broad_all <- get_broad_causes(age)
+    job_by_broad <- as.integer(colSums(vb)[broad_all])
+    prev_by_broad <- setNames(integer(length(broad_all)), broad_all)
+    for (m in rep$mapping) prev_by_broad[m$broad_cause] <- prev_by_broad[m$broad_cause] + m$count
+    test(sprintf("preview per-broad-cause assignments match job path for %s/%s", age, alg),
+         all(prev_by_broad[broad_all] == job_by_broad))
   }
 }
 
@@ -589,7 +616,7 @@ assert_deliverables <- function(res, label, age, tag) {
   test(sprintf("%s: credible-interval bounds present and ordered (low <= high)", tag),
        all(res$pcalib_postsumm[primary, "lowcredI", ] <= res$pcalib_postsumm[primary, "upcredI", ]))
   test(sprintf("%s: misclassification matrix present", tag),
-       !is.null(extract_misclass_matrix(res, single_algo_name = "combined")))
+       !is.null(extract_misclass_matrix(res, single_algo_name = label)))
 }
 
 run_golden <- function(va_input, age, ensemble, label, tag) {

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -263,6 +263,58 @@ for (ag in c("neonate", "child")) {
 }
 
 # =============================================================================
+# 2e. INPUT DATA VALIDATION -- preview_cause_mapping report
+# =============================================================================
+section("2e. preview_cause_mapping report")
+
+# EAVA neonate package data: 250 Unspecified excluded, rest recognized.
+eava_prev <- as.data.frame(comsamoz_CCVAoutput$neonate$eava)
+eava_prev$ID <- as.character(eava_prev$ID)
+rep_eava <- preview_cause_mapping(eava_prev, "neonate")
+test("preview: total_records is full upload count", rep_eava$total_records == 1190)
+test("preview: 250 Unspecified excluded",
+     length(rep_eava$excluded_undetermined) == 1 &&
+     rep_eava$excluded_undetermined[[1]]$cause == "Unspecified" &&
+     rep_eava$excluded_undetermined[[1]]$count == 250)
+test("preview: no unrecognized causes in clean package data",
+     length(rep_eava$unrecognized) == 0 && isFALSE(rep_eava$has_errors))
+test("preview: calibrated denominator excludes Unspecified (940)",
+     rep_eava$calibrated_denominator == 940)
+test("preview: mapping rows sum to the calibrated denominator",
+     sum(vapply(rep_eava$mapping, function(m) m$count, integer(1))) == 940)
+
+# A deliberately misspelled cause must be flagged unrecognized with a suggestion.
+bad_df <- data.frame(ID = as.character(1:5),
+                     cause = c("Prematurity", "Pnemonia", "Pnemonia", "Neonatal sepsis", "Birth asphyxia"),
+                     stringsAsFactors = FALSE)
+rep_bad <- preview_cause_mapping(bad_df, "neonate")
+test("preview: misspelled cause is unrecognized and blocks (has_errors)",
+     rep_bad$has_errors &&
+     any(vapply(rep_bad$unrecognized, function(u) u$cause == "Pnemonia" && u$count == 2, logical(1))))
+test("preview: unrecognized cause carries a spelling suggestion",
+     any(vapply(rep_bad$unrecognized,
+                function(u) u$cause == "Pnemonia" && !is.null(u$suggestion) && nzchar(u$suggestion),
+                logical(1))))
+
+# Consistency: preview's recognized denominator == job-path mapped rows, for
+# every bundled dataset (both age groups, all algorithms). This is the anti-drift
+# guarantee: the preview must agree with what the real job will calibrate.
+for (age in c("neonate", "child")) {
+  for (alg in c("interva", "insilicova", "eava")) {
+    d <- as.data.frame(comsamoz_CCVAoutput[[age]][[alg]])
+    if ("cause1" %in% names(d) && !"cause" %in% names(d)) names(d)[names(d) == "cause1"] <- "cause"
+    d$ID <- as.character(d$ID)
+    rep <- preview_cause_mapping(d, age)
+    dropped <- drop_undetermined_causes(d)
+    vb <- if (is_broad_format(dropped$cause, age)) build_broad_matrix(dropped, age)
+          else safe_cause_map(fix_causes_for_vacalibration(dropped), age)
+    job_denom <- sum(rowSums(vb) > 0)
+    test(sprintf("preview denominator matches job path for %s/%s", age, alg),
+         rep$calibrated_denominator == job_denom)
+  }
+}
+
+# =============================================================================
 # 3. INPUT DATA VALIDATION -- Backend RDS sample data
 # =============================================================================
 section("3. Backend RDS Sample Data")

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -166,6 +166,103 @@ if (!is.null(interva_broad)) {
 }
 
 # =============================================================================
+# 2b. INPUT DATA VALIDATION -- Undetermined-cause exclusion ("Unspecified")
+# =============================================================================
+section("2b. Undetermined-cause exclusion (Unspecified)")
+
+# vacalibration::cause_map() drops records whose cause is "Unspecified" by
+# design (subset(df, cause != "Unspecified")). The vacalibration package's own
+# EAVA neonate dataset (comsamoz_CCVAoutput) has 250 such records. Without
+# dropping them up front, assert_all_causes_mapped (issue #92) treats those
+# intended drops as an error and rejects the whole dataset -- the exact failure
+# users hit when uploading the package's bundled datasets. The backend must
+# drop them (loudly logged, not silent) so calibration reproduces the package's
+# native denominator (940) instead of erroring.
+data(comsamoz_CCVAoutput)
+eava_pkg <- as.data.frame(comsamoz_CCVAoutput$neonate$eava)
+eava_pkg$ID <- as.character(eava_pkg$ID)
+n_unspec <- sum(tolower(trimws(eava_pkg$cause)) == "unspecified")
+test("package EAVA neonate data contains Unspecified records (fixture sanity)",
+     n_unspec == 250)
+
+# Baseline: without dropping, the #92 guard must reject the dataset
+raw_broad <- tryCatch(
+  safe_cause_map(df = fix_causes_for_vacalibration(eava_pkg), age_group = "neonate"),
+  error = function(e) NULL)
+test("without dropping, assert_all_causes_mapped rejects Unspecified records",
+     !is.null(raw_broad) &&
+     inherits(tryCatch(assert_all_causes_mapped(eava_pkg, raw_broad, "neonate"),
+                       error = function(e) e), "error"))
+
+# With the fix: drop undetermined causes, then the full path succeeds
+eava_dropped <- drop_undetermined_causes(eava_pkg)
+test("drop_undetermined_causes removes exactly the Unspecified records",
+     nrow(eava_dropped) == nrow(eava_pkg) - n_unspec)
+dropped_broad <- tryCatch(
+  safe_cause_map(df = fix_causes_for_vacalibration(eava_dropped), age_group = "neonate"),
+  error = function(e) NULL)
+test("after dropping, EAVA package data passes assert_all_causes_mapped",
+     !is.null(dropped_broad) &&
+     isTRUE(assert_all_causes_mapped(eava_dropped, dropped_broad, "neonate")))
+test("after dropping, denominator matches package native (940)",
+     !is.null(dropped_broad) && nrow(dropped_broad) == 940)
+
+# Datasets without undetermined causes must be untouched
+test("drop_undetermined_causes leaves InterVA data unchanged",
+     nrow(drop_undetermined_causes(interva_df)) == nrow(interva_df))
+
+# =============================================================================
+# 2c. INPUT DATA VALIDATION -- Child specific-cause mapping (package data)
+# =============================================================================
+section("2c. Child specific-cause mapping (vacalibration package data)")
+
+# safe_cause_map injects dummy rows for all 9 child broad categories to work
+# around cause_map()'s non-conformable bug. Two child dummies were invalid
+# specific-cause names ("diarrheal diseases" [misspelled] and "other" [not a
+# child specific cause]), so they renamed to NA, model.matrix dropped those
+# columns, and cause_map crashed with "non-conformable arguments" -- breaking
+# every specific-format child upload, including the vacalibration package's own
+# comsamoz_CCVAoutput child datasets. (Neonate was unaffected: its "other"
+# dummy matches the neonate map's literal "other" entry; child's does not.)
+child_broad_causes <- c("malaria", "pneumonia", "diarrhea", "severe_malnutrition",
+                        "hiv", "injury", "other", "other_infections", "nn_causes")
+for (alg in c("interva", "insilicova", "eava")) {
+  cd <- as.data.frame(comsamoz_CCVAoutput$child[[alg]])
+  if ("cause1" %in% names(cd)) names(cd)[names(cd) == "cause1"] <- "cause"
+  cd$ID <- as.character(cd$ID)
+  cd <- drop_undetermined_causes(cd)
+  cb <- tryCatch(safe_cause_map(fix_causes_for_vacalibration(cd), "child"),
+                 error = function(e) NULL)
+  test(sprintf("child %s package data maps via safe_cause_map without error", alg),
+       !is.null(cb))
+  test(sprintf("child %s broad matrix has all 9 broad causes", alg),
+       !is.null(cb) && setequal(colnames(cb), child_broad_causes))
+  test(sprintf("child %s broad matrix passes assert_all_causes_mapped", alg),
+       !is.null(cb) && isTRUE(assert_all_causes_mapped(cd, cb, "child")))
+}
+
+# =============================================================================
+# 2d. INPUT DATA VALIDATION -- safe_cause_map dummy integrity
+# =============================================================================
+section("2d. safe_cause_map dummy integrity")
+
+# safe_cause_map() injects one dummy record per broad category so cause_map()
+# sees all categories. If any dummy is not a recognized specific-cause name,
+# cause_map() crashes ("non-conformable") or silently drops a category. Assert
+# the hardcoded dummies produce EVERY broad category for both age groups -- a
+# direct regression guard for the child "diarrheal diseases"/"other" bug.
+for (ag in c("neonate", "child")) {
+  seed_cause <- if (ag == "neonate") c("prematurity", "neonatal sepsis") else c("malaria", "pneumonia")
+  minimal <- data.frame(ID = c("m1", "m2"), cause = seed_cause, stringsAsFactors = FALSE)
+  m <- tryCatch(safe_cause_map(minimal, ag), error = function(e) NULL)
+  test(sprintf("safe_cause_map(%s) succeeds on minimal input", ag), !is.null(m))
+  test(sprintf("safe_cause_map(%s) dummies inject all broad categories", ag),
+       !is.null(m) && setequal(colnames(m), get_broad_causes(ag)))
+  test(sprintf("safe_cause_map(%s) returns only the real records (dummies removed)", ag),
+       !is.null(m) && nrow(m) == nrow(minimal))
+}
+
+# =============================================================================
 # 3. INPUT DATA VALIDATION -- Backend RDS sample data
 # =============================================================================
 section("3. Backend RDS Sample Data")
@@ -397,6 +494,72 @@ if (input_only) {
 # COMPUTATION TESTS (skipped in --input-only mode)
 # =============================================================================
 if (!input_only) {
+
+# =============================================================================
+# 5a. GOLDEN DATASET CONTRACT -- vacalibration package's own bundled data
+# =============================================================================
+# The failures users hit came from uploading the vacalibration package's OWN
+# bundled datasets (comsamoz_CCVAoutput) -- data the scrubbed frontend/RDS
+# samples did not represent, so the suite stayed green while production broke.
+# This contract test runs EVERY bundled dataset through the FULL upload path
+# (drop undetermined -> map -> vacalibration) for both age groups and all three
+# algorithms, plus an ensemble per age group, and asserts each returns the four
+# deliverables: uncalibrated CSMF, calibrated CSMF, calibrated credible-interval
+# bounds, and the misclassification matrix. This is the regression net for the
+# whole "package data drifts from dashboard assumptions" class of bug (neonate
+# Unspecified drop, child safe_cause_map dummies). Small MCMC -- shape, not
+# convergence, is what is under test here.
+section("5a. Golden Dataset Contract (vacalibration package data)")
+
+data(comsamoz_CCVAoutput)
+
+# Map one bundled dataset exactly the way the backend upload path does.
+golden_broad <- function(age, algo) {
+  d <- as.data.frame(comsamoz_CCVAoutput[[age]][[algo]])
+  if ("cause1" %in% names(d) && !"cause" %in% names(d)) names(d)[names(d) == "cause1"] <- "cause"
+  d$ID <- as.character(d$ID)
+  d <- drop_undetermined_causes(d)
+  vb <- if (is_broad_format(d$cause, age)) build_broad_matrix(d, age) else
+        safe_cause_map(fix_causes_for_vacalibration(d), age)
+  assert_all_causes_mapped(d, vb, age)
+  vb
+}
+
+# Assert a vacalibration result carries all four deliverables for `label`.
+assert_deliverables <- function(res, label, age, tag) {
+  broad <- get_broad_causes(age)
+  labs <- dimnames(res$pcalib_postsumm)[[1]]
+  primary <- if (label %in% labs) label else labs[1]
+  test(sprintf("%s: uncalibrated CSMF spans all broad causes", tag),
+       setequal(names(res$p_uncalib[primary, ]), broad))
+  test(sprintf("%s: calibrated CSMF (postmean) finite", tag),
+       all(is.finite(res$pcalib_postsumm[primary, "postmean", ])))
+  test(sprintf("%s: credible-interval bounds present and ordered (low <= high)", tag),
+       all(res$pcalib_postsumm[primary, "lowcredI", ] <= res$pcalib_postsumm[primary, "upcredI", ]))
+  test(sprintf("%s: misclassification matrix present", tag),
+       !is.null(extract_misclass_matrix(res, single_algo_name = "combined")))
+}
+
+run_golden <- function(va_input, age, ensemble, label, tag) {
+  res <- tryCatch(
+    vacalibration(va_data = va_input, age_group = age, country = "Mozambique",
+      missmat_type = "prior", ensemble = ensemble,
+      nMCMC = 300, nBurn = 300, nThin = 1, verbose = FALSE, seed = 1),
+    error = function(e) e)
+  test(sprintf("%s runs without error", tag), !inherits(res, "error"))
+  if (!inherits(res, "error")) assert_deliverables(res, label, age, tag)
+}
+
+for (age in c("neonate", "child")) {
+  for (algo in c("interva", "insilicova", "eava")) {
+    run_golden(setNames(list(golden_broad(age, algo)), algo), age, FALSE, algo,
+               sprintf("golden %s/%s", age, algo))
+  }
+  ens_input <- setNames(lapply(c("interva", "insilicova", "eava"),
+                               function(a) golden_broad(age, a)),
+                        c("interva", "insilicova", "eava"))
+  run_golden(ens_input, age, TRUE, "ensemble", sprintf("golden %s/ensemble", age))
+}
 
 # =============================================================================
 # 5. VACALIBRATION COMPUTATION -- Single algorithm


### PR DESCRIPTION
Closes #103

## Why

Uploading the datasets bundled with the `vacalibration` package (`comsamoz_CCVAoutput`) — the most likely thing a researcher uploads — failed on the dashboard, only surfacing *after* job submission. Confirmed against the dev DB: both a single EAVA job and an ensemble job failed with the identical error.

## What

Two independent bugs, plus hardening and a transparency feature.

### Bug fixes
- **Neonate — `Unspecified` (EAVA):** 250/1190 records labeled `Unspecified` tripped the `assert_all_causes_mapped` guard (#92). `vacalibration::cause_map()` drops `Unspecified` by design (it's an undetermined cause that can't be calibrated), so the dashboard now does the same **up front** via `drop_undetermined_causes()`, logged loudly (not silent). Result reproduces the package's native denominator (940).
- **Child — `safe_cause_map` dummies:** the child dummy list had two invalid specific-cause names (`"diarrheal diseases"`, `"other"`) that renamed to `NA` and crashed `cause_map()` with `non-conformable arguments`, breaking **every** specific-format child upload. Fixed to `"diarrhoeal diseases"` and `"stroke"`. (Neonate escaped this only because its `other` list happens to contain a literal `"other"`.)

### Hardening (prevents this whole class of bug)
- **Golden-dataset contract test:** every bundled dataset (both age groups × all 3 algorithms + ensemble) runs through the full path, asserting calibrated/uncalibrated CSMF, credible intervals, and misclassification matrix. This is the regression net the scrubbed sample data lacked.
- **`safe_cause_map` self-check:** translates `cause_map`'s cryptic non-conformable error and asserts all broad categories are present, so a bad dummy fails loudly with a clear message.

### Feature — pre-submit cause preview (#3)
- New backend helper `preview_cause_mapping()` + `POST /jobs/preview` endpoint (reuses the exact job-path mapping units; no job row, no MCMC).
- Frontend `previewMapping()` + `CausePreview` panel in `JobForm`: on file attach, shows each cause → broad mapping, excluded/undetermined counts, unrecognized causes with spelling suggestions, and the true calibrated denominator. **Blocks Submit on unrecognized causes; warns (but allows) on expected exclusions.**
- Anti-drift test asserts the preview mapping equals the job-path mapping for every bundled dataset.

## Testing
- R suite (with MCMC): **383/383 pass**.
- Frontend (vitest): **236/236 pass**.

## Docs
Design spec and implementation plan under `docs/superpowers/`.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added a pre-submit cause-mapping preview for uploaded calibration files.
  * Displays record totals, exclusions, mappings, and suggestions for unrecognized causes.
  * Prevents calibration submission when causes cannot be mapped.
  * Supports previews for single and multi-algorithm uploads.

* **Bug Fixes**
  * Excludes unspecified deaths from calibration inputs.
  * Improved child-age cause mapping and validation of broad categories.

* **Tests**
  * Added coverage for preview behavior, mapping consistency, upload scenarios, and calibration regressions.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->