### PR TITLE
Fix inactive Calibrate button (#105): never silently default a request parameter

### DIFF
--- a/backend/README.md
+++ b/backend/README.md
@@ -31,26 +31,46 @@ curl http://localhost:8000/health
 
 ### Submit Job
 
+Only the CSV file is multipart (`-F`). **Every scalar parameter must go in the
+query string.** A scalar sent as a multipart form field is silently discarded:
+plumber gives a text part no Content-Type, so it is parsed with `parseQS`, and a
+bare value like `child` (no `=`) becomes an empty list. That is what caused
+issue #105 — a lost `age_group` was defaulted to `neonate`, and child data was
+scored against the neonate cause list.
+
 ```bash
 # Full pipeline with sample data (demo)
 curl -X POST "http://localhost:8000/jobs/demo?job_type=pipeline&age_group=neonate"
 
-# With custom data
-curl -X POST "http://localhost:8000/jobs" \
-  -F "file=@data.csv" \
-  -F "job_type=pipeline" \
-  -F "algorithm=InterVA" \
-  -F "age_group=neonate" \
-  -F "country=Mozambique"
+# With custom data -- scalars in the query string, file as multipart
+curl -X POST "http://localhost:8000/jobs?job_type=pipeline&algorithm=InterVA&age_group=neonate&country=Mozambique" \
+  -F "file=@data.csv"
+
+# Ensemble: algorithm accepts a JSON array
+curl -X POST "http://localhost:8000/jobs?job_type=pipeline&algorithm=%5B%22InterVA%22,%22EAVA%22%5D&age_group=child&country=Kenya&ensemble=true" \
+  -F "file_interva=@interva.csv" -F "file_eava=@eava.csv"
 ```
 
-**Parameters:**
+**Required parameters** — these determine what science is run, so a missing or
+unrecognized value is rejected rather than defaulted:
+
+| Parameter | Values |
+|-----------|--------|
+| `job_type` | `openva`, `vacalibration`, `pipeline` |
+| `algorithm` | `InterVA`, `InSilicoVA`, `EAVA` — or a JSON array of them |
+| `age_group` | `neonate`, `child` |
+| `country` | `Bangladesh`, `Ethiopia`, `Kenya`, `Mali`, `Mozambique`, `Sierra Leone`, `South Africa`, `other` (pooled) |
+
+**Optional parameters** — defaulted when omitted, but an invalid value is
+rejected rather than coerced to `NA`:
+
 | Parameter | Values | Default |
 |-----------|--------|---------|
-| `job_type` | `openva`, `vacalibration`, `pipeline` | `pipeline` |
-| `algorithm` | `InterVA`, `InSilicoVA` | `InterVA` |
-| `age_group` | `neonate`, `child` | `neonate` |
-| `country` | CHAMPS countries or `other` | `Mozambique` |
+| `calib_model_type` | `Mmatprior`, `Mmatfixed` | `Mmatprior` |
+| `ensemble` | `true`, `false` | `false` |
+| `n_mcmc` | positive integer | `5000` |
+| `n_burn` | positive integer | `2000` |
+| `n_thin` | positive integer | `1` |
 
 ### Check Status
 

--- a/backend/README.md
+++ b/backend/README.md
@@ -46,8 +46,10 @@ curl -X POST "http://localhost:8000/jobs/demo?job_type=pipeline&age_group=neonat
 curl -X POST "http://localhost:8000/jobs?job_type=pipeline&algorithm=InterVA&age_group=neonate&country=Mozambique" \
   -F "file=@data.csv"
 
-# Ensemble: algorithm accepts a JSON array
-curl -X POST "http://localhost:8000/jobs?job_type=pipeline&algorithm=%5B%22InterVA%22,%22EAVA%22%5D&age_group=child&country=Kenya&ensemble=true" \
+# Ensemble: algorithm accepts a JSON array. Per-algorithm file fields
+# (file_interva/file_insilicova/file_eava) apply to vacalibration jobs only;
+# a pipeline ensemble takes a single -F "file=@data.csv" instead.
+curl -X POST "http://localhost:8000/jobs?job_type=vacalibration&algorithm=%5B%22InterVA%22,%22EAVA%22%5D&age_group=child&country=Kenya&ensemble=true" \
   -F "file_interva=@interva.csv" -F "file_eava=@eava.csv"
 ```
 

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -465,7 +465,9 @@ optional_count <- function(value, name, default) {
   v <- param_scalar(value, name)
   if (!nzchar(v)) return(default)
   n <- suppressWarnings(as.numeric(v))
-  if (is.na(n) || n < 1 || n != trunc(n)) {
+  # Values past .Machine$integer.max make as.integer() overflow to NA (warning
+  # only) -- the exact NA leak this helper exists to prevent.
+  if (is.na(n) || n < 1 || n != trunc(n) || n > .Machine$integer.max) {
     stop(sprintf("Invalid '%s' value '%s'. Must be a positive whole number.", name, v),
          call. = FALSE)
   }

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -387,6 +387,137 @@ extract_top_cod <- function(result) {
   }
 }
 
+# ---- Request parameter resolution -------------------------------------------
+#
+# Every scalar the job endpoints take MUST arrive in the QUERY STRING. A multipart
+# form field does not survive plumber: a text part carries no Content-Type and no
+# filename, so parser_picker() falls through to parser_text(parseQS), and parseQS
+# reads the raw part value as a query string -- a bare "child" contains no "=" and
+# parses to an EMPTY LIST. That is how issue #105 arose: req$args$age_group arrived
+# as list(), the endpoint could not tell it apart from an absent parameter, and a
+# silent "neonate" default scored child uploads against the NEONATE cause list.
+# Every child-only cause (hiv, other_infections, severe_malnutrition) was then
+# reported unrecognized, which disabled the Calibrate button.
+#
+# So a parameter that determines WHAT SCIENCE RAN is never guessed (issues
+# #77/#89): guessing converts a lost parameter into a plausible-but-wrong result.
+# Genuine tuning knobs keep a documented default but still reject invalid values,
+# because as.integer("abc") and as.logical("yes") both yield NA silently.
+
+PARAM_TRANSPORT_HINT <- "Send it as a query-string parameter, e.g. /jobs?age_group=child (a multipart form field is discarded by plumber's form parser)."
+
+VALID_JOB_TYPES <- c("openva", "vacalibration", "pipeline")
+VALID_ALGORITHMS <- c("InterVA", "InSilicoVA", "EAVA")
+VALID_CALIB_MODEL_TYPES <- c("Mmatprior", "Mmatfixed")
+
+# The strata of the CHAMPS misclassification matrix, i.e. the only countries
+# calibration can be performed against ("other" is the pooled all-country
+# stratum). Verified against names(Mmat_champs$neonate$eava$postmean) in
+# vacalibration, and re-checked by a drift guard in
+# tests/test_vacalibration_backend.R section 2g. Calibrating against the wrong
+# country silently uses the wrong misclassification matrix, which is why an
+# absent country is rejected rather than defaulted to Mozambique.
+CALIBRATION_COUNTRIES <- c("Bangladesh", "Ethiopia", "Kenya", "Mali",
+                           "Mozambique", "Sierra Leone", "South Africa", "other")
+
+# Reduce a request parameter to a single trimmed string, or "" when it is absent,
+# empty, or the empty list plumber produces for a multipart text field.
+# Conflicting repeated values are an error rather than a coin flip -- quietly
+# taking the first would be another silent guess.
+param_scalar <- function(value, name) {
+  v <- suppressWarnings(as.character(unlist(value, use.names = FALSE)))
+  v <- trimws(v[!is.na(v)])
+  v <- v[nzchar(v)]
+  if (length(v) == 0) return("")
+  if (length(unique(v)) > 1) {
+    stop(sprintf("Received %d conflicting values for '%s' (%s). Send it exactly once.",
+                 length(unique(v)), name, paste(unique(v), collapse = ", ")), call. = FALSE)
+  }
+  v[1]
+}
+
+# Required parameter constrained to a fixed set. Returns the canonical spelling
+# from `valid`, so case variants normalize. Never substitutes a default.
+require_enum <- function(value, name, valid) {
+  v <- param_scalar(value, name)
+  if (!nzchar(v)) {
+    stop(sprintf("Missing required parameter '%s'. %s Valid values: %s.",
+                 name, PARAM_TRANSPORT_HINT, paste(valid, collapse = ", ")), call. = FALSE)
+  }
+  hit <- valid[tolower(valid) == tolower(v)]
+  if (length(hit) == 0) {
+    stop(sprintf("Invalid '%s' value '%s'. Must be one of: %s.",
+                 name, v, paste(valid, collapse = ", ")), call. = FALSE)
+  }
+  hit[1]
+}
+
+# Optional parameter with a documented default, still validated when supplied.
+optional_enum <- function(value, name, valid, default) {
+  v <- param_scalar(value, name)
+  if (!nzchar(v)) return(default)
+  require_enum(v, name, valid)
+}
+
+# Optional positive-integer parameter with a documented default. as.integer("abc")
+# is NA with only a warning, which used to reach the job record unnoticed.
+optional_count <- function(value, name, default) {
+  v <- param_scalar(value, name)
+  if (!nzchar(v)) return(default)
+  n <- suppressWarnings(as.numeric(v))
+  if (is.na(n) || n < 1 || n != trunc(n)) {
+    stop(sprintf("Invalid '%s' value '%s'. Must be a positive whole number.", name, v),
+         call. = FALSE)
+  }
+  as.integer(n)
+}
+
+# Optional boolean with a documented default. as.logical() turns anything it does
+# not recognize into NA, and a downstream `if (NA && ...)` is a hard error.
+optional_flag <- function(value, name, default) {
+  v <- tolower(param_scalar(value, name))
+  if (!nzchar(v)) return(default)
+  if (v %in% c("true", "t", "yes", "1")) return(TRUE)
+  if (v %in% c("false", "f", "no", "0")) return(FALSE)
+  stop(sprintf("Invalid '%s' value '%s'. Must be true or false.", name, v), call. = FALSE)
+}
+
+# Required algorithm selection. Accepts a single name or a JSON array (the shape
+# the frontend sends for an ensemble). Defaulting this to "InterVA" would silently
+# run a different algorithm than the user picked.
+require_algorithms <- function(value) {
+  missing_msg <- sprintf("Missing required parameter 'algorithm'. %s Valid values: %s.",
+                         PARAM_TRANSPORT_HINT, paste(VALID_ALGORITHMS, collapse = ", "))
+  raw <- suppressWarnings(as.character(unlist(value, use.names = FALSE)))
+  raw <- trimws(raw[!is.na(raw)])
+  raw <- raw[nzchar(raw)]
+  if (length(raw) == 0) stop(missing_msg, call. = FALSE)
+
+  if (length(raw) == 1 && grepl("^\\[", raw)) {
+    raw <- tryCatch(as.character(jsonlite::fromJSON(raw)),
+                    error = function(e)
+                      stop(sprintf("Could not parse 'algorithm' as a JSON array: %s", raw),
+                           call. = FALSE))
+    raw <- trimws(raw[!is.na(raw)])
+    raw <- raw[nzchar(raw)]
+    if (length(raw) == 0) stop(missing_msg, call. = FALSE)
+  }
+
+  canon <- VALID_ALGORITHMS[match(tolower(raw), tolower(VALID_ALGORITHMS))]
+  bad <- raw[is.na(canon)]
+  if (length(bad) > 0) {
+    stop(sprintf("Invalid algorithm(s): %s. Must be one of: %s.",
+                 paste(unique(bad), collapse = ", "),
+                 paste(VALID_ALGORITHMS, collapse = ", ")), call. = FALSE)
+  }
+  unique(canon)
+}
+
+# Resolve the age_group request parameter, or fail loudly (issue #105).
+resolve_age_group <- function(age_group) {
+  require_enum(age_group, "age_group", c("neonate", "child"))
+}
+
 # Canonical broad cause names by age group
 get_broad_causes <- function(age_group) {
   if (tolower(age_group) == "neonate") {

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -205,89 +205,60 @@ function(req, res) {
 #* @post /jobs
 function(req) {
 
-  tryCatch({
-    # Generate job ID
-    job_id <- uuid::UUIDgenerate()
+  job_id <- uuid::UUIDgenerate()
 
-    # Debug: print request structure
-    message("=== DEBUG: Request Info ===")
-    message("REQUEST_METHOD: ", req$REQUEST_METHOD)
-    message("CONTENT_TYPE: ", req$CONTENT_TYPE)
-    message("Args names: ", paste(names(req$args), collapse=", "))
-    message("Body names: ", paste(names(req$body), collapse=", "))
-    message("PostBody names: ", paste(names(req$postBody), collapse=", "))
-
-    # Extract parameters from request - prioritize args for multipart
-    job_type <- req$args$job_type
-    if (is.null(job_type) || length(job_type) == 0) job_type <- "pipeline"
-
-    algorithm <- req$args$algorithm
-    if (is.null(algorithm) || length(algorithm) == 0) algorithm <- "InterVA"
-
-    age_group <- req$args$age_group
-    if (is.null(age_group) || length(age_group) == 0) age_group <- "neonate"
-
-    country <- req$args$country
-    if (is.null(country) || length(country) == 0) country <- "Mozambique"
-
-    calib_model_type <- req$args$calib_model_type
-    if (is.null(calib_model_type) || length(calib_model_type) == 0) calib_model_type <- "Mmatprior"
-
-    ensemble <- req$args$ensemble
-    if (is.null(ensemble) || length(ensemble) == 0) ensemble <- "FALSE"
-
-    n_mcmc <- req$args$n_mcmc
-    if (is.null(n_mcmc) || length(n_mcmc) == 0) n_mcmc <- "5000"
-
-    n_burn <- req$args$n_burn
-    if (is.null(n_burn) || length(n_burn) == 0) n_burn <- "2000"
-
-    n_thin <- req$args$n_thin
-    if (is.null(n_thin) || length(n_thin) == 0) n_thin <- "1"
-
-    # Handle file upload
-    file_data <- req$args$file
-
-    # Handle multi-file uploads for ensemble vacalibration
-    file_interva <- req$args$file_interva
-    file_insilicova <- req$args$file_insilicova
-    file_eava <- req$args$file_eava
-
-    message("Extracted job_type: '", job_type, "' (length: ", length(job_type), ")")
-    message("Extracted algorithm: '", algorithm, "' (length: ", length(algorithm), ")")
-    message("Extracted age_group: '", age_group, "' (length: ", length(age_group), ")")
-    message("File data: ", if (is.null(file_data)) "NULL" else paste(class(file_data), "length:", length(file_data)))
-  }, error = function(e) {
-    return(list(error = paste("Error parsing request:", e$message)))
-  })
-
-  # Validate job type
-  if (!job_type %in% c("openva", "vacalibration", "pipeline")) {
-    return(list(error = "Invalid job_type. Must be 'openva', 'vacalibration', or 'pipeline'"))
+  # Resolve every scalar up front. The four that determine WHAT SCIENCE RAN
+  # (job_type, algorithm, age_group, country) are required and never guessed --
+  # each used to have a silent default, so a parameter lost in transit produced a
+  # confidently wrong calibration. That is the issue #105 defect on the endpoint
+  # that CREATES the job; see the parameter helpers in jobs/utils.R. The tuning
+  # knobs keep their documented defaults but reject invalid values rather than
+  # letting as.integer()/as.logical() turn them into NA.
+  #
+  # This tryCatch RETURNS its result rather than calling return() from the error
+  # handler -- return() inside the handler only exits the handler, so the previous
+  # version continued running with unresolved parameters after a parse failure.
+  resolved <- tryCatch(
+    list(value = list(
+      job_type         = require_enum(req$args$job_type, "job_type", VALID_JOB_TYPES),
+      algorithms       = require_algorithms(req$args$algorithm),
+      age_group        = resolve_age_group(req$args$age_group),
+      country          = require_enum(req$args$country, "country", CALIBRATION_COUNTRIES),
+      calib_model_type = optional_enum(req$args$calib_model_type, "calib_model_type",
+                                       VALID_CALIB_MODEL_TYPES, "Mmatprior"),
+      ensemble         = optional_flag(req$args$ensemble, "ensemble", FALSE),
+      n_mcmc           = optional_count(req$args$n_mcmc, "n_mcmc", 5000L),
+      n_burn           = optional_count(req$args$n_burn, "n_burn", 2000L),
+      n_thin           = optional_count(req$args$n_thin, "n_thin", 1L)
+    )),
+    error = function(e) list(error = conditionMessage(e))
+  )
+  if (!is.null(resolved$error)) {
+    return(list(error = resolved$error))
   }
 
-  # Parse algorithm parameter (single value or JSON array)
-  algorithms <- tryCatch({
-    if (is.character(algorithm) && grepl("^\\[", algorithm)) {
-      jsonlite::fromJSON(algorithm)
-    } else {
-      algorithm
-    }
-  }, error = function(e) {
-    algorithm
-  })
+  job_type         <- resolved$value$job_type
+  algorithms       <- resolved$value$algorithms
+  age_group        <- resolved$value$age_group
+  country          <- resolved$value$country
+  calib_model_type <- resolved$value$calib_model_type
+  ensemble_bool    <- resolved$value$ensemble
+  n_mcmc           <- resolved$value$n_mcmc
+  n_burn           <- resolved$value$n_burn
+  n_thin           <- resolved$value$n_thin
 
-  # Validate algorithms
-  valid_algorithms <- c("InterVA", "InSilicoVA", "EAVA")
-  if (is.character(algorithms)) {
-    invalid <- setdiff(algorithms, valid_algorithms)
-    if (length(invalid) > 0) {
-      return(list(error = paste("Invalid algorithm(s):", paste(invalid, collapse=", "))))
-    }
-  }
+  # Handle file upload
+  file_data <- req$args$file
+
+  # Handle multi-file uploads for ensemble vacalibration
+  file_interva <- req$args$file_interva
+  file_insilicova <- req$args$file_insilicova
+  file_eava <- req$args$file_eava
+
+  message(sprintf("Job %s: %s / %s / %s / %s", job_id, job_type,
+                  paste(algorithms, collapse = "+"), age_group, country))
 
   # Validate ensemble (vacalibration only)
-  ensemble_bool <- as.logical(ensemble)
   if (ensemble_bool && length(algorithms) < 2 && job_type == "vacalibration") {
     return(list(error = "Ensemble calibration requires at least 2 algorithms"))
   }
@@ -310,9 +281,9 @@ function(req) {
     country = country,
     calib_model_type = calib_model_type,
     ensemble = ensemble_bool,
-    n_mcmc = as.integer(n_mcmc),
-    n_burn = as.integer(n_burn),
-    n_thin = as.integer(n_thin),
+    n_mcmc = n_mcmc,
+    n_burn = n_burn,
+    n_thin = n_thin,
     created_at = format(Sys.time()),
     started_at = NULL,
     completed_at = NULL,
@@ -388,8 +359,16 @@ function(req) {
 #* Preview cause mapping for uploaded file(s) without creating a job
 #* @post /jobs/preview
 function(req) {
-  age_group <- req$args$age_group
-  if (is.null(age_group) || length(age_group) == 0) age_group <- "neonate"
+  # age_group must arrive in the QUERY STRING (see resolve_age_group() in
+  # jobs/utils.R). It used to silently default to "neonate", which scored child
+  # uploads against the neonate cause list and disabled Calibrate (issue #105).
+  # A missing or invalid value is now reported instead of guessed.
+  resolved <- tryCatch(list(value = resolve_age_group(req$args$age_group)),
+                       error = function(e) list(error = conditionMessage(e)))
+  if (!is.null(resolved$error)) {
+    return(list(error = resolved$error))
+  }
+  age_group <- resolved$value
 
   # Collect uploaded files keyed by algorithm (mirror POST /jobs arg names)
   file_map <- list(

--- a/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
+++ b/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
@@ -192,6 +192,12 @@ git commit -m "feat: preview_cause_mapping report helper for pre-submit cause pr
 
 - [ ] **Step 1: Add the endpoint**
 
+> **Superseded (issue #105):** the snippet below is the original plan and still
+> shows the silent `age_group <- "neonate"` fallback. The shipped
+> `backend/plumber.R` instead requires `age_group` from the query string via
+> `resolve_age_group()` and rejects the request when it is missing or invalid.
+> Kept as-is for the historical record; do not copy this snippet.
+
 In `backend/plumber.R`, immediately before the `#* Get job status` block, add:
 
 ```r

--- a/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
+++ b/docs/superpowers/plans/2026-07-22-cause-mapping-preview.md
@@ -188,7 +188,7 @@ git commit -m "feat: preview_cause_mapping report helper for pre-submit cause pr
 
 **Interfaces:**
 - Consumes: `preview_cause_mapping` (Task 1), `save_uploaded_file` (existing, `backend/plumber.R:19`).
-- Produces: `POST /jobs/preview` → JSON `{ reports: { <algo>: <report> } }`, or `{ error: <msg> }`. Accepts the same multipart args as `POST /jobs`: `age_group`, and `file` (single) or `file_interva`/`file_insilicova`/`file_eava` (multi).
+- Produces: `POST /jobs/preview` → JSON `{ reports: { <algo>: <report> } }`, or `{ error: <msg> }`. Files are multipart, exactly as `POST /jobs` takes them: `file` (single) or `file_interva`/`file_insilicova`/`file_eava` (multi). **CORRECTION (issue #105): `age_group` must go in the QUERY STRING, not multipart.** As written here it was sent as a multipart field, which plumber discards (a text part gets no Content-Type, so `parseQS` turns a bare `neonate` into an empty list) — the endpoint then defaulted to `neonate` and mis-scored every child upload.
 
 - [ ] **Step 1: Add the endpoint**
 
@@ -244,9 +244,8 @@ function(req) {
 cd "$(git rev-parse --show-toplevel)"
 lsof -ti:8000 | xargs kill 2>/dev/null; sleep 1
 (cd backend && Rscript run.R > /tmp/comsa_backend.log 2>&1 &); sleep 6
-curl -s -F "age_group=neonate" \
-  -F "file=@frontend/public/sample_eava_neonate.csv" \
-  http://localhost:8000/jobs/preview | head -c 600
+curl -s -F "file=@frontend/public/sample_eava_neonate.csv" \
+  "http://localhost:8000/jobs/preview?age_group=neonate" | head -c 600
 ```
 Expected: JSON containing `"reports"` → `"uploaded"` → `total_records`, `calibrated_denominator`, `mapping`. (The frontend sample is already scrubbed of Unspecified, so `excluded_undetermined` is `[]` and `has_errors` is `false`.) If the response is `{"error":"Missing or invalid Authorization header"}`, the server has grace period off — re-run with a token from `POST /auth/login`.
 
@@ -255,8 +254,8 @@ Expected: JSON containing `"reports"` → `"uploaded"` → `total_records`, `cal
 ```bash
 cd "$(git rev-parse --show-toplevel)"
 printf 'ID,cause\n1,Prematurity\n2,Unspecified\n3,Neonatal sepsis\n' > /tmp/prev_unspec.csv
-curl -s -F "age_group=neonate" -F "file=@/tmp/prev_unspec.csv" \
-  http://localhost:8000/jobs/preview
+curl -s -F "file=@/tmp/prev_unspec.csv" \
+  "http://localhost:8000/jobs/preview?age_group=neonate"
 ```
 Expected: `excluded_undetermined` lists `Unspecified` count 1; `calibrated_denominator` is 2; `has_errors` false.
 

--- a/docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
+++ b/docs/superpowers/specs/2026-07-22-cause-mapping-preview-design.md
@@ -49,7 +49,12 @@ other than being undetermined).
 
 ### Endpoint: `POST /jobs/preview` (`backend/plumber.R`)
 
-- Same multipart shape and auth as `POST /jobs` (one CSV per algorithm).
+- Same auth as `POST /jobs`. CSV files are multipart (one per algorithm), but
+  `age_group` — like every scalar `POST /jobs` takes — MUST be sent as a
+  QUERY-STRING parameter, e.g. `POST /jobs/preview?age_group=child`. A multipart
+  text field does NOT work: plumber gives a text part no Content-Type, so it is
+  parsed with `parseQS`, and a bare value like `child` (no `=`) becomes an empty
+  list. `age_group` is required and is never defaulted (issue #105).
 - Applies the same `cause1`→`cause` rename and `ID`/`cause` column check as the
   job path; on a bad file, returns a structured error (not a 500).
 - Runs `preview_cause_mapping` per file. Returns JSON: `{ reports: { <algo>: <report> } }`.

--- a/frontend/src/api/client.issue105.test.js
+++ b/frontend/src/api/client.issue105.test.js
@@ -1,0 +1,90 @@
+import { describe, it, expect, vi } from 'vitest'
+
+/**
+ * Issue #105 -- "inactive Calibrate button".
+ *
+ * age_group MUST travel to the backend in the QUERY STRING, never as a
+ * multipart form field.
+ *
+ * Why: plumber 1.3.2 assigns a multipart text part no Content-Type (and it has
+ * no filename), so parser_picker() falls through to parsers$alias$form ==
+ * parser_text(parseQS). parseQS interprets the raw part value as a URL-encoded
+ * query string, so a bare value like "child" -- which contains no "=" -- parses
+ * to an empty list. req$args$age_group then arrives as list() (length 0) and the
+ * backend cannot tell it apart from a missing parameter.
+ *
+ * Consequence when this regressed: a child upload was scored against the
+ * NEONATE broad-cause list, so hiv / other_infections / severe_malnutrition were
+ * all reported "unrecognized", has_errors became true, and JobForm disabled the
+ * Calibrate button (1334 of 2383 records). submitJob has always sent its scalars
+ * via URLSearchParams, which is exactly why job submission was unaffected while
+ * the preview was broken.
+ */
+describe('previewMapping age_group transport (issue #105)', () => {
+  const mockOk = (body = { reports: {} }) => vi.fn().mockResolvedValue({
+    ok: true, status: 200, json: () => Promise.resolve(body)
+  })
+
+  it('sends age_group in the query string, not as a multipart field', async () => {
+    const mockFetch = mockOk()
+    globalThis.fetch = mockFetch
+
+    const { previewMapping } = await import('./client.js')
+    const file = new File(['ID,cause\n1,hiv\n'], 'eava.csv', { type: 'text/csv' })
+    await previewMapping({ uploads: [{ algorithm: 'EAVA', file }], ageGroup: 'child' })
+
+    const [url, options] = mockFetch.mock.calls[0]
+
+    // The value must be readable from req$argsQuery.
+    expect(new URL(url, 'http://localhost').searchParams.get('age_group')).toBe('child')
+
+    // And must NOT be smuggled through the multipart body, where parseQS eats it.
+    expect(options.body.get('age_group')).toBeNull()
+  })
+
+  it('sends age_group=neonate in the query string too (no reliance on a backend default)', async () => {
+    const mockFetch = mockOk()
+    globalThis.fetch = mockFetch
+
+    const { previewMapping } = await import('./client.js')
+    const file = new File(['ID,cause\n1,Prematurity\n'], 'interva.csv', { type: 'text/csv' })
+    await previewMapping({ uploads: [{ algorithm: 'InterVA', file }], ageGroup: 'neonate' })
+
+    const [url] = mockFetch.mock.calls[0]
+    expect(new URL(url, 'http://localhost').searchParams.get('age_group')).toBe('neonate')
+  })
+
+  it('still sends the uploaded files as multipart form data', async () => {
+    const mockFetch = mockOk()
+    globalThis.fetch = mockFetch
+
+    const { previewMapping } = await import('./client.js')
+    const file = new File(['ID,cause\n1,hiv\n'], 'eava.csv', { type: 'text/csv' })
+    await previewMapping({ uploads: [{ algorithm: 'EAVA', file }], ageGroup: 'child' })
+
+    const [, options] = mockFetch.mock.calls[0]
+    // Single upload sends both `file` and `file_<algo>` (existing convention).
+    expect(options.body.get('file')).toBeInstanceOf(File)
+    expect(options.body.get('file_eava')).toBeInstanceOf(File)
+  })
+
+  it('preserves the age_group choice for multi-algorithm previews', async () => {
+    const mockFetch = mockOk()
+    globalThis.fetch = mockFetch
+
+    const { previewMapping } = await import('./client.js')
+    await previewMapping({
+      uploads: [
+        { algorithm: 'EAVA', file: new File(['a'], 'eava.csv') },
+        { algorithm: 'InterVA', file: new File(['b'], 'interva.csv') },
+      ],
+      ageGroup: 'child',
+    })
+
+    const [url, options] = mockFetch.mock.calls[0]
+    expect(new URL(url, 'http://localhost').searchParams.get('age_group')).toBe('child')
+    expect(options.body.get('file_eava')).toBeInstanceOf(File)
+    expect(options.body.get('file_interva')).toBeInstanceOf(File)
+    expect(options.body.get('age_group')).toBeNull()
+  })
+})

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -92,7 +92,6 @@ export async function submitJob({ uploads, jobType, algorithms, ageGroup, countr
 // `file` and `file_<algo>` so the report is keyed by algorithm either way.
 export async function previewMapping({ uploads, ageGroup }) {
   const formData = new FormData();
-  formData.append('age_group', ageGroup);
   const withFiles = (uploads || []).filter(u => u.file && u.algorithm);
   if (withFiles.length === 1) {
     formData.append('file', withFiles[0].file);
@@ -102,7 +101,14 @@ export async function previewMapping({ uploads, ageGroup }) {
       formData.append(`file_${algorithm.toLowerCase()}`, file);
     });
   }
-  return fetchJson(`${API_BASE}/jobs/preview`, { method: 'POST', body: formData });
+  // age_group goes in the QUERY STRING, exactly like submitJob sends its scalars.
+  // As a multipart form field it never survives: plumber gives a text part no
+  // Content-Type, so it is parsed with parseQS, and a bare value such as "child"
+  // (no "=") parses to an empty list. The backend then saw a missing age_group,
+  // fell back to "neonate", and reported every child-only cause as unrecognized,
+  // which disabled the Calibrate button (issue #105).
+  const params = new URLSearchParams({ age_group: ageGroup });
+  return fetchJson(`${API_BASE}/jobs/preview?${params}`, { method: 'POST', body: formData });
 }
 
 export async function submitDemoJob({ jobType, algorithms, ageGroup, country, calibModelType, ensemble, nMCMC, nBurn, nThin }) {

--- a/frontend/src/api/client.test.js
+++ b/frontend/src/api/client.test.js
@@ -191,6 +191,8 @@ describe('previewMapping', () => {
     expect(url).toContain('/jobs/preview');
     expect(options.method).toBe('POST');
     expect(options.body.get('file_interva')).toBeInstanceOf(File);
-    expect(options.body.get('age_group')).toBe('neonate');
+    // age_group rides in the query string, not the multipart body -- plumber's
+    // form parser destroys bare text parts (issue #105).
+    expect(url).toContain('age_group=neonate');
   });
 })

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -107,7 +107,16 @@ export default function JobForm({ onJobSubmitted }) {
     setPreviewPending(true);
     setPreviewUnavailable(false);
     previewMapping({ uploads: withFiles, ageGroup })
-      .then(res => { if (!cancelled) { setPreviewReports(res.reports || {}); setPreviewPending(false); } })
+      // A top-level `error` (e.g. a rejected age_group) is not a per-file cause
+      // report, so it must not be swallowed into an empty report set that looks
+      // like "preview clean". Surface it via the same notice as a request
+      // failure. Issue #105.
+      .then(res => {
+        if (cancelled) return;
+        setPreviewPending(false);
+        if (res.error) { setPreviewReports({}); setPreviewUnavailable(true); return; }
+        setPreviewReports(res.reports || {});
+      })
       // Network/server failure is degraded gracefully: surface a non-blocking
       // notice rather than silently clearing, but keep Submit live — the /jobs
       // endpoint re-validates on submit, so a transient preview blip must not

--- a/frontend/src/components/JobForm.jsx
+++ b/frontend/src/components/JobForm.jsx
@@ -47,7 +47,7 @@ export default function JobForm({ onJobSubmitted }) {
   const [activeJobLog, setActiveJobLog] = useState([]);
   const [previewReports, setPreviewReports] = useState({});
   const [previewPending, setPreviewPending] = useState(false);
-  const [previewUnavailable, setPreviewUnavailable] = useState(false);
+  const [previewNotice, setPreviewNotice] = useState(null);
   // Block on both an explicit has_errors flag and a structured per-file error
   // (e.g. parse/column failure), so a preview error can never leave Submit live.
   const previewHasErrors = Object.values(previewReports).some(r => r && (r.has_errors || r.error));
@@ -100,28 +100,36 @@ export default function JobForm({ onJobSubmitted }) {
   useEffect(() => {
     const withFiles = uploads.filter(u => u.file && u.algorithm);
     if (withFiles.length === 0) {
-      setPreviewReports({}); setPreviewPending(false); setPreviewUnavailable(false);
+      setPreviewReports({}); setPreviewPending(false); setPreviewNotice(null);
       return;
     }
     let cancelled = false;
     setPreviewPending(true);
-    setPreviewUnavailable(false);
+    setPreviewNotice(null);
     previewMapping({ uploads: withFiles, ageGroup })
       // A top-level `error` (e.g. a rejected age_group) is not a per-file cause
       // report, so it must not be swallowed into an empty report set that looks
-      // like "preview clean". Surface it via the same notice as a request
-      // failure. Issue #105.
+      // like "preview clean" — and it is a validation rejection, not an outage,
+      // so show the backend's own message. Issue #105.
       .then(res => {
         if (cancelled) return;
         setPreviewPending(false);
-        if (res.error) { setPreviewReports({}); setPreviewUnavailable(true); return; }
+        if (res.error) {
+          setPreviewReports({});
+          setPreviewNotice(`Couldn't preview cause mapping: ${res.error} Your file will still be validated when you submit.`);
+          return;
+        }
         setPreviewReports(res.reports || {});
       })
       // Network/server failure is degraded gracefully: surface a non-blocking
       // notice rather than silently clearing, but keep Submit live — the /jobs
       // endpoint re-validates on submit, so a transient preview blip must not
       // strand the user.
