### PR TITLE
Fix CausePreview crash when the backend reports no close match

### DIFF
--- a/frontend/src/components/CausePreview.jsx
+++ b/frontend/src/components/CausePreview.jsx
@@ -1,3 +1,15 @@
+// R hands us a length-1 vector as ["x"] and a NULL as {} — an EMPTY OBJECT, which
+// is truthy in JS. `suggestion = if (is.na(s)) NULL else s` (backend/jobs/utils.R)
+// therefore arrives as {} whenever no close match was found, and rendering that as
+// a React child throws "Objects are not valid as a React child". Unwrap the vector
+// and treat the empty object as absent.
+function scalar(value) {
+  if (value == null) return null;
+  if (Array.isArray(value)) return value.length ? scalar(value[0]) : null;
+  if (typeof value === 'object') return null;
+  return value;
+}
+
 // Renders the backend's cause-mapping report for one algorithm. Purely
 // presentational — all mapping decisions come from the backend report, so the
 // frontend never re-implements the cause taxonomy.
@@ -18,14 +30,18 @@ export default function CausePreview({ report, algorithmLabel }) {
         <div className="cause-preview-unrecognized" role="alert">
           <p>{unrecognized.length} unrecognized cause(s) — fix these before submitting:</p>
           <ul>
-            {unrecognized.map((u) => (
-              <li key={u.cause}>
-                “{u.cause}” ({u.count} records)
-                {u.suggestion
-                  ? <> — did you mean <em>{u.suggestion}</em>?</>
-                  : <> — no close match; relabel to a supported cause.</>}
-              </li>
-            ))}
+            {unrecognized.map((u) => {
+              const cause = scalar(u.cause);
+              const suggestion = scalar(u.suggestion);
+              return (
+                <li key={cause}>
+                  “{cause}” ({scalar(u.count)} records)
+                  {suggestion
+                    ? <> — did you mean <em>{suggestion}</em>?</>
+                    : <> — no close match; relabel to a supported cause.</>}
+                </li>
+              );
+            })}
           </ul>
         </div>
       )}

--- a/frontend/src/components/CausePreview.test.jsx
+++ b/frontend/src/components/CausePreview.test.jsx
@@ -95,3 +95,45 @@ describe('CausePreview collapsing (issue #104)', () => {
     expect(container.querySelector('details')).toBeNull();
   });
 });
+
+// --- Live-shape regression: R's NULL arrives as {} ---------------------------
+// Found by rendering the real response from POST /jobs/preview on the deployment.
+// backend/jobs/utils.R:251 does `suggestion = if (is.na(s)) NULL else s`, and R's
+// list() KEEPS a NULL element, which toJSON writes as {} -- truthy in JS. The old
+// fixtures used `suggestion: null`, a shape the backend never actually sends, so
+// the crash was invisible to the suite.
+describe('CausePreview with the backend\'s real serialization', () => {
+  const liveReport = {
+    total_records: [14],
+    calibrated_denominator: [13],
+    excluded_undetermined: [],
+    unrecognized: [{ cause: ['totally_bogus_cause'], count: [1], suggestion: {} }],
+    mapping: [{ input_cause: ['Birth asphyxia'], broad_cause: ['ipre'], count: [6] }],
+    has_errors: [true],
+  };
+
+  it('renders an empty-object suggestion as "no close match" instead of crashing', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={liveReport} />);
+    const li = container.querySelector('.cause-preview-unrecognized li');
+    expect(li.textContent).toMatch(/totally_bogus_cause/);
+    expect(li.textContent).toMatch(/no close match/);
+    expect(li.textContent).not.toMatch(/did you mean/);
+  });
+
+  it('unwraps R length-1 vectors rather than printing them as arrays', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={liveReport} />);
+    const li = container.querySelector('.cause-preview-unrecognized li').textContent;
+    expect(li).toMatch(/“totally_bogus_cause” \(1 records\)/);
+    expect(container.querySelector('.cause-preview-headline').textContent).toMatch(/13 of 14/);
+  });
+
+  it('still shows a real suggestion when the backend supplies one', () => {
+    const { container } = render(<CausePreview algorithmLabel="InterVA" report={{
+      ...liveReport,
+      unrecognized: [{ cause: ['Pnemonia'], count: [2], suggestion: ['pneumonia'] }],
+    }} />);
+    const li = container.querySelector('.cause-preview-unrecognized li').textContent;
+    expect(li).toMatch(/did you mean/);
+    expect(li).toMatch(/pneumonia/);
+  });
+});


### PR DESCRIPTION
Found while testing the #107 deployment by rendering the shipped components against payloads fetched **live** from `dev.sites.idies.jhu.edu` instead of from fixtures.

## The crash

Rendering the real response from `POST /jobs/preview` throws:

```
Objects are not valid as a React child (found: object with keys {})
```

`backend/jobs/utils.R:251` builds each unrecognized entry with:

```r
list(cause = cn, count = n, suggestion = if (is.na(s)) NULL else s)
```

R's `list()` **keeps** a `NULL` element rather than dropping it (unlike `l$x <- NULL`), and `toJSON` writes that `NULL` as `{}`. An empty object is truthy in JS, so this took the wrong branch and tried to render the object:

```jsx
{u.suggestion ? <> — did you mean <em>{u.suggestion}</em>?</> : <> — no close match; …</>}
```

Confirmed against the deployment — the wire shape is always `"suggestion": {}` when there is no match, with one unrecognized cause and with three:

```json
"unrecognized": [{ "cause": ["totally_bogus_cause"], "count": [1], "suggestion": {} }]
```

Every no-close-match case hits it, which is the common case and exactly the scenario in #105 ("no close match; relabel to a supported cause").

## Why the suite missed it

The fixtures used `suggestion: null` — a shape the backend does not send. `null` is falsy, so the tests exercised the correct branch and the crash was invisible. The new tests use the wire shape verbatim, including the `["x"]` length-1 vectors R also emits for `cause`, `count` and `total_records`.

## The fix

A `scalar()` helper that unwraps R's length-1 vectors and treats an empty object as absent, applied to the fields that get rendered. Same class of defensive normalization as the `asCauseList()` helper added in #107 for `not_calibrated`.

## Tests

Three new assertions in `CausePreview.test.jsx` using the live wire shape. Verified as real guards by removing `scalar()` and re-running — 2 fail with the exact `Objects are not valid as a React child` error.

Frontend 268 → 271 across 33 files, eslint clean, production build succeeds. R suite unaffected at 52/52.

## Note

Pre-existing, not introduced by #107 — but it lives in a file #107 touched, and #107's own deployment testing is what surfaced it.

🤖 Generated with [Claude Code](https://claude.com/claude-code)