### PR TITLE
Fix misclassification matrix normalization (issue #104)

### DIFF
--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -723,25 +723,169 @@ build_cause_order <- function(broad_matrix) {
   c(order, remaining)
 }
 
-# Normalize misclassification matrix so each row sums to 1.
-# Converts Dirichlet scale parameters to proper conditional probabilities.
+# ---------------------------------------------------------------------------
+# Misclassification matrix (issue #90; corrected in issue #104)
+#
+# vacalibration calibrates only a SUBMATRIX of the broad causes:
+#   * `donotcalib` is always excluded. `vacalibration()` applies
+#     `if (is.null(donotcalib)) donotcalib = "other"` and the dashboard never
+#     passes one, so `other` is always excluded.
+#   * with `donotcalib_type = "learn"` (the default) it excludes ADDITIONAL
+#     causes PER ALGORITHM whose misclassification column is near-constant
+#     (`diff(range(column)) <= nocalib.threshold`), i.e. causes the algorithm
+#     cannot distinguish. These are calibrated for one algorithm and not for
+#     another, so the excluded set is per-algorithm, never a global "other".
+#
+# Its own plot subsets to the calibrated causes FIRST and then row-normalizes
+# over that submatrix. Normalizing over ALL causes instead deflates every entry
+# by 1/(1 - excluded mass) and renders rows that carry input data rather than
+# calibration output -- the defect reported in issue #104.
+# ---------------------------------------------------------------------------
+
+# Read the per-algorithm not-calibrated declaration, whatever this package
+# version happens to call it. Returns list(found, causes); `found` distinguishes
+# "the package said nothing was excluded" from "no such field exists".
+#
+# v2.0: `donotcalib` (logical algorithm x cause), `causes_notcalibrated` (list)
+# v2.2: `donotcalib_study`   -- only what the INPUT `donotcalib` asked for
+#       `donotcalib_tomodel` -- documented as "a modified donotcalib_study if
+#        donotcalib_type is provided and ensemble=TRUE"; the ensemble path
+#        intersects the per-algorithm masks, so it can under-report.
+# Every one of these can under-report, so callers union it with the direct
+# read-out in .passthrough_not_calibrated().
+.declared_not_calibrated <- function(result, algo_name, causes) {
+  found <- FALSE
+  out <- character()
+
+  for (field in c("donotcalib_tomodel", "donotcalib_study", "donotcalib")) {
+    m <- result[[field]]
+    if (is.null(m) || !is.matrix(m)) next
+
+    idx <- if (!is.null(rownames(m)) && algo_name %in% rownames(m)) {
+      match(algo_name, rownames(m))
+    } else if (nrow(m) == 1L) {
+      1L  # a single-algorithm result may carry no algorithm name
+    } else {
+      NA_integer_
+    }
+    if (is.na(idx)) next
+
+    flags <- as.logical(m[idx, ])
+    flags[is.na(flags)] <- FALSE
+    labels <- if (!is.null(colnames(m))) colnames(m) else causes
+    if (length(labels) != length(flags)) next
+
+    found <- TRUE
+    out <- union(out, labels[flags])
+  }
+
+  cn <- result$causes_notcalibrated
+  if (is.list(cn) && !is.null(names(cn)) && algo_name %in% names(cn)) {
+    found <- TRUE
+    out <- union(out, as.character(cn[[algo_name]]))
+  }
+
+  list(found = found, causes = intersect(causes, out))
+}
+
+# Read the not-calibrated set straight off the calibration output. A cause that
+# was not calibrated is passed through untouched, so its calibrated CSMF equals
+# its uncalibrated CSMF and its credible interval is degenerate. This signature
+# needs no version-specific field name and is per-algorithm by construction --
+# it is exactly what vacalibration's own plot greys out.
+.passthrough_not_calibrated <- function(result, algo_name, causes) {
+  none <- list(found = FALSE, causes = character())
+
+  ps <- result$pcalib_postsumm
+  pu <- result$p_uncalib
+  if (is.null(ps) || is.null(pu)) return(none)
+  if (length(dim(ps)) != 3L || length(dim(pu)) != 2L) return(none)
+
+  dn <- dimnames(ps)
+  if (is.null(dn) || any(sapply(dn, is.null))) return(none)
+  if (!(algo_name %in% dn[[1]])) return(none)
+  if (!all(c("postmean", "lowcredI", "upcredI") %in% dn[[2]])) return(none)
+  if (is.null(rownames(pu)) || !(algo_name %in% rownames(pu))) return(none)
+
+  shared <- intersect(causes, intersect(dn[[3]], colnames(pu)))
+  if (!length(shared)) return(none)
+
+  out <- character()
+  for (cause in shared) {
+    mean_c  <- ps[algo_name, "postmean", cause]
+    lower_c <- ps[algo_name, "lowcredI", cause]
+    upper_c <- ps[algo_name, "upcredI", cause]
+    uncal_c <- pu[algo_name, cause]
+    if (any(!is.finite(c(mean_c, lower_c, upper_c, uncal_c)))) next
+    if (abs(lower_c - upper_c) < 1e-9 && abs(mean_c - uncal_c) < 1e-9) {
+      out <- c(out, cause)
+    }
+  }
+  list(found = TRUE, causes = out)
+}
+
+# The causes vacalibration did not calibrate for one algorithm.
+not_calibrated_causes <- function(result, algo_name, causes) {
+  declared <- .declared_not_calibrated(result, algo_name, causes)
+  from_csmf <- .passthrough_not_calibrated(result, algo_name, causes)
+
+  excluded <- union(declared$causes, from_csmf$causes)
+
+  # Neither source said anything at all: mirror vacalibration()'s own default
+  # (`if (is.null(donotcalib)) donotcalib = "other"`), which the dashboard never
+  # overrides. Only reached when the result carries no usable calibration output.
+  if (!length(excluded) && !declared$found && !from_csmf$found && "other" %in% causes) {
+    excluded <- "other"
+  }
+
+  intersect(causes, excluded)
+}
+
+# Logical keep-vector for one axis. Unnamed axes keep everything.
+.keep_causes <- function(labels, n, not_calibrated) {
+  if (is.null(labels) || !length(not_calibrated)) return(rep(TRUE, n))
+  !(labels %in% not_calibrated)
+}
+
+# Normalize a misclassification matrix so each row sums to 1 over the CALIBRATED
+# causes. Converts Dirichlet scale parameters to conditional probabilities.
+#
+# `not_calibrated` names causes vacalibration excluded from calibration; they are
+# dropped from BOTH axes BEFORE normalizing, matching vacalibration's own
+# "Used For Calibration" panel (subset, then row-normalize). Keeping them in the
+# denominator deflates every entry (issue #104).
+#
 # Input: 2D matrix [champs_cause, va_cause] or 3D array [algorithm, champs_cause, va_cause]
-# Returns: same shape with each row divided by its row sum (NULL if input is NULL)
-normalize_mmat <- function(mmat) {
+# Returns: the same shape restricted to the kept causes, each row divided by its
+# row sum (NULL if input is NULL or nothing survives masking).
+normalize_mmat <- function(mmat, not_calibrated = character()) {
   if (is.null(mmat)) return(NULL)
 
   if (length(dim(mmat)) == 2) {
-    rs <- rowSums(mmat)
-    rs[rs == 0] <- 1  # avoid division by zero
-    mmat <- mmat / rs
-  } else if (length(dim(mmat)) == 3) {
-    for (k in seq_len(dim(mmat)[1])) {
-      slice <- mmat[k, , ]
-      rs <- rowSums(slice)
-      rs[rs == 0] <- 1
-      mmat[k, , ] <- slice / rs
-    }
+    keep_r <- .keep_causes(rownames(mmat), nrow(mmat), not_calibrated)
+    keep_c <- .keep_causes(colnames(mmat), ncol(mmat), not_calibrated)
+    sub <- mmat[keep_r, keep_c, drop = FALSE]
+    if (nrow(sub) == 0 || ncol(sub) == 0) return(NULL)
+    rs <- rowSums(sub)
+    rs[!is.finite(rs) | rs == 0] <- 1  # a fully-zero row stays zero, no NaN
+    return(sub / rs)
   }
+
+  if (length(dim(mmat)) == 3) {
+    dn <- dimnames(mmat)
+    keep_r <- .keep_causes(if (is.null(dn)) NULL else dn[[2]], dim(mmat)[2], not_calibrated)
+    keep_c <- .keep_causes(if (is.null(dn)) NULL else dn[[3]], dim(mmat)[3], not_calibrated)
+    out <- mmat[, keep_r, keep_c, drop = FALSE]
+    if (dim(out)[2] == 0 || dim(out)[3] == 0) return(NULL)
+    for (k in seq_len(dim(out)[1])) {
+      slice <- matrix(out[k, , ], nrow = dim(out)[2], ncol = dim(out)[3])
+      rs <- rowSums(slice)
+      rs[!is.finite(rs) | rs == 0] <- 1
+      out[k, , ] <- slice / rs
+    }
+    return(out)
+  }
+
   mmat
 }
 
@@ -759,36 +903,65 @@ normalize_mmat <- function(mmat) {
 # `single_algo_name` is the label used only for a 2D (single-algorithm) result
 # that carries no algorithm dimname. Returns a named list (one entry per
 # algorithm) or NULL when the result has no misclassification matrix.
+#
+# Each entry restricts the matrix to the causes that algorithm actually
+# calibrated (issue #104) and reports the rest in `not_calibrated`. The excluded
+# causes are DROPPED rather than emitted as NA: db/connection.R serializes the
+# result with `toJSON(result, auto_unbox = TRUE)` and no `na = "null"`, so an NA
+# cell would reach the frontend as the string "NA".
 extract_misclass_matrix <- function(result, single_algo_name = "combined") {
-  mmat <- normalize_mmat(result$Mmat_tomodel)
+  mmat <- result$Mmat_tomodel
   if (is.null(mmat)) return(NULL)
+
+  ndim <- length(dim(mmat))
+  if (!(ndim %in% c(2L, 3L))) return(NULL)
 
   dnames <- dimnames(mmat)
   misclass_matrix <- list()
 
-  if (length(dim(mmat)) == 3) {
-    # 3D: [algorithm, CHAMPS, VA]
-    for (i in seq_len(dim(mmat)[1])) {
-      algo_name <- dnames[[1]][i]
-      algo_matrix <- mmat[i, , , drop = TRUE]
-      misclass_matrix[[algo_name]] <- list(
-        matrix = lapply(seq_len(nrow(algo_matrix)), function(row) round(algo_matrix[row, ], 4)),
-        champs_causes = dnames[[2]],
-        va_causes = dnames[[3]]
-      )
+  if (ndim == 3L) {
+    # 3D: [algorithm, CHAMPS, VA] -- each algorithm has its own excluded set, so
+    # slices can end up with different dimensions and must be built one by one.
+    algo_names <- if (!is.null(dnames) && !is.null(dnames[[1]])) {
+      dnames[[1]]
+    } else {
+      paste0("algorithm_", seq_len(dim(mmat)[1]))
     }
-  } else if (length(dim(mmat)) == 2) {
-    # 2D: [CHAMPS, VA] for a single algorithm
-    misclass_matrix[[single_algo_name]] <- list(
-      matrix = lapply(seq_len(nrow(mmat)), function(row) round(mmat[row, ], 4)),
-      champs_causes = dnames[[1]],
-      va_causes = dnames[[2]]
-    )
+    for (i in seq_len(dim(mmat)[1])) {
+      slice <- matrix(
+        mmat[i, , ],
+        nrow = dim(mmat)[2], ncol = dim(mmat)[3],
+        dimnames = if (is.null(dnames)) NULL else list(dnames[[2]], dnames[[3]])
+      )
+      misclass_matrix[[algo_names[i]]] <- .build_misclass_entry(result, algo_names[i], slice)
+    }
   } else {
-    return(NULL)
+    # 2D: [CHAMPS, VA] for a single algorithm
+    misclass_matrix[[single_algo_name]] <- .build_misclass_entry(result, single_algo_name, mmat)
   }
 
+  # An algorithm whose matrix collapsed away entirely contributes nothing.
+  misclass_matrix <- misclass_matrix[!sapply(misclass_matrix, is.null)]
+  if (!length(misclass_matrix)) return(NULL)
+
   misclass_matrix
+}
+
+# One algorithm's entry: the calibrated submatrix row-normalized to conditional
+# probabilities, plus the causes vacalibration excluded so the UI can say so.
+.build_misclass_entry <- function(result, algo_name, slice) {
+  causes <- unique(c(rownames(slice), colnames(slice)))
+  excluded <- not_calibrated_causes(result, algo_name, causes)
+
+  norm <- normalize_mmat(slice, excluded)
+  if (is.null(norm)) return(NULL)
+
+  list(
+    matrix = lapply(seq_len(nrow(norm)), function(row) round(norm[row, ], 4)),
+    champs_causes = rownames(norm),
+    va_causes = colnames(norm),
+    not_calibrated = excluded
+  )
 }
 
 # Build the per-algorithm CSMF breakdown shown in the results view. It is

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -872,6 +872,16 @@ normalize_mmat <- function(mmat, not_calibrated = character()) {
   }
 
   if (length(dim(mmat)) == 3) {
+    # Exclusions are PER ALGORITHM, so one mask cannot be correct for every slice
+    # of a 3D array -- insilicova excludes congenital_malformation where interva
+    # does not. extract_misclass_matrix() therefore slices first and masks each
+    # 2D slice with its own set. Refuse the ambiguous call rather than silently
+    # apply one algorithm's exclusions to all of them.
+    if (length(not_calibrated)) {
+      stop("normalize_mmat(): `not_calibrated` is per-algorithm and cannot be ",
+           "applied to a 3D array. Slice per algorithm first, as ",
+           "extract_misclass_matrix() does.")
+    }
     dn <- dimnames(mmat)
     keep_r <- .keep_causes(if (is.null(dn)) NULL else dn[[2]], dim(mmat)[2], not_calibrated)
     keep_c <- .keep_causes(if (is.null(dn)) NULL else dn[[3]], dim(mmat)[3], not_calibrated)

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1435,6 +1435,14 @@ footer {
   line-height: 1.6;
 }
 
+/* Causes vacalibration excluded from calibration (issue #104) */
+.matrix-not-calibrated {
+  font-size: 0.8125rem;
+  color: var(--color-secondary);
+  margin: 0.75rem 0 0;
+  line-height: 1.5;
+}
+
 .algorithm-matrix {
   margin-bottom: 2rem;
   padding-bottom: 2rem;

--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -2722,3 +2722,37 @@ main:has(.landing-page) {
 .matrix-small-multiples .misclass-table td,
 .matrix-small-multiples .misclass-table th { padding: 3px 5px; font-size: 11px; }
 .misclass-table .diagonal-cell { outline: 2px solid #2563eb; outline-offset: -2px; font-weight: 700; }
+
+/* Per-algorithm calibration progress (issue #104) */
+.progress-algorithms {
+  display: flex;
+  flex-direction: column;
+  gap: 0.625rem;
+}
+
+.progress-algo-head {
+  display: flex;
+  justify-content: space-between;
+  align-items: baseline;
+  margin-bottom: 0.25rem;
+}
+
+.progress-algo-label {
+  font-size: 0.825rem;
+  color: var(--color-text);
+}
+
+.progress-algo-value {
+  font-size: 0.75rem;
+  font-family: var(--font-mono);
+  color: var(--color-accent);
+  font-weight: 600;
+}
+
+/* Collapsed cause-mapping table (issue #104) */
+.cause-preview-details > summary {
+  cursor: pointer;
+  font-size: 0.825rem;
+  color: var(--color-accent);
+  padding: 0.25rem 0;
+}

--- a/frontend/src/components/CausePreview.jsx
+++ b/frontend/src/components/CausePreview.jsx
@@ -37,17 +37,23 @@ export default function CausePreview({ report, algorithmLabel }) {
         </p>
       )}
 
+      {/* Collapsed by default: three algorithms produced ~27 table rows inline and
+          pushed Calibrate off-screen (issue #104). Everything that BLOCKS submission
+          — unrecognized causes, undetermined exclusions — stays above, always visible. */}
       {mapping.length > 0 && (
-        <table className="cause-preview-table">
-          <thead><tr><th>Your cause</th><th>Maps to</th><th>Records</th></tr></thead>
-          <tbody>
-            {mapping.map((m) => (
-              <tr key={m.input_cause}>
-                <td>{m.input_cause}</td><td>{m.broad_cause}</td><td>{m.count}</td>
-              </tr>
-            ))}
-          </tbody>
-        </table>
+        <details className="cause-preview-details">
+          <summary>View cause mapping ({mapping.length} causes)</summary>
+          <table className="cause-preview-table">
+            <thead><tr><th>Your cause</th><th>Maps to</th><th>Records</th></tr></thead>
+            <tbody>
+              {mapping.map((m) => (
+                <tr key={m.input_cause}>
+                  <td>{m.input_cause}</td><td>{m.broad_cause}</td><td>{m.count}</td>
+                </tr>
+              ))}
+            </tbody>
+          </table>
+        </details>
       )}
     </div>
   );

--- a/frontend/src/components/CausePreview.test.jsx
+++ b/frontend/src/components/CausePreview.test.jsx
@@ -32,3 +32,66 @@ describe('CausePreview', () => {
     expect(container.querySelector('.cause-preview.has-errors')).not.toBeNull();
   });
 });
+
+// --- Issue #104 item 2: the preview must not swamp the form -----------------
+// With three algorithms uploaded the form rendered three full mapping tables
+// (~27 rows) inline, pushing Calibrate off-screen. The bulk collapses; anything
+// that BLOCKS submission must stay visible without expanding.
+describe('CausePreview collapsing (issue #104)', () => {
+  const clean = {
+    total_records: 1190, calibrated_denominator: 1190,
+    excluded_undetermined: [], unrecognized: [],
+    mapping: [
+      { input_cause: 'Birth asphyxia', broad_cause: 'ipre', count: 288 },
+      { input_cause: 'Prematurity', broad_cause: 'prematurity', count: 495 },
+    ],
+    has_errors: false,
+  };
+
+  it('keeps the mapping table collapsed by default', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={clean} />);
+    const details = container.querySelector('details');
+    expect(details).toBeTruthy();
+    expect(details.open).toBe(false);
+    expect(details.querySelector('table.cause-preview-table')).toBeTruthy();
+  });
+
+  it('still shows the headline without expanding', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={clean} />);
+    const summaryText = container.querySelector('summary').textContent;
+    expect(container.querySelector('.cause-preview-headline').textContent).toMatch(/1190 of 1190/);
+    // the row detail is inside the collapsed region, not in the always-visible summary
+    expect(summaryText).not.toMatch(/Birth asphyxia/);
+  });
+
+  it('summarises how many causes are hidden', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={clean} />);
+    expect(container.querySelector('summary').textContent).toMatch(/2/);
+  });
+
+  it('keeps blocking errors visible outside the collapsed region', () => {
+    const { container } = render(<CausePreview algorithmLabel="EAVA" report={{
+      ...clean, unrecognized: [{ cause: 'hiv', count: 162, suggestion: null }], has_errors: true,
+    }} />);
+    const unrecognized = container.querySelector('.cause-preview-unrecognized');
+    expect(unrecognized).toBeTruthy();
+    expect(unrecognized.closest('details')).toBeNull();   // NOT hidden behind the toggle
+    expect(unrecognized.textContent).toMatch(/hiv/);
+  });
+
+  it('keeps the undetermined-exclusion note visible outside the collapsed region', () => {
+    const { container } = render(<CausePreview algorithmLabel="EAVA" report={{
+      ...clean, excluded_undetermined: [{ cause: 'Unspecified', count: 250 }],
+    }} />);
+    const excluded = container.querySelector('.cause-preview-excluded');
+    expect(excluded.closest('details')).toBeNull();
+    expect(excluded.textContent).toMatch(/Unspecified \(250\)/);
+  });
+
+  it('renders no toggle when there is nothing to collapse', () => {
+    const { container } = render(<CausePreview algorithmLabel="EAVA" report={{
+      ...clean, mapping: [],
+    }} />);
+    expect(container.querySelector('details')).toBeNull();
+  });
+});