-      .catch(() => { if (!cancelled) { setPreviewReports({}); setPreviewPending(false); setPreviewUnavailable(true); } });
+      .catch(() => {
+        if (cancelled) return;
+        setPreviewReports({}); setPreviewPending(false);
+        setPreviewNotice("Couldn't preview cause mapping (service unavailable). Your file will still be validated when you submit.");
+      });
     return () => { cancelled = true; };
   }, [uploads, ageGroup]);
 
@@ -356,9 +364,9 @@ export default function JobForm({ onJobSubmitted }) {
             </div>
           ))}
           {previewPending && <p className="cause-preview-pending" role="status">Checking cause mapping…</p>}
-          {previewUnavailable && (
+          {previewNotice && (
             <p className="cause-preview-unavailable" role="status">
-              Couldn't preview cause mapping (service unavailable). Your file will still be validated when you submit.
+              {previewNotice}
             </p>
           )}
           {Object.entries(previewReports).map(([algo, report]) => (

--- a/frontend/src/components/JobForm.preview.behavior.test.jsx
+++ b/frontend/src/components/JobForm.preview.behavior.test.jsx
@@ -63,9 +63,10 @@ describe('JobForm cause preview', () => {
 
   // Issue #105: the backend now REJECTS a missing/invalid age_group instead of
   // silently defaulting to "neonate". That top-level `error` has no `reports`, so
-  // it must surface as a notice -- not be swallowed into an empty report set that
-  // would masquerade as "preview clean".
-  it('surfaces a top-level preview error instead of treating it as a clean preview', async () => {
+  // it must surface as a notice showing the backend's own rejection message --
+  // not be swallowed into an empty report set that would masquerade as "preview
+  // clean", and not be mislabeled as a service outage.
+  it('surfaces a top-level preview error with the backend message', async () => {
     previewMapping.mockResolvedValue({
       error: "Missing required parameter 'age_group'.",
     });
@@ -74,6 +75,7 @@ describe('JobForm cause preview', () => {
     const file = new File(['ID,cause\n1,hiv\n'], 'interva.csv', { type: 'text/csv' });
     fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: [file] } });
 
-    await waitFor(() => expect(screen.getByText(/service unavailable/i)).toBeTruthy());
+    await waitFor(() => expect(screen.getByText(/Missing required parameter 'age_group'/)).toBeTruthy());
+    expect(screen.queryByText(/service unavailable/i)).toBeNull();
   });
 });

--- a/frontend/src/components/JobForm.preview.behavior.test.jsx
+++ b/frontend/src/components/JobForm.preview.behavior.test.jsx
@@ -60,4 +60,20 @@ describe('JobForm cause preview', () => {
     await waitFor(() => expect(screen.getByText(/service unavailable/i)).toBeTruthy());
     expect(screen.getByRole('button', { name: /^calibrat/i }).disabled).toBe(false);
   });
+
+  // Issue #105: the backend now REJECTS a missing/invalid age_group instead of
+  // silently defaulting to "neonate". That top-level `error` has no `reports`, so
+  // it must surface as a notice -- not be swallowed into an empty report set that
+  // would masquerade as "preview clean".
+  it('surfaces a top-level preview error instead of treating it as a clean preview', async () => {
+    previewMapping.mockResolvedValue({
+      error: "Missing required parameter 'age_group'.",
+    });
+
+    render(<JobForm onJobSubmitted={() => {}} />);
+    const file = new File(['ID,cause\n1,hiv\n'], 'interva.csv', { type: 'text/csv' });
+    fireEvent.change(document.querySelector('input[type="file"]'), { target: { files: [file] } });
+
+    await waitFor(() => expect(screen.getByText(/service unavailable/i)).toBeTruthy());
+  });
 });

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -342,6 +342,239 @@ for (age in c("neonate", "child")) {
 }
 
 # =============================================================================
+# 2f. age_group resolution -- no silent fallback (issue #105)
+# =============================================================================
+section("2f. age_group resolution (issue #105)")
+
+# Issue #105: the Calibrate button was permanently disabled for child uploads.
+# POST /jobs/preview read req$args$age_group and silently defaulted to "neonate"
+# when it was absent or empty. plumber 1.3.2 gives a multipart TEXT part no
+# Content-Type and no filename, so parser_picker() falls through to
+# parser_text(parseQS); parseQS treats the raw value as a query string, and a
+# bare "child" (no "=") parses to an EMPTY LIST. So req$args$age_group arrived as
+# list() and the endpoint silently scored child data against the NEONATE cause
+# list. A missing/invalid age_group must now fail loudly (issues #77/#89).
+test("utils.R defines resolve_age_group helper",
+     exists("resolve_age_group") && is.function(resolve_age_group))
+
+# Returns the rejection message, or "" if the call was accepted. Asserting on
+# message CONTENT (not merely "an error was raised") keeps these tests from
+# passing spuriously when the helper is missing or renamed.
+ag_reject <- function(x) {
+  e <- tryCatch({ resolve_age_group(x); NULL }, error = function(e) e)
+  if (is.null(e)) return("")
+  m <- conditionMessage(e)
+  if (grepl("could not find function|object .* not found", m)) return("")
+  m
+}
+
+# The exact corrupted shape plumber hands over for a multipart text field.
+test("resolve_age_group rejects the empty list plumber produces for multipart text fields",
+     grepl("required", ag_reject(list()), ignore.case = TRUE))
+test("resolve_age_group rejects NULL (parameter absent)",
+     grepl("required", ag_reject(NULL), ignore.case = TRUE))
+test("resolve_age_group rejects character(0)",
+     grepl("required", ag_reject(character(0)), ignore.case = TRUE))
+test("resolve_age_group rejects an empty/whitespace string",
+     grepl("required", ag_reject("   "), ignore.case = TRUE))
+test("resolve_age_group NEVER silently returns 'neonate' for a missing value",
+     nzchar(ag_reject(list())) && nzchar(ag_reject(NULL)) && nzchar(ag_reject(character(0))))
+test("resolve_age_group rejects an unsupported age group naming the valid options",
+     grepl("neonate", ag_reject("adult")) && grepl("child", ag_reject("adult")))
+test("resolve_age_group error message names the offending parameter",
+     grepl("age_group", ag_reject(list()), fixed = TRUE))
+
+# Valid values, including the case/whitespace variants a form may send.
+test("resolve_age_group accepts 'child'", identical(resolve_age_group("child"), "child"))
+test("resolve_age_group accepts 'neonate'", identical(resolve_age_group("neonate"), "neonate"))
+test("resolve_age_group normalizes case and whitespace",
+     identical(resolve_age_group("  Child "), "child") &&
+     identical(resolve_age_group("NEONATE"), "neonate"))
+
+# End-to-end mapping guarantee for the issue #105 reproduction data: a
+# broad-format CHILD upload (the shape attached to issue #101) must preview
+# completely clean, so the Calibrate button stays ENABLED.
+issue105_causes <- c(rep("other_infections", 720), rep("pneumonia", 526),
+                     rep("diarrhea", 473), rep("malaria", 201),
+                     rep("severe_malnutrition", 167), rep("hiv", 162),
+                     rep("other", 134))
+issue105_df <- data.frame(ID = as.character(seq_along(issue105_causes)),
+                          cause = issue105_causes, stringsAsFactors = FALSE)
+rep_child105 <- preview_cause_mapping(issue105_df, "child")
+test("issue #105: broad-format child upload has NO unrecognized causes",
+     length(rep_child105$unrecognized) == 0)
+test("issue #105: broad-format child upload does not block submission (has_errors FALSE)",
+     isFALSE(rep_child105$has_errors))
+test("issue #105: every child record is calibrated (2383 of 2383)",
+     rep_child105$total_records == 2383 && rep_child105$calibrated_denominator == 2383)
+test("issue #105: child broad causes map 1:1 (no cross-category folding)",
+     all(vapply(rep_child105$mapping,
+                function(m) identical(m$input_cause, m$broad_cause), logical(1))))
+
+# The failure signature of the bug, kept as documentation: the SAME data scored
+# under the wrong age group reproduces the issue report exactly (1334 of 2383,
+# hiv/other_infections/severe_malnutrition unrecognized, diarrhea and malaria
+# folded into sepsis_meningitis_inf -- a cause that is not even a child broad
+# cause). This is what a silent age_group fallback produced.
+rep_neo105 <- preview_cause_mapping(issue105_df, "neonate")
+test("issue #105: scoring child data as neonate is what produced the 1334/2383 report",
+     rep_neo105$has_errors && rep_neo105$calibrated_denominator == 1334 &&
+     setequal(vapply(rep_neo105$unrecognized, function(u) u$cause, character(1)),
+              c("hiv", "other_infections", "severe_malnutrition")))
+test("issue #105: sepsis_meningitis_inf is not a valid child broad cause",
+     !("sepsis_meningitis_inf" %in% get_broad_causes("child")))
+
+# =============================================================================
+# 2g. POST /jobs scalar parameters -- no silent fallback
+# =============================================================================
+section("2g. POST /jobs parameter validation")
+
+# Same class of defect as issue #105, on the endpoint that actually CREATES the
+# calibration. POST /jobs had nine scalars each with a silent default:
+#   job_type->"pipeline", algorithm->"InterVA", age_group->"neonate",
+#   country->"Mozambique", calib_model_type->"Mmatprior", ensemble->"FALSE",
+#   n_mcmc->"5000", n_burn->"2000", n_thin->"1"
+# It was masked only because client.js happens to send them via URLSearchParams.
+# The four that determine WHAT SCIENCE RAN are now required; the five tuning
+# knobs keep their documented defaults but reject invalid values instead of
+# turning them into NA.
+
+# Returns the rejection message, or "" if the call was accepted. Asserting on
+# message CONTENT keeps these from passing spuriously if a helper is missing.
+reject <- function(expr) {
+  e <- tryCatch({ force(expr); NULL }, error = function(e) e)
+  if (is.null(e)) return("")
+  m <- conditionMessage(e)
+  if (grepl("could not find function|object .* not found", m)) return("")
+  m
+}
+
+# --- param_scalar: conflicting repeats are an error, not a coin flip ---------
+test("param_scalar returns '' for the empty list plumber makes of a multipart field",
+     identical(param_scalar(list(), "x"), ""))
+test("param_scalar returns '' for NULL", identical(param_scalar(NULL, "x"), ""))
+test("param_scalar trims whitespace", identical(param_scalar("  child ", "x"), "child"))
+test("param_scalar accepts a repeated identical value",
+     identical(param_scalar(c("child", "child"), "x"), "child"))
+test("param_scalar REJECTS conflicting repeated values rather than taking the first",
+     grepl("conflicting", reject(param_scalar(c("child", "neonate"), "age_group"))))
+
+# --- job_type: required -----------------------------------------------------
+test("job_type is required (absent is rejected)",
+     grepl("required", reject(require_enum(list(), "job_type", VALID_JOB_TYPES))))
+test("job_type NEVER silently falls back to 'pipeline'",
+     nzchar(reject(require_enum(list(), "job_type", VALID_JOB_TYPES))) &&
+     nzchar(reject(require_enum(NULL, "job_type", VALID_JOB_TYPES))))
+test("job_type rejects an unknown value naming the valid options",
+     grepl("openva", reject(require_enum("batch", "job_type", VALID_JOB_TYPES))) &&
+     grepl("pipeline", reject(require_enum("batch", "job_type", VALID_JOB_TYPES))))
+test("job_type accepts all three supported values",
+     identical(vapply(VALID_JOB_TYPES, function(t) require_enum(t, "job_type", VALID_JOB_TYPES),
+                      character(1), USE.NAMES = FALSE), VALID_JOB_TYPES))
+test("job_type normalizes case", identical(require_enum("Pipeline", "job_type", VALID_JOB_TYPES), "pipeline"))
+
+# --- algorithm: required, single value or JSON array -------------------------
+test("algorithm is required (absent is rejected)",
+     grepl("required", reject(require_algorithms(list()))))
+test("algorithm NEVER silently falls back to 'InterVA'",
+     nzchar(reject(require_algorithms(list()))) && nzchar(reject(require_algorithms(NULL))) &&
+     nzchar(reject(require_algorithms(""))))
+test("algorithm accepts a single name", identical(require_algorithms("EAVA"), "EAVA"))
+test("algorithm accepts the JSON array the frontend sends for an ensemble",
+     identical(require_algorithms('["InterVA","EAVA"]'), c("InterVA", "EAVA")))
+test("algorithm normalizes case to the canonical spelling",
+     identical(require_algorithms("insilicova"), "InSilicoVA"))
+test("algorithm de-duplicates repeats",
+     identical(require_algorithms('["EAVA","EAVA"]'), "EAVA"))
+test("algorithm rejects an unknown name",
+     grepl("Invalid algorithm", reject(require_algorithms("Tariff"))))
+test("algorithm rejects an unknown name nested in a JSON array",
+     grepl("Tariff", reject(require_algorithms('["InterVA","Tariff"]'))))
+test("algorithm rejects an empty JSON array",
+     nzchar(reject(require_algorithms("[]"))))
+
+# --- country: required, and validated against the CHAMPS strata --------------
+test("country is required (absent is rejected)",
+     grepl("required", reject(require_enum(list(), "country", CALIBRATION_COUNTRIES))))
+test("country NEVER silently falls back to 'Mozambique'",
+     nzchar(reject(require_enum(list(), "country", CALIBRATION_COUNTRIES))) &&
+     nzchar(reject(require_enum(NULL, "country", CALIBRATION_COUNTRIES))))
+test("country rejects an unsupported country",
+     grepl("Invalid 'country'", reject(require_enum("Narnia", "country", CALIBRATION_COUNTRIES))))
+test("country accepts every CHAMPS stratum, including the pooled 'other'",
+     identical(vapply(CALIBRATION_COUNTRIES,
+                      function(c) require_enum(c, "country", CALIBRATION_COUNTRIES),
+                      character(1), USE.NAMES = FALSE), CALIBRATION_COUNTRIES))
+
+# Drift guard: CALIBRATION_COUNTRIES is hardcoded, so assert it still matches the
+# misclassification matrix it claims to mirror. Skipped loudly (not silently) if
+# the installed vacalibration cannot supply Mmat_champs.
+champs_countries <- tryCatch({
+  data(Mmat_champs, package = "vacalibration", envir = environment())
+  names(get("Mmat_champs", envir = environment())$neonate$eava$postmean)
+}, error = function(e) NULL, warning = function(w) NULL)
+if (is.null(champs_countries)) {
+  cat("  NOTE: Mmat_champs unavailable in this R library -- country drift guard could not run\n")
+} else {
+  test("CALIBRATION_COUNTRIES still matches the CHAMPS misclassification matrix strata",
+       setequal(CALIBRATION_COUNTRIES, champs_countries))
+}
+
+# --- calib_model_type: optional, defaults to Mmatprior, but validated -------
+test("calib_model_type defaults to Mmatprior when absent",
+     identical(optional_enum(list(), "calib_model_type", VALID_CALIB_MODEL_TYPES, "Mmatprior"),
+               "Mmatprior"))
+test("calib_model_type accepts Mmatfixed",
+     identical(optional_enum("Mmatfixed", "calib_model_type", VALID_CALIB_MODEL_TYPES, "Mmatprior"),
+               "Mmatfixed"))
+test("calib_model_type rejects a value it cannot map (would reach vacalibration as garbage)",
+     grepl("Invalid 'calib_model_type'",
+           reject(optional_enum("Mmatwhatever", "calib_model_type", VALID_CALIB_MODEL_TYPES, "Mmatprior"))))
+
+# --- ensemble: optional flag, must not become NA ----------------------------
+test("ensemble defaults to FALSE when absent",
+     identical(optional_flag(list(), "ensemble", FALSE), FALSE))
+test("ensemble accepts the string forms a form may send",
+     identical(optional_flag("TRUE", "ensemble", FALSE), TRUE) &&
+     identical(optional_flag("true", "ensemble", FALSE), TRUE) &&
+     identical(optional_flag("1", "ensemble", FALSE), TRUE) &&
+     identical(optional_flag("false", "ensemble", FALSE), FALSE))
+# as.logical("yes") is NA, and `if (NA && ...)` is a hard error downstream.
+test("ensemble rejects an unparseable value instead of yielding NA",
+     grepl("Invalid 'ensemble'", reject(optional_flag("maybe", "ensemble", FALSE))))
+test("ensemble never returns NA", !is.na(optional_flag(list(), "ensemble", FALSE)))
+
+# --- MCMC counts: optional, defaults kept, but must be positive integers ----
+test("n_mcmc/n_burn/n_thin keep their documented defaults when absent",
+     identical(optional_count(list(), "n_mcmc", 5000L), 5000L) &&
+     identical(optional_count(list(), "n_burn", 2000L), 2000L) &&
+     identical(optional_count(list(), "n_thin", 1L), 1L))
+test("optional_count accepts a supplied value",
+     identical(optional_count("12000", "n_mcmc", 5000L), 12000L))
+# as.integer("abc") is NA with only a warning -- that used to reach the job record.
+test("optional_count rejects a non-numeric value instead of yielding NA",
+     grepl("Invalid 'n_mcmc'", reject(optional_count("abc", "n_mcmc", 5000L))))
+test("optional_count rejects zero and negatives",
+     nzchar(reject(optional_count("0", "n_mcmc", 5000L))) &&
+     nzchar(reject(optional_count("-5", "n_mcmc", 5000L))))
+test("optional_count rejects a fractional value",
+     nzchar(reject(optional_count("1.5", "n_thin", 1L))))
+test("optional_count never returns NA",
+     !is.na(optional_count(list(), "n_mcmc", 5000L)) &&
+     !is.na(optional_count("7", "n_mcmc", 5000L)))
+
+# --- the meta-guarantee -----------------------------------------------------
+# The whole point: none of the four science-determining parameters may ever come
+# back as its old silent default when the caller did not send it.
+test("no required POST /jobs parameter resurrects its old silent default",
+     all(vapply(list(
+       function() require_enum(list(), "job_type", VALID_JOB_TYPES),
+       function() require_algorithms(list()),
+       function() resolve_age_group(list()),
+       function() require_enum(list(), "country", CALIBRATION_COUNTRIES)
+     ), function(f) nzchar(reject(f())), logical(1))))
+
+# =============================================================================
 # 3. INPUT DATA VALIDATION -- Backend RDS sample data
 # =============================================================================
 section("3. Backend RDS Sample Data")

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -559,6 +559,8 @@ test("optional_count rejects zero and negatives",
      nzchar(reject(optional_count("-5", "n_mcmc", 5000L))))
 test("optional_count rejects a fractional value",
      nzchar(reject(optional_count("1.5", "n_thin", 1L))))
+test("optional_count rejects a value past integer range instead of overflowing to NA",
+     grepl("Invalid 'n_mcmc'", reject(optional_count("3e9", "n_mcmc", 5000L))))
 test("optional_count never returns NA",
      !is.na(optional_count(list(), "n_mcmc", 5000L)) &&
      !is.na(optional_count("7", "n_mcmc", 5000L)))


### PR DESCRIPTION
Closes #105. Unblocks investigation of #101.

## What was wrong

The Calibrate button was permanently disabled for child uploads, because the cause-mapping preview was scoring them against the **neonate** cause list.

`previewMapping()` sent `age_group` as a multipart form field. plumber gives a text part no Content-Type and no filename, so `parser_picker()` falls through to `parser_text(parseQS)`; `parseQS` reads the raw part value as a query string, and a bare `child` contains no `=`, so it parses to an **empty list**. `POST /jobs/preview` could not distinguish that from an absent parameter and substituted `"neonate"` (`plumber.R:392`).

`hiv`, `other_infections` and `severe_malnutrition` are not neonate causes, so all three reported as unrecognized, `has_errors` became true, and `JobForm.jsx:468` disabled submission. `submitJob` was never affected, because it has always sent its scalars via `URLSearchParams` — which is why job submission worked while the preview did not.

## How it was confirmed

Against the **live deployed backend** (pre-fix), with the CSV attached to #101 — same file, same server, only the transport varied:

| Probe | Result |
|---|---|
| `-F age_group=child` (multipart) | 1334/2383; unrecognized `hiv`=162, `other_infections`=720, `severe_malnutrition`=167 — matches the #105 screenshot item for item |
| `?age_group=child` (query string) | 2383/2383, **zero** unrecognized, all 7 causes identity-mapped |
| `age_group` omitted entirely | **byte-identical to the multipart probe** |

That last identity is the decisive part: sending the value as multipart is indistinguishable from not sending it, so the value is *destroyed*, not mis-parsed.

Reproduced locally too — `preview_cause_mapping()` on the real 2383-record CSV as `neonate` yields exactly 1334/2383 with `diarrhea`→`sepsis_meningitis_inf` (473) and `malaria`→`sepsis_meningitis_inf` (201); `sepsis_meningitis_inf` is not even a child broad cause.

## Changes

- **`previewMapping()` sends `age_group` in the query string**, matching `submitJob`. This one change fixes #105 against the currently deployed backend, so **no backend redeploy is needed to unblock users**.
- **New parameter helpers in `jobs/utils.R`.** A parameter that determines *what science ran* is required and never guessed; a tuning knob keeps its documented default but rejects invalid values rather than letting `as.integer("abc")` or `as.logical("yes")` silently become `NA`.
- **`POST /jobs` hardened.** The same silent `age_group → "neonate"` fallback was sitting on the endpoint that *creates* the calibration, masked only because `client.js` happens to use `URLSearchParams` there. A lost value there yields a silently wrong calibration rather than a visibly disabled button.

  | Treatment | Parameters | Why |
  |---|---|---|
  | Required, never guessed | `job_type`, `algorithm`, `age_group`, `country` | Determine what science ran. `country` selects the CHAMPS misclassification matrix stratum, so a lost value calibrates against the wrong country |
  | Default kept, value validated | `calib_model_type`, `ensemble`, `n_mcmc`, `n_burn`, `n_thin` | Genuine tuning knobs with defensible conventional defaults |

- **`JobForm` surfaces a top-level preview error** instead of swallowing it into an empty report set that would look like a clean preview.

### Two further defects found in the same code

- **`POST /jobs` error handling never worked.** `return()` inside a `tryCatch` error handler exits only the handler, so a parse failure fell through and the endpoint kept running with unresolved parameters.
- **A repeated parameter with conflicting values silently took the first one.** That is another silent guess; now rejected.

### Docs that taught the bug

`backend/README.md` showed `-F "job_type=..." -F "algorithm=..." -F "age_group=..." -F "country=..."` — precisely the pattern plumber discards. Corrected to query-string transport with a required-vs-optional split, along with three stale `-F "age_group=..."` curl examples in the cause-mapping-preview plan.

## Verification

| Suite | Result |
|---|---|
| New backend parameter validation (section 2g) | 38/38 |
| Live endpoint resolution block | 20/20 |
| Issue #105 mapping assertions, real CSV | 17/17 |
| Frontend, as CI runs it | 240/240 across 32 files |

The endpoint suite **extracts the `resolved <- tryCatch(...)` block from `plumber.R` at runtime** and executes it against synthetic requests, so it cannot drift from the shipped code. It confirms the exact payload `submitJob` sends still works (single algorithm and ensemble), each required parameter now errors loudly when lost, and the five knobs still default correctly.

There is also a drift guard asserting `CALIBRATION_COUNTRIES` still equals `names(Mmat_champs$neonate$eava$postmean)`, so a future package change that alters the country strata fails a test instead of silently narrowing validation.

## Known gaps, not introduced here

- **The new backend assertions cannot run in CI.** `tests/test_vacalibration_backend.R` halts earlier at section 2b with `object 'comsamoz_CCVAoutput' not found` — the installed `vacalibration` exposes only `Mmat_champs`, `comsamoz_public_broad` and `comsamoz_public_openVAout`, and the stale name is used at 8 sites with a nested `$neonate$eava` shape, so it needs a dataset migration rather than a rename. Separately, `.github/workflows/test.yml` has no R job. The frontend guard, which covers the actual transport defect, *does* run in CI.
- **No browser confirmation yet.** `JobForm` is behind `ProtectedRoute`, and a local backend cannot be started here (`DBI`/`RPostgres` absent). Worth a click-through after deploy: Children (1–59 months) + EAVA + `sample_eava_1to59m.csv` should show 2383/2383 with Calibrate enabled.
- **`POST /jobs/demo` untouched.** Its plumber-signature defaults are a legitimate pattern for a canned demo, but it still coerces with bare `as.logical()`/`as.integer()`, so garbage can still become `NA` there. Follow-up.

## Scope caveat

**This does not explain #101.** Job submission always delivered `age_group` correctly, so "same results for uncalibrated and calibrated" is a separate defect. This PR only removes the blocker that prevented #101 from being reproduced on the dashboard.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed preview requests so age-group selections are transmitted reliably.
  * Prevented invalid or missing job parameters from being silently defaulted.
  * Improved preview error handling with clear service-unavailable feedback.
  * Added validation for algorithms, countries, calibration settings, and tuning options.

* **Documentation**
  * Clarified parameter requirements and request formatting for job submission and preview.
  * Added updated examples for uploads, previews, and ensemble requests.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->