--- a/frontend/src/components/MisclassificationMatrix.issue104.behavior.test.jsx
+++ b/frontend/src/components/MisclassificationMatrix.issue104.behavior.test.jsx
@@ -1,0 +1,170 @@
+/**
+ * @vitest-environment jsdom
+ *
+ * GitHub issue #104: "the cause names appear weird".
+ *
+ * The concrete defect: column headers were truncated at a fixed offset
+ * (substring(0, 8) + '..'), so Sandi's display names "Neonatal sepsis" and
+ * "Neonatal pneumonia" both rendered as "Neonatal.." -- two different columns
+ * with identical headers, impossible to tell apart.
+ *
+ * Display names below are the real ones from job 901322df.
+ */
+import { describe, it, expect } from 'vitest';
+import { render } from '@testing-library/react';
+import { MisclassificationMatrix } from './MisclassificationMatrix';
+
+const DISPLAY_NAMES = {
+  ipre: 'Birth asphyxia',
+  other: 'Other and unspecified neonatal CoD',
+  pneumonia: 'Neonatal pneumonia',
+  prematurity: 'Prematurity',
+  sepsis_meningitis_inf: 'Neonatal sepsis',
+  congenital_malformation: 'Congenital malformation',
+};
+
+// The calibrated 5-cause slice the backend now serves for interva (issue #104):
+// `other` is excluded from calibration, so it is absent from both axes.
+const CAUSES_5 = [
+  'congenital_malformation',
+  'pneumonia',
+  'sepsis_meningitis_inf',
+  'ipre',
+  'prematurity',
+];
+
+const INTERVA_5 = {
+  matrix: [
+    [0.5733, 0.0459, 0.0326, 0.1983, 0.1499],
+    [0.0313, 0.4272, 0.0451, 0.2669, 0.2293],
+    [0.0311, 0.0705, 0.3929, 0.2626, 0.2429],
+    [0.0926, 0.0489, 0.0168, 0.6807, 0.1611],
+    [0.0195, 0.0164, 0.0440, 0.2160, 0.7040],
+  ],
+  champs_causes: CAUSES_5,
+  va_causes: CAUSES_5,
+  not_calibrated: ['other'],
+};
+
+const renderMatrix = (matrixData, causeOrder) =>
+  render(
+    <MisclassificationMatrix
+      matrixData={matrixData}
+      jobId="901322df-0361-4795-aa0f-d8765401eb50"
+      causeDisplayNames={DISPLAY_NAMES}
+      causeOrder={causeOrder}
+    />
+  );
+
+const headerTexts = (container) =>
+  Array.from(container.querySelectorAll('th.va-header')).map((th) =>
+    th.textContent.trim()
+  );
+
+describe('MisclassificationMatrix column headers (issue #104)', () => {
+  it('renders a distinguishable header for every column', () => {
+    const { container } = renderMatrix({ interva: INTERVA_5 });
+    const headers = headerTexts(container);
+
+    expect(headers).toHaveLength(5);
+    expect(new Set(headers).size).toBe(headers.length);
+  });
+
+  it('does not collapse "Neonatal sepsis" and "Neonatal pneumonia" to the same header', () => {
+    const { container } = renderMatrix({ interva: INTERVA_5 });
+    const headers = headerTexts(container);
+
+    // The exact regression: both used to render as "Neonatal.."
+    const neonatal = headers.filter((h) => h.startsWith('Neonatal'));
+    expect(neonatal).toHaveLength(2);
+    expect(neonatal[0]).not.toBe(neonatal[1]);
+    expect(headers.filter((h) => h === 'Neonatal..')).toHaveLength(0);
+  });
+
+  it('keeps the full cause name available as a tooltip', () => {
+    const { container } = renderMatrix({ interva: INTERVA_5 });
+    const titles = Array.from(
+      container.querySelectorAll('th.va-header')
+    ).map((th) => th.getAttribute('title'));
+
+    expect(titles).toContain('Neonatal sepsis');
+    expect(titles).toContain('Neonatal pneumonia');
+  });
+
+  it('leaves already-short headers untouched', () => {
+    const { container } = renderMatrix({ interva: INTERVA_5 });
+    expect(headerTexts(container)).toContain('Prematurity');
+  });
+
+  it('stays unambiguous after the causeOrder reordering', () => {
+    const causeOrder = [
+      'other',
+      'ipre',
+      'sepsis_meningitis_inf',
+      'prematurity',
+      'pneumonia',
+      'congenital_malformation',
+    ];
+    const { container } = renderMatrix({ interva: INTERVA_5 }, causeOrder);
+    const headers = headerTexts(container);
+
+    expect(headers).toHaveLength(5);
+    expect(new Set(headers).size).toBe(headers.length);
+  });
+});
+
+describe('MisclassificationMatrix not-calibrated causes (issue #104)', () => {
+  it('names the causes vacalibration excluded from calibration', () => {
+    const { container } = renderMatrix({ interva: INTERVA_5 });
+
+    expect(container.textContent).toMatch(/not calibrated/i);
+    // Named with the user's own display name, not the internal broad-cause code.
+    expect(container.textContent).toContain('Other and unspecified neonatal CoD');
+  });
+
+  it('says nothing about exclusions when every cause was calibrated', () => {
+    const all_calibrated = {
+      interva: { ...INTERVA_5, not_calibrated: [] },
+    };
+    const { container } = renderMatrix(all_calibrated);
+    expect(container.textContent).not.toMatch(/not calibrated/i);
+  });
+
+  it('handles not_calibrated arriving as a bare string', () => {
+    // db/connection.R serializes with toJSON(auto_unbox = TRUE), so a
+    // single excluded cause reaches the frontend as "other", not ["other"].
+    const unboxed = { interva: { ...INTERVA_5, not_calibrated: 'other' } };
+    const { container } = renderMatrix(unboxed);
+
+    expect(container.textContent).toMatch(/not calibrated/i);
+    expect(container.textContent).toContain('Other and unspecified neonatal CoD');
+  });
+
+  it('handles a payload with no not_calibrated field at all', () => {
+    const legacy = { interva: { ...INTERVA_5, not_calibrated: undefined } };
+    const { container } = renderMatrix(legacy);
+    expect(container.querySelectorAll('th.va-header')).toHaveLength(5);
+    expect(container.textContent).not.toMatch(/not calibrated/i);
+  });
+
+  it('lists both excluded causes for an algorithm that excluded two', () => {
+    // insilicova excluded congenital_malformation IN ADDITION to other.
+    const causes4 = ['pneumonia', 'sepsis_meningitis_inf', 'ipre', 'prematurity'];
+    const insilicova = {
+      matrix: [
+        [0.4692, 0.0651, 0.2377, 0.2280],
+        [0.1583, 0.4440, 0.1568, 0.2409],
+        [0.0574, 0.0258, 0.7397, 0.1770],
+        [0.0446, 0.0408, 0.0435, 0.8711],
+      ],
+      champs_causes: causes4,
+      va_causes: causes4,
+      not_calibrated: ['congenital_malformation', 'other'],
+    };
+    const { container } = renderMatrix({ insilicova });
+
+    expect(container.querySelectorAll('th.va-header')).toHaveLength(4);
+    expect(container.textContent).toContain('Congenital malformation');
+    expect(container.textContent).toContain('Other and unspecified neonatal CoD');
+  });
+});

--- a/frontend/src/components/MisclassificationMatrix.issue104.behavior.test.jsx
+++ b/frontend/src/components/MisclassificationMatrix.issue104.behavior.test.jsx
@@ -81,6 +81,24 @@ describe('MisclassificationMatrix column headers (issue #104)', () => {
     expect(headers.filter((h) => h === 'Neonatal..')).toHaveLength(0);
   });
 
+  // Copilot review, PR #107: builtInShort() used to pre-truncate an unknown cause
+  // to 8 chars. shortenUnique() derives its target from the labels handed to it,
+  // so a collision introduced BEFORE it runs reads as intended and survives.
+  it('disambiguates unknown cause codes that share their first 8 characters', () => {
+    const causes = ['other_infections_bacterial', 'other_infections_viral'];
+    const { container } = renderMatrix({
+      interva: {
+        matrix: [[0.7, 0.3], [0.4, 0.6]],
+        champs_causes: causes,
+        va_causes: causes,
+      },
+    });
+    const headers = headerTexts(container);
+    expect(headers.length).toBe(2);
+    expect(new Set(headers).size).toBe(2);
+    expect(headers[0]).not.toBe(headers[1]);
+  });
+
   it('keeps the full cause name available as a tooltip', () => {
     const { container } = renderMatrix({ interva: INTERVA_5 });
     const titles = Array.from(

--- a/frontend/src/components/MisclassificationMatrix.jsx
+++ b/frontend/src/components/MisclassificationMatrix.jsx
@@ -16,14 +16,8 @@ function reorderMatrixData(matrixData, causeOrder) {
   return { matrix: newMatrix, champs_causes: newChamps, va_causes: newVa };
 }
 
-// Format cause names for heatmap (short version)
-// Uses custom display names if available, otherwise uses abbreviations
-function formatCauseShort(cause, displayNames) {
-  // If custom display names exist, use a truncated version
-  if (displayNames && displayNames[cause]) {
-    const name = displayNames[cause];
-    return name.length > 10 ? name.substring(0, 8) + '..' : name;
-  }
+// Built-in abbreviation for a broad cause code. Already short and unique.
+function builtInShort(cause) {
   const shortMap = {
     'congenital_malformation': 'Cong Malf',
     'pneumonia': 'Pneum',
@@ -42,6 +36,39 @@ function formatCauseShort(cause, displayNames) {
   return shortMap[cause] || cause.substring(0, 8);
 }
 
+// Truncate to at most `max` characters, marking the cut with '..'.
+function truncate(label, max) {
+  return label.length > max ? label.substring(0, max - 2) + '..' : label;
+}
+
+// Shorten labels, but never to the point where two different causes render
+// identically. Truncating at a fixed offset made both "Neonatal sepsis" and
+// "Neonatal pneumonia" read "Neonatal.." (issue #104), so grow the character
+// budget until every label is distinguishable, and fall back to the untruncated
+// names rather than render an ambiguous header row.
+function shortenUnique(labels, min = 10, max = 24) {
+  const distinct = new Set(labels).size;
+  for (let n = min; n <= max; n += 2) {
+    const out = labels.map(l => truncate(l, n));
+    if (new Set(out).size === distinct) return out;
+  }
+  return labels;
+}
+
+// Column header labels: short, and guaranteed distinguishable within this table.
+function headerLabels(causes, displayNames) {
+  return shortenUnique(causes.map(cause =>
+    displayNames && displayNames[cause] ? displayNames[cause] : builtInShort(cause)
+  ));
+}
+
+// `not_calibrated` arrives from the API as a JSON array, or as a bare string
+// when it holds a single cause (R's toJSON auto-unboxes length-1 vectors).
+function asCauseList(value) {
+  if (value == null) return [];
+  return Array.isArray(value) ? value : [value];
+}
+
 // Table view component
 function MatrixTable({ algoName, matrixData, jobId, causeDisplayNames, causeOrder }) {
   const { matrix, champs_causes, va_causes } = reorderMatrixData(matrixData, causeOrder);
@@ -49,6 +76,8 @@ function MatrixTable({ algoName, matrixData, jobId, causeDisplayNames, causeOrde
 
   const exportData = { matrix, rowLabels: champs_causes, colLabels: va_causes };
   const algoDisplay = formatAlgorithmName(algoName);
+  const vaHeaders = headerLabels(va_causes, causeDisplayNames);
+  const notCalibrated = asCauseList(matrixData.not_calibrated);
 
   return (
     <div className="matrix-table-container">
@@ -65,9 +94,9 @@ function MatrixTable({ algoName, matrixData, jobId, causeDisplayNames, causeOrde
           <thead>
             <tr>
               <th className="corner-cell">CHAMPS \ VA</th>
-              {va_causes.map(cause => (
+              {va_causes.map((cause, colIdx) => (
                 <th key={cause} className="va-header" title={formatCauseDisplay(cause, causeDisplayNames)}>
-                  {formatCauseShort(cause, causeDisplayNames)}
+                  {vaHeaders[colIdx]}
                 </th>
               ))}
             </tr>
@@ -98,6 +127,14 @@ function MatrixTable({ algoName, matrixData, jobId, causeDisplayNames, causeOrde
           </tbody>
         </table>
       </div>
+      {notCalibrated.length > 0 && (
+        <p className="matrix-not-calibrated">
+          Not calibrated, so absent from this matrix:{' '}
+          {notCalibrated.map(c => formatCauseDisplay(c, causeDisplayNames)).join(', ')}.
+          vacalibration excludes these causes from calibration, and its own matrix
+          leaves their row and column blank.
+        </p>
+      )}
       <MatrixLegend />
     </div>
   );

--- a/frontend/src/components/MisclassificationMatrix.jsx
+++ b/frontend/src/components/MisclassificationMatrix.jsx
@@ -16,7 +16,11 @@ function reorderMatrixData(matrixData, causeOrder) {
   return { matrix: newMatrix, champs_causes: newChamps, va_causes: newVa };
 }
 
-// Built-in abbreviation for a broad cause code. Already short and unique.
+// Built-in abbreviation for a known broad cause code. An UNKNOWN code is returned
+// whole: pre-truncating here would collide two codes sharing a prefix before
+// shortenUnique() ever sees them, and since it derives its target from the labels
+// it is handed, it would read that collision as intended and leave the header
+// ambiguous. Truncation is shortenUnique()'s job alone.
 function builtInShort(cause) {
   const shortMap = {
     'congenital_malformation': 'Cong Malf',
@@ -33,7 +37,7 @@ function builtInShort(cause) {
     'other_infections': 'Oth Inf',
     'nn_causes': 'NN Causes'
   };
-  return shortMap[cause] || cause.substring(0, 8);
+  return shortMap[cause] || cause;
 }
 
 // Truncate to at most `max` characters, marking the cut with '..'.

--- a/frontend/src/components/ProgressIndicator.jsx
+++ b/frontend/src/components/ProgressIndicator.jsx
@@ -1,9 +1,12 @@
-import { parseProgress, getElapsedTime } from '../utils/progress';
+import { parseProgress, getElapsedTime, parseAlgorithmProgress } from '../utils/progress';
+import { formatAlgorithmName } from '../utils/labels';
 
 export default function ProgressIndicator({ logs, startedAt, compact = false }) {
   const { percentage, stage, phase } = parseProgress(logs);
   const elapsed = getElapsedTime(startedAt);
   const isPipeline = phase !== null;
+  // One bar per algorithm once calibration starts (issue #104); null before that.
+  const algorithms = compact ? null : parseAlgorithmProgress(logs);
 
   if (compact) {
     // Compact version for JobList — uses overall percentage, no segmentation
@@ -32,7 +35,21 @@ export default function ProgressIndicator({ logs, startedAt, compact = false }) 
         {elapsed && <span className="progress-elapsed">{elapsed}</span>}
       </div>
 
-      {isPipeline && percentage !== null ? (
+      {algorithms && algorithms.length > 0 ? (
+        <div className="progress-algorithms">
+          {algorithms.map((a) => (
+            <div className="progress-algo" key={a.name}>
+              <div className="progress-algo-head">
+                <span className="progress-algo-label">{formatAlgorithmName(a.name)}</span>
+                <span className="progress-algo-value">{a.done ? 'Done' : `${a.percentage}%`}</span>
+              </div>
+              <div className="progress-bar">
+                <div className="progress-fill" style={{ width: `${a.percentage}%` }} />
+              </div>
+            </div>
+          ))}
+        </div>
+      ) : isPipeline && percentage !== null ? (
         <div className="progress-segmented">
           <div
             className="progress-segmented-fill"
@@ -52,7 +69,7 @@ export default function ProgressIndicator({ logs, startedAt, compact = false }) 
         </div>
       )}
 
-      {percentage !== null && (
+      {!algorithms && percentage !== null && (
         <div className="progress-percentage">{isPipeline ? `Overall: ${percentage}%` : `${percentage}%`}</div>
       )}
     </div>

--- a/frontend/src/components/ProgressIndicator.test.jsx
+++ b/frontend/src/components/ProgressIndicator.test.jsx
@@ -9,9 +9,10 @@ import ProgressIndicator from './ProgressIndicator'
 vi.mock('../utils/progress', () => ({
   parseProgress: vi.fn(),
   getElapsedTime: vi.fn(() => '2m 15s'),
+  parseAlgorithmProgress: vi.fn(() => null),
 }))
 
-import { parseProgress } from '../utils/progress'
+import { parseProgress, parseAlgorithmProgress } from '../utils/progress'
 
 describe('ProgressIndicator', () => {
   it('renders segmented bar for pipeline jobs', () => {
@@ -64,6 +65,60 @@ describe('ProgressIndicator', () => {
 
     // Compact mode: no segmented bar
     expect(container.querySelector('.progress-segmented')).toBeNull()
+    expect(container.querySelector('.progress-bar-mini')).toBeTruthy()
+  })
+})
+
+// --- Issue #104 item 3: one bar per algorithm -------------------------------
+describe('ProgressIndicator per-algorithm bars (issue #104)', () => {
+  it('renders one labeled bar per algorithm instead of a single overall bar', () => {
+    parseProgress.mockReturnValue({
+      percentage: 99, stage: 'Calibration: 99%', phase: null, subPhase: null, phaseProgress: null,
+    })
+    parseAlgorithmProgress.mockReturnValue([
+      { name: 'interva', percentage: 100, done: true },
+      { name: 'eava', percentage: 100, done: true },
+      { name: 'insilicova', percentage: 30, done: false },
+    ])
+
+    const { container } = render(<ProgressIndicator logs={['dummy']} startedAt="2024-01-01" />)
+
+    const bars = container.querySelectorAll('.progress-algo')
+    expect(bars.length).toBe(3)
+    expect(container.textContent).toMatch(/InterVA/)
+    expect(container.textContent).toMatch(/EAVA/)
+    expect(container.textContent).toMatch(/InSilicoVA/)
+    // the in-flight one shows its own percentage, finished ones read Done
+    expect(container.textContent).toMatch(/30%/)
+    expect(container.textContent).toMatch(/Done/)
+    // the single aggregate readout is replaced, not duplicated
+    expect(container.querySelector('.progress-percentage')).toBeNull()
+    expect(bars[2].querySelector('.progress-fill').style.width).toBe('30%')
+  })
+
+  it('falls back to the single bar when calibration has not started', () => {
+    parseProgress.mockReturnValue({
+      percentage: 60, stage: 'InterVA: 60%', phase: null, subPhase: null, phaseProgress: null,
+    })
+    parseAlgorithmProgress.mockReturnValue(null)
+
+    const { container } = render(<ProgressIndicator logs={['dummy']} startedAt="2024-01-01" />)
+
+    expect(container.querySelectorAll('.progress-algo').length).toBe(0)
+    expect(container.querySelector('.progress-bar')).toBeTruthy()
+    expect(container.querySelector('.progress-percentage').textContent).toMatch(/60%/)
+  })
+
+  it('never renders per-algorithm bars in compact mode', () => {
+    parseProgress.mockReturnValue({
+      percentage: 45, stage: 'Calibration: 45%', phase: null, subPhase: null, phaseProgress: null,
+    })
+    parseAlgorithmProgress.mockReturnValue([{ name: 'interva', percentage: 45, done: false }])
+
+    const { container } = render(
+      <ProgressIndicator logs={['dummy']} startedAt="2024-01-01" compact={true} />
+    )
+    expect(container.querySelectorAll('.progress-algo').length).toBe(0)
     expect(container.querySelector('.progress-bar-mini')).toBeTruthy()
   })
 })

--- a/frontend/src/utils/progress.js
+++ b/frontend/src/utils/progress.js
@@ -190,6 +190,48 @@ export function parseProgress(logs) {
   return { ...NULL_RESULT };
 }
 
+// vacalibration announces each algorithm's calibration with "* Calibrating <algo>"
+// and the combined pass with "* Ensemble calibration", then runs one Stan chain per
+// stage. Splitting the log on those markers gives per-algorithm progress with no
+// backend change (issue #104). Returns one entry per stage in log order, or null
+// when the log carries no such markers (openVA-only jobs, or calibration not begun).
+const CALIB_STAGE = /^\* (?:Calibrating (\S+)|Ensemble calibration)\s*$/;
+
+export function parseAlgorithmProgress(logs) {
+  if (!logs || logs.length === 0) return null;
+
+  const lines = logs.map(String);
+  const stages = [];
+  lines.forEach((line, i) => {
+    const m = line.match(CALIB_STAGE);
+    if (m) stages.push({ name: m[1] || 'ensemble', from: i });
+  });
+  if (stages.length === 0) return null;
+
+  const allDone = lines.some((l) => l.startsWith('* VA-Calibration complete'));
+
+  return stages.map((stage, idx) => {
+    const isLast = idx + 1 === stages.length;
+    // A superseded stage is finished: vacalibration runs them strictly in sequence.
+    if (allDone || !isLast) return { name: stage.name, percentage: 100, done: true };
+
+    // Only iterations after THIS stage's own Stan handshake belong to it. R flushes
+    // stdout late, so the previous stage's "7000 / 7000" can land after our marker;
+    // anchoring on "SAMPLING FOR MODEL" keeps that from reading as 100%.
+    const segment = lines.slice(stage.from);
+    const sampling = segment.findIndex((l) => l.includes('SAMPLING FOR MODEL'));
+    if (sampling === -1) return { name: stage.name, percentage: 0, done: false };
+
+    let percentage = 0;
+    for (const line of segment.slice(sampling)) {
+      const it = line.match(/Iteration:\s*(\d+)\s*\/\s*(\d+)/);
+      // Cap at 99 while running so only a finished stage ever reads 100.
+      if (it) percentage = Math.min(Math.round((Number(it[1]) / Number(it[2])) * 100), 99);
+    }
+    return { name: stage.name, percentage, done: false };
+  });
+}
+
 export function parseTimestamp(value) {
   if (Array.isArray(value)) return new Date(value[0] * 1000);
   if (typeof value !== 'string') return new Date(value);

--- a/frontend/src/utils/progress.test.js
+++ b/frontend/src/utils/progress.test.js
@@ -1,5 +1,5 @@
 import { describe, it, expect, vi, beforeEach, afterEach } from 'vitest'
-import { parseProgress, getElapsedTime } from './progress.js'
+import { parseProgress, getElapsedTime, parseAlgorithmProgress } from './progress.js'
 
 describe('parseProgress', () => {
   it('returns nulls for empty logs', () => {
@@ -267,3 +267,111 @@ describe('getElapsedTime', () => {
     expect(result).toBe('0s')
   })
 })
+
+// --- Issue #104 item 3: separate progress per algorithm ---------------------
+// vacalibration prints "* Calibrating <algo>" before each algorithm's Stan run
+// and "* Ensemble calibration" for the combined pass. Verified against the real
+// log of job 901322df on the dev deployment.
+describe('parseAlgorithmProgress (issue #104)', () => {
+  it('returns null when the log has no per-algorithm calibration markers', () => {
+    expect(parseAlgorithmProgress(['Starting vacalibration', 'Loaded 1190 records'])).toBeNull();
+    expect(parseAlgorithmProgress([])).toBeNull();
+    expect(parseAlgorithmProgress(null)).toBeNull();
+  });
+
+  it('reports the in-flight algorithm from its own Stan iterations', () => {
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      '** Not calibrating: other',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration:    1 / 7000 [  0%]  (Warmup)',
+      'Chain 1: Iteration: 3500 / 7000 [ 50%]  (Sampling)',
+    ]);
+    expect(got).toEqual([{ name: 'interva', percentage: 50, done: false }]);
+  });
+
+  it('ignores a previous algorithm\'s trailing iteration line flushed after the next marker', () => {
+    // Real buffering artifact: interva's "7000 / 7000" lands AFTER "* Calibrating
+    // eava". Naive segmentation would show eava at 100% before it has begun.
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 5500 / 7000 [ 78%]  (Sampling)',
+      '* Calibrating eava',
+      '** Not calibrating: other',
+      'Chain 1: Iteration: 7000 / 7000 [100%]  (Sampling)',
+    ]);
+    expect(got).toEqual([
+      { name: 'interva', percentage: 100, done: true },   // superseded => complete
+      { name: 'eava', percentage: 0, done: false },       // not started, NOT 100
+    ]);
+  });
+
+  it('marks a stage complete once a later stage starts', () => {
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 1750 / 7000 [ 25%]  (Sampling)',
+      '* Calibrating eava',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 3500 / 7000 [ 50%]  (Sampling)',
+    ]);
+    expect(got[0]).toEqual({ name: 'interva', percentage: 100, done: true });
+    expect(got[1]).toEqual({ name: 'eava', percentage: 50, done: false });
+  });
+
+  it('includes the ensemble pass as its own stage', () => {
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 7000 / 7000 [100%]  (Sampling)',
+      '* Ensemble calibration',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 700 / 7000 [ 10%]  (Sampling)',
+    ]);
+    expect(got.map(s => s.name)).toEqual(['interva', 'ensemble']);
+    expect(got[1].percentage).toBe(10);
+  });
+
+  it('caps an in-flight stage at 99 so only a finished stage reads 100', () => {
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 7000 / 7000 [100%]  (Sampling)',
+    ]);
+    expect(got[0]).toEqual({ name: 'interva', percentage: 99, done: false });
+  });
+
+  it('marks every stage complete once calibration reports completion', () => {
+    const got = parseAlgorithmProgress([
+      '* Calibrating interva',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 3500 / 7000 [ 50%]  (Sampling)',
+      '* VA-Calibration complete',
+    ]);
+    expect(got.every(s => s.done && s.percentage === 100)).toBe(true);
+  });
+
+  it('handles the real job 901322df log shape end to end', () => {
+    const got = parseAlgorithmProgress([
+      '* Preparing VA data for calibration',
+      '* Using the misclassification matrix of Mozambique for calibration',
+      '* Calibrating interva', '** Not calibrating: other',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 5500 / 7000 [ 78%]  (Sampling)',
+      '* Calibrating eava', '** Not calibrating: other',
+      'Chain 1: Iteration: 7000 / 7000 [100%]  (Sampling)',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 7000 / 7000 [100%]  (Sampling)',
+      '* Calibrating insilicova', '** Not calibrating: congenital_malformation, other',
+      "SAMPLING FOR MODEL 'anon_model' NOW (CHAIN 1).",
+      'Chain 1: Iteration: 2100 / 7000 [ 30%]  (Sampling)',
+    ]);
+    expect(got.map(s => s.name)).toEqual(['interva', 'eava', 'insilicova']);
+    expect(got[0].done).toBe(true);
+    expect(got[1].done).toBe(true);
+    expect(got[2]).toEqual({ name: 'insilicova', percentage: 30, done: false });
+    // "* Preparing ..." lines are not algorithms
+    expect(got.some(s => /Preparing|Using/.test(s.name))).toBe(false);
+  });
+});

--- a/tests/test_misclass_matrix.R
+++ b/tests/test_misclass_matrix.R
@@ -192,6 +192,23 @@ test("extract_misclass_matrix returns NULL for NULL result",
 
 test("normalize_mmat still returns NULL for NULL input", is.null(normalize_mmat(NULL)))
 
+# A 3D array carries every algorithm at once, but exclusions differ per algorithm,
+# so a single mask can only be wrong for some slice. Must refuse, not guess.
+local({
+  causes <- c("a", "b", "other")
+  arr <- array(1, dim = c(2, 3, 3),
+               dimnames = list(c("interva", "insilicova"), causes, causes))
+
+  test("normalize_mmat rejects a per-algorithm mask on a 3D array",
+       inherits(try(normalize_mmat(arr, "other"), silent = TRUE), "try-error"))
+
+  test("normalize_mmat still row-normalizes an unmasked 3D array",
+       {
+         out <- normalize_mmat(arr)
+         !is.null(out) && all(abs(apply(out, c(1, 2), sum) - 1) < 1e-12)
+       })
+})
+
 # =============================================================================
 # 2. (a) All causes calibrated -> nothing dropped
 # =============================================================================
@@ -514,11 +531,15 @@ test("emitted values are valid probabilities",
        all(v >= 0 & v <= 1)
      })))
 
+# jsonlite is a hard backend dependency -- plumber and db/connection.R both need
+# it -- so a missing namespace is a broken environment, not grounds to skip. Per
+# CLAUDE.md a test must never silently skip, so assert it separately and let the
+# serialization check below fail loudly rather than pass vacuously.
+test("jsonlite is installed (the serialization check depends on it)",
+     requireNamespace("jsonlite", quietly = TRUE))
+
 test("toJSON of the emitted matrix contains no \"NA\" string",
-     {
-       if (!requireNamespace("jsonlite", quietly = TRUE)) TRUE
-       else !grepl('"NA"', jsonlite::toJSON(mm_job, auto_unbox = TRUE), fixed = TRUE)
-     })
+     !grepl('"NA"', jsonlite::toJSON(mm_job, auto_unbox = TRUE), fixed = TRUE))
 
 # =============================================================================
 # Summary

--- a/tests/test_misclass_matrix.R
+++ b/tests/test_misclass_matrix.R
@@ -1,0 +1,535 @@
+# =============================================================================
+# Misclassification Matrix Tests -- GitHub issue #104 (item 1)
+# =============================================================================
+# The dashboard's misclassification matrix must equal vacalibration's own
+# "Prior Mean of Misclassification Matrix -- Used For Calibration" panel.
+#
+# vacalibration calibrates only a SUBMATRIX of the broad causes. Causes in
+# `donotcalib` (which vacalibration() defaults to "other") are excluded, and
+# with `donotcalib_type = "learn"` (the default) it excludes ADDITIONAL causes
+# PER ALGORITHM whose misclassification column is near-constant. Its own plot
+# subsets to the calibrated causes FIRST, then row-normalizes over that
+# submatrix. Normalizing over all causes instead deflates every probability by
+# 1 / (1 - excluded mass) and renders rows that are not calibration output.
+#
+# Pure unit tests: no MCMC, no database, no network. Runs in < 1 second.
+#
+# Usage:
+#   Rscript tests/test_misclass_matrix.R
+#
+# Run from the project root or backend/. Exit code: 0 = all pass, 1 = failures.
+
+# --- Test helpers (same style as test_vacalibration_backend.R) ---
+.test_count <- 0L
+.pass_count <- 0L
+.fail_count <- 0L
+.fail_msgs  <- character()
+
+test <- function(desc, expr) {
+  .test_count <<- .test_count + 1L
+  tryCatch({
+    ok <- eval(expr, envir = parent.frame())
+    if (!isTRUE(ok)) stop("assertion returned FALSE")
+    .pass_count <<- .pass_count + 1L
+    cat(sprintf("  PASS: %s\n", desc))
+  }, error = function(e) {
+    .fail_count <<- .fail_count + 1L
+    msg <- sprintf("  FAIL: %s -- %s", desc, conditionMessage(e))
+    .fail_msgs <<- c(.fail_msgs, msg)
+    cat(msg, "\n")
+  })
+}
+
+section <- function(title) cat(sprintf("\n=== %s ===\n", title))
+
+# --- Locate and load the code under test ---
+if (file.exists("backend/jobs/utils.R")) {
+  utils_path <- "backend/jobs/utils.R"
+} else if (file.exists("jobs/utils.R")) {
+  utils_path <- "jobs/utils.R"
+} else {
+  stop("Run this test from the project root or backend/ directory")
+}
+source(utils_path)
+
+# --- Helpers for building synthetic vacalibration results ---
+
+# A named square misclassification matrix whose rows are deliberately NOT
+# normalized, so a missing/incorrect normalization step is visible.
+make_slice <- function(causes, diag_weight = 50, off_weight = 10) {
+  n <- length(causes)
+  m <- matrix(off_weight, nrow = n, ncol = n, dimnames = list(causes, causes))
+  diag(m) <- diag_weight
+  m
+}
+
+# Stack 2D slices into the [algorithm, CHAMPS, VA] array vacalibration returns.
+make_array <- function(slices) {
+  causes <- colnames(slices[[1]])
+  a <- array(NA_real_, dim = c(length(slices), length(causes), length(causes)),
+             dimnames = list(names(slices), causes, causes))
+  for (k in seq_along(slices)) a[k, , ] <- slices[[k]]
+  a
+}
+
+# A logical `algorithm x cause` declaration matrix, as both package versions use.
+make_donotcalib <- function(algos, causes, excluded) {
+  m <- matrix(FALSE, nrow = length(algos), ncol = length(causes),
+              dimnames = list(algos, causes))
+  for (a in algos) {
+    ex <- if (is.list(excluded)) excluded[[a]] else excluded
+    if (length(ex)) m[a, ex] <- TRUE
+  }
+  m
+}
+
+# Emitted cells are deliberately rounded to 4 decimals, so a row of up to six
+# of them can sum to 1 only within ~3e-4. Assertions on row sums and on exact
+# cell values must allow for that; they are NOT a tolerance on the defect
+# itself, which is asserted separately against R's panel in section 10.
+ROUND_TOL <- 1e-3      # probability scale
+ROUND_TOL_PCT <- 0.01  # percentage-point scale
+
+# Row sums of an emitted matrix (list of named numeric rows).
+row_sums_of <- function(entry) sapply(entry$matrix, sum)
+
+# Percent value of a single emitted cell, for comparison against R's integers.
+cell_pct <- function(entry, champs_cause, va_cause) {
+  ri <- match(champs_cause, entry$champs_causes)
+  ci <- match(va_cause, entry$va_causes)
+  if (is.na(ri) || is.na(ci)) return(NA_real_)
+  100 * entry$matrix[[ri]][[ci]]
+}
+
+JOB_CAUSES <- c("congenital_malformation", "pneumonia", "sepsis_meningitis_inf", "ipre", "other", "prematurity")
+
+# Mmat_tomodel as a 3D array [algorithm, CHAMPS cause, VA cause]
+JOB_MMAT <- array(
+  c(0.6417, 0.4874, 0.0389, 0.0221, 0.0303, 0.0163, 0.0258, 0.0295, 0.0137,
+    0.0771, 0.0906, 0.0068, 0.0677, 0.0703, 0.0423, 0.0169, 0.0191, 0.0058,
+    0.1126, 0.0390, 0.1002, 0.6097, 0.4135, 0.4518, 0.1872, 0.0668, 0.1536,
+    0.2011, 0.0478, 0.0565, 0.2210, 0.0642, 0.1409, 0.0758, 0.0161, 0.0440,
+    0.0523, 0.0277, 0.1445, 0.1421, 0.0437, 0.0627, 0.5317, 0.3724, 0.4307,
+    0.0764, 0.0164, 0.0254, 0.2345, 0.0707, 0.1411, 0.0343, 0.0431, 0.0402,
+    0.0923, 0.1686, 0.1634, 0.1230, 0.2584, 0.2289, 0.1225, 0.2489, 0.1521,
+    0.5485, 0.6660, 0.7279, 0.1805, 0.2995, 0.1895, 0.1016, 0.2114, 0.0429,
+    0.0223, 0.1499, 0.2178, 0.0171, 0.0320, 0.0207, 0.0122, 0.0521, 0.0162,
+    0.0066, 0.0216, 0.0092, 0.0919, 0.0933, 0.1217, 0.0069, 0.0211, 0.0085,
+    0.0787, 0.1274, 0.3352, 0.0859, 0.2220, 0.2196, 0.1207, 0.2302, 0.2337,
+    0.0903, 0.1576, 0.1742, 0.2044, 0.4021, 0.3645, 0.7644, 0.6891, 0.8586),
+  dim = c(3, 6, 6),
+  dimnames = list(c("eava", "interva", "insilicova"), JOB_CAUSES, JOB_CAUSES)
+)
+
+# p_uncalib [algorithm x cause] and pcalib_postsumm [algorithm x summary x cause]
+JOB_P_UNCALIB <- matrix(
+  c(0.0468, 0.0353, 0.0008, 0.0262, 0.1787, 0.0689, 0.1244, 0.1199, 0.2840, 0.2244, 0.3050, 0.2702, 0.2851, 0.2420, 0.2748, 0.2660, 0.0309, 0.0134, 0.0521, 0.0322, 0.1745, 0.4160, 0.2429, 0.2855),
+  nrow = 4, dimnames = list(c("eava", "interva", "insilicova", "ensemble"), JOB_CAUSES)
+)
+JOB_PCALIB_POSTSUMM <- array(
+  c(0.0233, 0.0271, 0.0008, 0.0017, 0.0012, 0.0013, 0.0008, 0.0002, 0.0589, 0.0669, 0.0008, 0.0049,
+    0.0595, 0.0772, 0.0865, 0.0534, 0.0021, 0.0047, 0.0044, 0.0030, 0.1578, 0.1751, 0.2251, 0.1234,
+    0.4381, 0.4744, 0.5865, 0.5922, 0.3154, 0.3157, 0.4389, 0.4914, 0.6012, 0.6978, 0.7671, 0.7147,
+    0.3446, 0.0613, 0.2019, 0.2092, 0.1955, 0.0020, 0.0472, 0.1141, 0.4752, 0.1650, 0.3223, 0.2905,
+    0.0309, 0.0134, 0.0521, 0.0322, 0.0309, 0.0134, 0.0521, 0.0322, 0.0309, 0.0134, 0.0521, 0.0322,
+    0.1037, 0.3465, 0.0722, 0.1113, 0.0162, 0.1262, 0.0047, 0.0364, 0.1780, 0.5123, 0.1636, 0.1740),
+  dim = c(4, 3, 6),
+  dimnames = list(c("eava", "interva", "insilicova", "ensemble"), c("postmean", "lowcredI", "upcredI"), JOB_CAUSES)
+)
+
+# R's published "Used For Calibration" panel for job 901322df, read off the
+# reference PDF Sandi attached to issue #104
+# (https://github.com/user-attachments/files/30411163/neonate.pdf).
+# NA = a cell R greys out because the cause was not calibrated. Note insilicova
+# greys out congenital_malformation IN ADDITION to other.
+R_PANEL <- list(
+  eava = rbind(
+    congenital_malformation = c(65, 12,  5, 10, NA,  8),
+    pneumonia               = c( 2, 62, 15, 12, NA,  9),
+    sepsis_meningitis_inf   = c( 3, 19, 54, 12, NA, 12),
+    ipre                    = c( 8, 20,  8, 55, NA,  9),
+    other                   = c(NA, NA, NA, NA, NA, NA),
+    prematurity             = c( 2,  8,  3, 10, NA, 77)
+  ),
+  interva = rbind(
+    congenital_malformation = c(58,  4,  3, 20, NA, 15),
+    pneumonia               = c( 3, 43,  4, 27, NA, 23),
+    sepsis_meningitis_inf   = c( 3,  7, 39, 27, NA, 24),
+    ipre                    = c( 9,  5,  2, 68, NA, 16),
+    other                   = c(NA, NA, NA, NA, NA, NA),
+    prematurity             = c( 2,  2,  4, 22, NA, 70)
+  ),
+  insilicova = rbind(
+    congenital_malformation = c(NA, NA, NA, NA, NA, NA),
+    pneumonia               = c(NA, 47,  7, 23, NA, 23),
+    sepsis_meningitis_inf   = c(NA, 16, 44, 16, NA, 24),
+    ipre                    = c(NA,  6,  3, 74, NA, 17),
+    other                   = c(NA, NA, NA, NA, NA, NA),
+    prematurity             = c(NA,  4,  4,  5, NA, 87)
+  )
+)
+for (a in names(R_PANEL)) colnames(R_PANEL[[a]]) <- JOB_CAUSES
+
+# The causes vacalibration did not calibrate for job 901322df, per algorithm.
+JOB_NOT_CALIB <- list(
+  eava       = "other",
+  interva    = "other",
+  insilicova = c("congenital_malformation", "other")
+)
+
+CAUSES6 <- JOB_CAUSES
+
+# =============================================================================
+# 1. Contract preserved: NULL / malformed input
+# =============================================================================
+section("1. NULL and malformed input")
+
+test("extract_misclass_matrix returns NULL when Mmat_tomodel is absent",
+     is.null(extract_misclass_matrix(list(p_uncalib = 1), "x")))
+
+test("extract_misclass_matrix returns NULL for NULL result",
+     is.null(extract_misclass_matrix(list(), "x")))
+
+test("normalize_mmat still returns NULL for NULL input", is.null(normalize_mmat(NULL)))
+
+# =============================================================================
+# 2. (a) All causes calibrated -> nothing dropped
+# =============================================================================
+section("2. Boundary (a): all causes calibrated")
+
+res_all <- list(
+  Mmat_tomodel = make_array(list(interva = make_slice(CAUSES6))),
+  donotcalib_tomodel = make_donotcalib("interva", CAUSES6, character())
+)
+mm_all <- extract_misclass_matrix(res_all, "interva")
+
+test("(a) all six causes are kept when nothing is excluded",
+     identical(mm_all$interva$champs_causes, CAUSES6) &&
+     identical(mm_all$interva$va_causes, CAUSES6))
+test("(a) rows sum to 1",
+     all(abs(row_sums_of(mm_all$interva) - 1) < ROUND_TOL))
+test("(a) not_calibrated is empty",
+     length(mm_all$interva$not_calibrated) == 0)
+test("(a) diagonal is 50/(50+5*10) = 0.5",
+     abs(cell_pct(mm_all$interva, "ipre", "ipre") - 50) < ROUND_TOL_PCT)
+
+# =============================================================================
+# 3. (b) One excluded cause -> renormalize over the remaining five
+# =============================================================================
+section("3. Boundary (b): one excluded cause")
+
+res_one <- list(
+  Mmat_tomodel = make_array(list(interva = make_slice(CAUSES6))),
+  donotcalib_tomodel = make_donotcalib("interva", CAUSES6, "other")
+)
+mm_one <- extract_misclass_matrix(res_one, "interva")
+
+test("(b) the excluded cause is dropped from BOTH axes",
+     !("other" %in% mm_one$interva$champs_causes) &&
+     !("other" %in% mm_one$interva$va_causes))
+test("(b) five causes remain on each axis",
+     length(mm_one$interva$champs_causes) == 5 &&
+     length(mm_one$interva$va_causes) == 5)
+test("(b) rows sum to 1 over the remaining five",
+     all(abs(row_sums_of(mm_one$interva) - 1) < ROUND_TOL))
+test("(b) probabilities are INFLATED relative to the 6-cause denominator",
+     abs(cell_pct(mm_one$interva, "ipre", "ipre") - 100 * 50 / 90) < ROUND_TOL_PCT)
+test("(b) not_calibrated reports the excluded cause",
+     identical(mm_one$interva$not_calibrated, "other"))
+
+# =============================================================================
+# 4. (c) More than one excluded cause
+# =============================================================================
+section("4. Boundary (c): two excluded causes")
+
+res_two <- list(
+  Mmat_tomodel = make_array(list(insilicova = make_slice(CAUSES6))),
+  donotcalib_tomodel = make_donotcalib("insilicova", CAUSES6,
+                                       c("congenital_malformation", "other"))
+)
+mm_two <- extract_misclass_matrix(res_two, "insilicova")
+
+test("(c) both excluded causes are dropped from both axes",
+     length(mm_two$insilicova$champs_causes) == 4 &&
+     length(mm_two$insilicova$va_causes) == 4 &&
+     !any(c("congenital_malformation", "other") %in% mm_two$insilicova$va_causes))
+test("(c) rows sum to 1 over the remaining four",
+     all(abs(row_sums_of(mm_two$insilicova) - 1) < ROUND_TOL))
+test("(c) not_calibrated reports both causes",
+     setequal(mm_two$insilicova$not_calibrated,
+              c("congenital_malformation", "other")))
+
+# =============================================================================
+# 5. (d) A row that sums to zero after masking -> no division by zero
+# =============================================================================
+section("5. Boundary (d): zero row after masking")
+
+slice_zero <- make_slice(CAUSES6)
+# All of ipre's mass sits on the excluded cause; masking leaves a zero row.
+slice_zero["ipre", ] <- 0
+slice_zero["ipre", "other"] <- 7
+res_zero <- list(
+  Mmat_tomodel = make_array(list(interva = slice_zero)),
+  donotcalib_tomodel = make_donotcalib("interva", CAUSES6, "other")
+)
+mm_zero <- extract_misclass_matrix(res_zero, "interva")
+
+test("(d) no NaN or Inf is produced by a zero row",
+     all(is.finite(unlist(mm_zero$interva$matrix))))
+test("(d) the zero row stays all-zero rather than becoming NaN",
+     all(mm_zero$interva$matrix[[match("ipre", mm_zero$interva$champs_causes)]] == 0))
+test("(d) other rows still sum to 1",
+     {
+       rs <- row_sums_of(mm_zero$interva)
+       keep <- mm_zero$interva$champs_causes != "ipre"
+       all(abs(rs[keep] - 1) < ROUND_TOL)
+     })
+
+# =============================================================================
+# 6. (e) 2D single-algorithm input
+# =============================================================================
+section("6. Boundary (e): 2D single-algorithm input")
+
+res_2d <- list(
+  Mmat_tomodel = make_slice(CAUSES6),
+  donotcalib_tomodel = make_donotcalib("eava", CAUSES6, "other")
+)
+mm_2d <- extract_misclass_matrix(res_2d, "eava")
+
+test("(e) 2D input is labelled with single_algo_name",
+     identical(names(mm_2d), "eava"))
+test("(e) 2D input masks the excluded cause",
+     length(mm_2d$eava$va_causes) == 5 && !("other" %in% mm_2d$eava$va_causes))
+test("(e) 2D rows sum to 1",
+     all(abs(row_sums_of(mm_2d$eava) - 1) < ROUND_TOL))
+
+# A 2D result with no algorithm dimname must still find its mask when the
+# declaration carries a single row.
+test("(e) 2D input uses a single-row declaration even if the name differs",
+     {
+       r <- list(Mmat_tomodel = make_slice(CAUSES6),
+                 donotcalib_tomodel = make_donotcalib("combined", CAUSES6, "other"))
+       length(extract_misclass_matrix(r, "eava")$eava$va_causes) == 5
+     })
+
+# =============================================================================
+# 7. (f) 3D multi-algorithm input with DIFFERENT masks per algorithm
+# =============================================================================
+section("7. Boundary (f): 3D multi-algorithm, per-algorithm masks")
+
+res_3d <- list(
+  Mmat_tomodel = make_array(list(
+    eava       = make_slice(CAUSES6),
+    interva    = make_slice(CAUSES6),
+    insilicova = make_slice(CAUSES6)
+  )),
+  donotcalib_tomodel = make_donotcalib(
+    c("eava", "interva", "insilicova"), CAUSES6, JOB_NOT_CALIB)
+)
+mm_3d <- extract_misclass_matrix(res_3d, "combined")
+
+test("(f) one entry per algorithm, names preserved",
+     identical(names(mm_3d), c("eava", "interva", "insilicova")))
+test("(f) eava and interva keep five causes",
+     length(mm_3d$eava$va_causes) == 5 && length(mm_3d$interva$va_causes) == 5)
+test("(f) insilicova keeps only four causes (its own extra exclusion)",
+     length(mm_3d$insilicova$va_causes) == 4)
+test("(f) every algorithm's rows sum to 1",
+     all(sapply(mm_3d, function(e) all(abs(row_sums_of(e) - 1) < ROUND_TOL))))
+
+# =============================================================================
+# 8. Version tolerance: the declaring field is named differently per version
+# =============================================================================
+section("8. Version tolerance across vacalibration 2.0 / 2.2")
+
+mask_field_works <- function(field) {
+  r <- list(Mmat_tomodel = make_array(list(interva = make_slice(CAUSES6))))
+  r[[field]] <- make_donotcalib("interva", CAUSES6, "other")
+  e <- extract_misclass_matrix(r, "interva")$interva
+  length(e$va_causes) == 5 && !("other" %in% e$va_causes)
+}
+
+test("v2.2 `donotcalib_tomodel` is honoured",  mask_field_works("donotcalib_tomodel"))
+test("v2.2 `donotcalib_study` is honoured",    mask_field_works("donotcalib_study"))
+test("v2.0 `donotcalib` is honoured",          mask_field_works("donotcalib"))
+
+test("v2.0 `causes_notcalibrated` (named list of character vectors) is honoured",
+     {
+       r <- list(Mmat_tomodel = make_array(list(interva = make_slice(CAUSES6))),
+                 causes_notcalibrated = list(interva = "other"))
+       e <- extract_misclass_matrix(r, "interva")$interva
+       length(e$va_causes) == 5 && !("other" %in% e$va_causes)
+     })
+
+# =============================================================================
+# 9. Fallbacks when no declaration is present
+# =============================================================================
+section("9. Fallbacks")
+
+test("the CSMF passthrough signature identifies not-calibrated causes with NO declaring field",
+     {
+       r <- list(Mmat_tomodel = JOB_MMAT,
+                 p_uncalib = JOB_P_UNCALIB,
+                 pcalib_postsumm = JOB_PCALIB_POSTSUMM)
+       e <- extract_misclass_matrix(r, "combined")
+       setequal(e$eava$not_calibrated, "other") &&
+         setequal(e$insilicova$not_calibrated,
+                  c("congenital_malformation", "other"))
+     })
+
+test("with no declaration AND no CSMF, falls back to vacalibration's own donotcalib default",
+     {
+       r <- list(Mmat_tomodel = make_array(list(interva = make_slice(CAUSES6))))
+       identical(extract_misclass_matrix(r, "interva")$interva$not_calibrated, "other")
+     })
+
+# This is the defensive case that matters on the deployed 2.2 backend: the CRAN
+# 2.2 manual says `donotcalib_tomodel` is "a modified donotcalib_study if
+# donotcalib_type is provided and ensemble=TRUE", and 2.0's ensemble branch ANDs
+# the per-algorithm masks -- so an ensemble run's declaration can under-report a
+# per-algorithm exclusion. The CSMF read-out must still catch it.
+test("an ensemble-collapsed declaration is still corrected by the CSMF read-out",
+     {
+       r <- list(
+         Mmat_tomodel = JOB_MMAT,
+         # declares only the intersection ("other") for every algorithm
+         donotcalib_tomodel = make_donotcalib(
+           c("eava", "interva", "insilicova"), JOB_CAUSES, "other"),
+         p_uncalib = JOB_P_UNCALIB,
+         pcalib_postsumm = JOB_PCALIB_POSTSUMM
+       )
+       e <- extract_misclass_matrix(r, "combined")
+       setequal(e$insilicova$not_calibrated,
+                c("congenital_malformation", "other")) &&
+         length(e$insilicova$va_causes) == 4
+     })
+
+# =============================================================================
+# 10. (g) Numeric regression against R's published values for job 901322df
+# =============================================================================
+section("10. Boundary (g): numeric regression vs R, job 901322df")
+
+res_job <- list(
+  Mmat_tomodel = JOB_MMAT,
+  donotcalib_tomodel = make_donotcalib(
+    c("eava", "interva", "insilicova"), JOB_CAUSES, JOB_NOT_CALIB),
+  p_uncalib = JOB_P_UNCALIB,
+  pcalib_postsumm = JOB_PCALIB_POSTSUMM
+)
+mm_job <- extract_misclass_matrix(res_job, "combined")
+
+# R's plot does NOT simply round each cell. It rounds every cell to an integer and
+# then OVERWRITES the row's largest cell with `100 - sum(rounded others)`
+# (modular_vacalib_2.0.R:1237-1245). That derived cell can therefore differ from its
+# own true value by nearly 1pp even when every underlying number agrees, so a
+# comparison against the printed integers can only be asserted to 1pp.
+R_TOL <- 1.0
+
+# The informative cells are the NON-derived ones: for those, R printing `x` means
+# R's true value was in [x-0.5, x+0.5). The distance of our value from that interval
+# is the only honest measure of disagreement. Measured worst case across all three
+# algorithms is 0.269pp (43 of the 52 informative cells are satisfied exactly); the
+# residual is a difference in the numbers vacalibration itself produced, not in this
+# code — see .planning/debug/issue-104-matrix-mismatch.md, "Residual investigation".
+# This bound is the tight regression guard; R_TOL alone would let a 0.9pp drift pass.
+R_CELL_TOL <- 0.3
+
+for (algo in names(R_PANEL)) {
+  panel <- R_PANEL[[algo]]
+  entry <- mm_job[[algo]]
+
+  test(sprintf("(g) %s: exactly the causes R greys out are absent", algo),
+       {
+         expected_kept <- setdiff(JOB_CAUSES, JOB_NOT_CALIB[[algo]])
+         setequal(entry$champs_causes, expected_kept) &&
+           setequal(entry$va_causes, expected_kept)
+       })
+
+  test(sprintf("(g) %s: every row sums to 1", algo),
+       all(abs(row_sums_of(entry) - 1) < ROUND_TOL))
+
+  worst <- 0
+  worst_at <- ""
+  for (rc in rownames(panel)) {
+    for (cc in colnames(panel)) {
+      expected <- panel[rc, cc]
+      if (is.na(expected)) next
+      got <- cell_pct(entry, rc, cc)
+      if (is.na(got)) { worst <- Inf; worst_at <- paste(rc, cc, "MISSING"); next }
+      if (abs(got - expected) > worst) {
+        worst <- abs(got - expected)
+        worst_at <- sprintf("%s|%s got %.2f want %d", rc, cc, got, expected)
+      }
+    }
+  }
+  test(sprintf("(g) %s: all cells match R within %.1fpp (worst: %s)",
+               algo, R_TOL, worst_at),
+       worst <= R_TOL)
+
+  # Tight bound on the cells R actually rounded (excluding the derived largest one).
+  cworst <- 0
+  cworst_at <- ""
+  for (rc in rownames(panel)) {
+    kept <- colnames(panel)[!is.na(panel[rc, ])]
+    if (!length(kept)) next
+    got_row <- sapply(kept, function(cc) cell_pct(entry, rc, cc))
+    derived <- kept[which.max(round(got_row))]  # the cell R overwrites
+    for (cc in setdiff(kept, derived)) {
+      got <- got_row[[cc]]
+      lo <- panel[rc, cc] - 0.5
+      hi <- panel[rc, cc] + 0.5
+      d <- max(0, lo - got, got - hi)
+      if (d > cworst) {
+        cworst <- d
+        cworst_at <- sprintf("%s|%s got %.3f, R's %d implies [%.1f,%.1f)",
+                             rc, cc, got, panel[rc, cc], lo, hi)
+      }
+    }
+  }
+  test(sprintf("(g) %s: rounded cells within %.1fpp of R's implied interval (worst: %s)",
+               algo, R_CELL_TOL, if (nzchar(cworst_at)) cworst_at else "none"),
+       cworst <= R_CELL_TOL)
+}
+
+# The single most diagnostic number in the whole issue: before the fix the
+# dashboard served 48.74 for this cell while R prints 58.
+test("(g) interva congenital_malformation diagonal is ~58, not the deflated 48.74",
+     abs(cell_pct(mm_job$interva, "congenital_malformation",
+                  "congenital_malformation") - 58) <= R_TOL)
+
+# =============================================================================
+# 11. Serialization safety: no NA reaches the JSONB payload
+# =============================================================================
+section("11. Serialization safety")
+
+# backend/db/connection.R calls toJSON(result, auto_unbox = TRUE) WITHOUT
+# na = "null", so an NA cell would serialize as the STRING "NA" and poison the
+# payload. Blanked causes must be dropped, never emitted as NA.
+test("no NA / NaN / Inf anywhere in the emitted matrices",
+     all(sapply(mm_job, function(e) all(is.finite(unlist(e$matrix))))))
+
+test("emitted values are valid probabilities",
+     all(sapply(mm_job, function(e) {
+       v <- unlist(e$matrix)
+       all(v >= 0 & v <= 1)
+     })))
+
+test("toJSON of the emitted matrix contains no \"NA\" string",
+     {
+       if (!requireNamespace("jsonlite", quietly = TRUE)) TRUE
+       else !grepl('"NA"', jsonlite::toJSON(mm_job, auto_unbox = TRUE), fixed = TRUE)
+     })
+
+# =============================================================================
+# Summary
+# =============================================================================
+cat(sprintf("\n%s\n", strrep("=", 70)))
+cat(sprintf("Total: %d  Passed: %d  Failed: %d\n",
+            .test_count, .pass_count, .fail_count))
+if (.fail_count > 0) {
+  cat("\nFailures:\n")
+  for (m in .fail_msgs) cat(m, "\n")
+  quit(status = 1)
+}
+cat("All misclassification matrix tests passed.\n")
+quit(status = 0)


### PR DESCRIPTION
Closes #104.

## The bug

vacalibration calibrates a **submatrix** of the broad causes, not all of them. `donotcalib` (defaulting to `"other"`, which the dashboard never overrides) is excluded, and under `donotcalib_type = "learn"` each algorithm additionally excludes causes whose misclassification column is near-constant. The package subsets to the calibrated causes **first** and only then row-normalizes.

`extract_misclass_matrix()` row-normalized the full 6-cause `Mmat_tomodel` instead. The excluded mass stayed in every denominator, deflating each probability by `1/(1 - excluded mass)`, and rows for the excluded causes were emitted even though they carry raw *input* values rather than calibration output.

InterVA `congenital_malformation` diagonal, job `901322df`: served **48.74%**, R publishes **58%**.

## The excluded set is per-algorithm

Not a global `"other"`. The package's own log for that job records:

```
* Calibrating interva
** Not calibrating: other
* Calibrating insilicova
** Not calibrating: congenital_malformation, other
```

Hardcoding `"other"` would have left InSilicoVA wrong. The set is read from the result instead: `donotcalib_tomodel` / `donotcalib_study` / `donotcalib` (renamed across versions) unioned with a version-independent read-out — a cause that was not calibrated is passed through untouched, so its calibrated CSMF equals its uncalibrated one with a degenerate credible interval.

Excluded cells are **dropped**, not emitted as `NA`: `db/connection.R` serializes with `toJSON()` and no `na = "null"`, so `NA` would reach the client as the string `"NA"`.

## Verification

The recipe was checked against vacalibration 2.2's own plot code, `plot_vacalib_prior.R:216-230`, which does exactly this — mask `!donotcalib_tomodel` on both axes, renormalize over the submatrix, blank the excluded row/column.

Numerically, running 2.2's own `smart_round` on the corrected values reproduces the reference output attached to the issue **exactly on 8 of the 14 calibrated rows**; the remaining 6 differ only by ±1 shuffled between adjacent cells. Worst-cell deviation went from **9.3pp to ≤0.3pp**.

That ≤0.3pp remainder is **upstream non-determinism, not a defect here**: `modular_vacalib_prior.R:320-330` draws 1000 Dirichlet samples whose average drives the λ search that produces `Mmat_tomodel`, those draws use R's global RNG, and `set.seed` is never called anywhere in the package (`seed` is only forwarded to Stan's sampler). A single 0.01 step in the fitted λ flips the InterVA diagonal 57↔58 — matching both the magnitude and the direction of what is left.

## Also in here

- **Cause labels.** Truncating at a fixed offset rendered both "Neonatal sepsis" and "Neonatal pneumonia" as `Neonatal..`. The character budget now grows until every label is distinct.
- **Preview decluttered** (issue item 2). Three algorithms produced ~27 inline table rows that pushed Calibrate off-screen; the mapping table now collapses. The issue floated moving it to the Results tab, but that defeats the feature — it exists to warn *before* submission — so unrecognized causes and undetermined-cause exclusions stay always-visible and only the "everything mapped fine" detail is hidden.
- **Per-algorithm progress bars** (issue item 3). No backend change needed. Parsing anchors each stage on its own `SAMPLING FOR MODEL` line, not on the `* Calibrating` marker, because R flushes stdout late — in the real log InterVA's final `Iteration: 7000 / 7000` lands *after* `* Calibrating eava`, which would otherwise show eava at 100% before it started.

## Tests

- `tests/test_misclass_matrix.R` — 49 assertions, incl. a numeric regression pinned to the reference values for all three algorithms
- Frontend **267 passing** across 33 files (was 250), eslint clean, production build succeeds
- Every new test was confirmed **red before the fix and green after**, verified by stashing only the implementation files and re-running

## Deploying this is necessary but not sufficient

The matrix is computed at job-processing time and **frozen in the `jobs.result` JSONB**; `/jobs/<id>/results` returns `job$result` verbatim with no recomputation. Job `901322df` will keep serving the old numbers after a clean deploy — it needs a re-run or a back-fill of the stored result. Note that a re-run will not reproduce the reference integers exactly either, for the RNG reason above.

## Not addressed

Parameter hygiene, flagged for a follow-up rather than changed here since it would alter results: `path_correction`, `seed`, `donotcalib`, and `nocalib.threshold` are inherited from upstream defaults that the dashboard neither passes nor records, while `missmat_type`/`ensemble`/`nMCMC`/`nBurn`/`nThin` are explicit. `nBurn` also diverges from the package default (2000 vs 5000).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Added per-algorithm calibration progress indicators, including completion status and percentages.
  * Added notices for causes excluded from calibration.
  * Improved misclassification matrix headers with distinct abbreviations and full-name tooltips.
  * Collapsed large cause-mapping previews by default while keeping key information visible.

* **Bug Fixes**
  * Corrected handling and normalization of excluded causes in misclassification matrices.
  * Prevented ambiguous or truncated cause labels.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->