### PR TITLE
Stop anonymous job enumeration; run the R suites in CI

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -5,6 +5,11 @@ on:
   push:
     branches: [master]
 
+# Both jobs only read the tree and run tests. Declared explicitly so the token
+# does not inherit a wider default from repo/org settings.
+permissions:
+  contents: read
+
 jobs:
   frontend:
     runs-on: ubuntu-latest
@@ -12,7 +17,13 @@ jobs:
       run:
         working-directory: frontend
     steps:
+      # persist-credentials: false — checkout@v4 otherwise writes GITHUB_TOKEN into
+      # .git/config, leaving it readable by every later step. These jobs run
+      # repository scripts and install packages from the network and never perform
+      # an authenticated git operation, so they have no use for it.
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: actions/setup-node@v4
         with:
@@ -48,6 +59,8 @@ jobs:
     runs-on: ubuntu-latest
     steps:
       - uses: actions/checkout@v4
+        with:
+          persist-credentials: false
 
       - uses: r-lib/actions/setup-r@v2
         with:

--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -32,3 +32,36 @@ jobs:
 
       - name: Production build
         run: npm run build
+
+  # The R suites that need nothing but base R + jsonlite. Before this job the
+  # workflow had no R step at all, so every backend assertion was local-only.
+  #
+  # DELIBERATELY NOT RUN HERE: tests/test_vacalibration_backend.R. It needs the
+  # vacalibration package (hence rstan, hence a long compile) AND it currently
+  # halts at section 2b on `object 'comsamoz_CCVAoutput' not found` — that
+  # dataset was restructured in vacalibration 2.x into comsamoz_public_broad /
+  # comsamoz_public_openVAout. Naming it here rather than globbing tests/ keeps
+  # that a stated exclusion instead of a silent skip (CLAUDE.md), and means
+  # adding a suite to tests/ does not quietly go uncovered — it just has to be
+  # listed, which is the point where you notice whether it needs vacalibration.
+  backend:
+    runs-on: ubuntu-latest
+    steps:
+      - uses: actions/checkout@v4
+
+      - uses: r-lib/actions/setup-r@v2
+        with:
+          r-version: '4.4'
+          use-public-rspm: true
+
+      # Installed directly rather than via setup-r-dependencies, which expects a
+      # DESCRIPTION file this repo does not have. use-public-rspm serves a
+      # prebuilt binary, so this is seconds, not a compile.
+      - name: Install jsonlite
+        run: Rscript -e 'install.packages("jsonlite")'
+
+      - name: Misclassification matrix (issue #104)
+        run: Rscript tests/test_misclass_matrix.R
+
+      - name: Job enumeration scope
+        run: Rscript tests/test_auth_visibility.R

--- a/backend/auth/middleware.R
+++ b/backend/auth/middleware.R
@@ -58,6 +58,10 @@ auth_filter <- function(req, res) {
   plumber::forward()
 }
 
+# NOTE: job_visibility() — which jobs a request may ENUMERATE — lives in
+# jobs/utils.R, not here. It has to be testable without a JWT library, and this
+# file sources auth/tokens.R, which needs `jose`.
+
 require_admin <- function(req, res) {
   if (is.null(req$user) || req$user$role != "admin") {
     res$status <- 403

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -995,3 +995,30 @@ build_per_algorithm <- function(result) {
   }
   per_algorithm
 }
+
+# Which jobs a request is allowed to ENUMERATE. Returns one of:
+#   "all"  — admin: every job
+#   "own"  — authenticated non-admin: only jobs they own
+#   "none" — unauthenticated: nothing to enumerate
+#
+# GET /jobs used to branch on `!is.null(req$user) && req$user$role != "admin"`,
+# so a request with NO Authorization header skipped the filter entirely and fell
+# through to the ADMIN branch, handing every user's job list to any anonymous
+# caller (confirmed against the deployment: 224 jobs, no credentials).
+# AUTH_GRACE_PERIOD deliberately lets an unauthenticated caller READ a job it can
+# already name (check_job_access in auth/middleware.R), but it was never meant to
+# hand out an enumeration of all of them — knowing one UUID and being given every
+# UUID are different exposures. Anonymous therefore enumerates nothing, which
+# costs the UI nothing because every route that lists jobs sits behind login.
+#
+# Lives here rather than in auth/middleware.R so it is testable without `jose`:
+# middleware.R sources auth/tokens.R, which needs that package.
+job_visibility <- function(user) {
+  if (is.null(user)) return("none")
+  role <- user$role
+  # Anything unexpected degrades to the LEAST privilege, never to admin.
+  if (length(role) == 1 && !is.na(role) && identical(as.character(role), "admin")) {
+    return("all")
+  }
+  "own"
+}

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -492,7 +492,7 @@ function(req) {
   tryCatch({
     # Admin sees every job, an authenticated user only their own, and an
     # unauthenticated caller enumerates nothing. See job_visibility() in
-    # auth/middleware.R — the previous `!is.null(req$user) &&` guard let an
+    # jobs/utils.R — the previous `!is.null(req$user) &&` guard let an
     # anonymous request fall through to the admin branch.
     job_ids <- switch(job_visibility(req$user),
       all = list_job_ids(),

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -490,16 +490,21 @@ function(req, res, job_id) {
 #* @get /jobs
 function(req) {
   tryCatch({
-    # Filter by user unless admin
-    if (!is.null(req$user) && req$user$role != "admin") {
-      conn <- get_db_connection()
-      result <- dbGetQuery(conn,
-        "SELECT id FROM jobs WHERE user_id = $1::uuid ORDER BY created_at DESC",
-        params = list(req$user$id))
-      job_ids <- result$id
-    } else {
-      job_ids <- list_job_ids()
-    }
+    # Admin sees every job, an authenticated user only their own, and an
+    # unauthenticated caller enumerates nothing. See job_visibility() in
+    # auth/middleware.R — the previous `!is.null(req$user) &&` guard let an
+    # anonymous request fall through to the admin branch.
+    job_ids <- switch(job_visibility(req$user),
+      all = list_job_ids(),
+      own = {
+        conn <- get_db_connection()
+        result <- dbGetQuery(conn,
+          "SELECT id FROM jobs WHERE user_id = $1::uuid ORDER BY created_at DESC",
+          params = list(req$user$id))
+        result$id
+      },
+      character()
+    )
 
     jobs <- lapply(job_ids, function(id) {
       tryCatch({

--- a/tests/test_auth_visibility.R
+++ b/tests/test_auth_visibility.R
@@ -1,0 +1,83 @@
+#!/usr/bin/env Rscript
+# Job enumeration scope (job_visibility) — backend/auth/middleware.R
+#
+# GET /jobs branched on `!is.null(req$user) && req$user$role != "admin"`, so a
+# request with no Authorization header skipped the filter and took the ADMIN
+# branch, returning every user's job list to any anonymous caller. Verified
+# against the deployment before the fix: `curl` with no auth returned 224 jobs.
+#
+# Deliberately dependency-free — no DB, no vacalibration, no jose, no plumber — so this
+# suite can run in CI (see .github/workflows/test.yml).
+
+.test_count <- 0; .pass_count <- 0; .fail_count <- 0; .fail_msgs <- character()
+
+test <- function(name, expr) {
+  .test_count <<- .test_count + 1
+  ok <- tryCatch(isTRUE(expr), error = function(e) {
+    .fail_msgs <<- c(.fail_msgs, sprintf("  FAIL: %s -- error: %s", name, conditionMessage(e)))
+    FALSE
+  })
+  if (ok) {
+    .pass_count <<- .pass_count + 1
+    cat(sprintf("  PASS: %s\n", name))
+  } else {
+    .fail_count <<- .fail_count + 1
+    if (!any(grepl(name, .fail_msgs, fixed = TRUE))) {
+      .fail_msgs <<- c(.fail_msgs, sprintf("  FAIL: %s -- returned FALSE", name))
+    }
+    cat(sprintf("  FAIL: %s\n", name))
+  }
+}
+
+section <- function(title) cat(sprintf("\n=== %s ===\n", title))
+
+# job_visibility() lives in jobs/utils.R precisely so this can be sourced with no
+# JWT library, no DB driver and no vacalibration.
+utils_path <- if (file.exists("backend/jobs/utils.R")) "backend/jobs/utils.R" else "../backend/jobs/utils.R"
+source(utils_path)
+
+section("1. Anonymous callers enumerate nothing")
+
+test("NULL user -> none", identical(job_visibility(NULL), "none"))
+
+section("2. Admin sees everything")
+
+test("role=admin -> all", identical(job_visibility(list(id = "u1", role = "admin")), "all"))
+test("admin as a length-1 list (R/JSON shape) -> all",
+     identical(job_visibility(list(id = "u1", role = list("admin"))), "all"))
+
+section("3. Authenticated non-admin sees only their own")
+
+test("role=user -> own", identical(job_visibility(list(id = "u1", role = "user")), "own"))
+test("role=researcher -> own", identical(job_visibility(list(id = "u1", role = "researcher")), "own"))
+test("role=Admin (wrong case) is NOT admin",
+     identical(job_visibility(list(id = "u1", role = "Admin")), "own"))
+test("role=admin with trailing space is NOT admin",
+     identical(job_visibility(list(id = "u1", role = "admin ")), "own"))
+
+section("4. Malformed role degrades to the LEAST privilege, never to admin")
+
+for (bad in list(NULL, NA, NA_character_, character(0), c("admin", "user"), list(), 0L, TRUE)) {
+  label <- paste0("role=", paste(utils::capture.output(str(bad)), collapse = " "))
+  got <- tryCatch(job_visibility(list(id = "u1", role = bad)), error = function(e) "ERROR")
+  test(sprintf("%s -> own (not all)", label), identical(got, "own"))
+}
+
+section("5. The exact regression: an unauthenticated request must not read as admin")
+
+# req$user is NULL under AUTH_GRACE_PERIOD; the old expression
+# `!is.null(req$user) && req$user$role != "admin"` was FALSE for it, selecting
+# the admin branch. job_visibility must never return "all" for that input.
+test("anonymous never yields the admin scope", !identical(job_visibility(NULL), "all"))
+test("only an explicit admin role yields the admin scope",
+     sum(sapply(list(NULL, list(role = "user"), list(role = NA), list(role = character(0))),
+                function(u) identical(job_visibility(u), "all"))) == 0)
+
+cat(sprintf("\n%s\n", strrep("=", 70)))
+cat(sprintf("Total: %d  Passed: %d  Failed: %d\n", .test_count, .pass_count, .fail_count))
+if (.fail_count > 0) {
+  cat("\nFailures:\n"); for (m in .fail_msgs) cat(m, "\n")
+  quit(status = 1)
+}
+cat("All job visibility tests passed.\n")
+quit(status = 0)

--- a/tests/test_auth_visibility.R
+++ b/tests/test_auth_visibility.R
@@ -1,5 +1,5 @@
 #!/usr/bin/env Rscript
-# Job enumeration scope (job_visibility) — backend/auth/middleware.R
+# Job enumeration scope (job_visibility) — backend/jobs/utils.R
 #
 # GET /jobs branched on `!is.null(req$user) && req$user$role != "admin"`, so a
 # request with no Authorization header skipped the filter and took the ADMIN


### PR DESCRIPTION
Two of the three follow-ups from the #104 work. The third (re-running the reporter's job) turned out to be impossible for a reason worth its own issue — see below.

## 1. Anonymous callers could enumerate every job

`GET /jobs` branched on `!is.null(req$user) && req$user$role != "admin"`. A request with no `Authorization` header fails that test and falls through to the **admin** branch. Confirmed against the deployment:

```
$ curl -s .../api/jobs | jq '.jobs | length'
224
```

`AUTH_GRACE_PERIOD` deliberately lets an unauthenticated caller *read* a job it can already name (`check_job_access`), but it was never meant to hand out an enumeration of all of them — knowing one UUID and being given every UUID are different exposures.

Scope is now explicit:

| caller | sees |
|---|---|
| admin | all jobs |
| authenticated non-admin | own jobs |
| anonymous | nothing |

No UI impact — every route that lists jobs is behind `ProtectedRoute`.

`job_visibility()` lives in `jobs/utils.R` rather than `auth/middleware.R` because middleware sources `auth/tokens.R`, which needs `jose`; keeping the helper dependency-free is what makes it testable in CI at all.

**17 assertions** in `tests/test_auth_visibility.R`, including that a malformed `role` (length-2 vector, `NA`, `character(0)`, a list, an integer, `TRUE`) degrades to least privilege rather than to admin — the old expression would have thrown or silently granted admin on several of those. Verified as a real guard by restoring the old logic: 8 assertions fail, `NULL user -> none` among them.

**Not changed here:** flipping `AUTH_GRACE_PERIOD` to `FALSE`. Its own stated exit condition ("after frontend auth ships") has been met, but it breaks every unauthenticated client and raises an unanswered question about legacy jobs with `user_id NULL`. → #109 for a maintainer decision.

## 2. The R suites now run in CI

`test.yml` had only a `frontend` job, so **nothing under `tests/` ran in CI** — including the 52 assertions guarding the #104 matrix fix. They were local-only, which made that guard decorative in CI terms.

New `backend` job runs the suites needing nothing but base R + `jsonlite` (52 + 17 assertions). `jsonlite` is installed directly rather than via `setup-r-dependencies`, which expects a `DESCRIPTION` this repo lacks.

`tests/test_vacalibration_backend.R` is a **named exclusion, not a silent skip**: it needs `vacalibration` (hence rstan, hence a long compile) *and* currently halts at section 2b on `object 'comsamoz_CCVAoutput' not found` — a dataset restructured in vacalibration 2.x into `comsamoz_public_broad` / `comsamoz_public_openVAout`. Listing suites explicitly also means a new suite cannot quietly go uncovered; it has to be listed, which is where you notice whether it drags in heavyweight deps.

## 3. Re-running the reporter's job is impossible — #110

Attempted, and it fails:

```
$ curl -X POST .../api/jobs/901322df-.../rerun
{"error":["Original input file not found: input_interva.csv"]}
```

`k8s/backend-deployment.yaml` declares **no volumes**, so `data/uploads/` and `data/outputs/` live on the container's ephemeral filesystem and are wiped on every pod replacement. Her inputs *and* outputs are gone — her result CSVs now 500 on download. Postgres is external, which is why the job row and its `result` JSONB survive while the files behind them do not.

`rerun` itself is sound: proved it by uploading a fresh CSV and re-running that job successfully in the same pod. Filed as **#110** with three remediation options. The reporter has been told she must re-upload.

## Verification

- `tests/test_misclass_matrix.R` **52/52**, `tests/test_auth_visibility.R` **17/17**
- Frontend **268/268** across 33 files (untouched, checked for collateral)
- `backend/jobs/utils.R`, `plumber.R`, `auth/middleware.R` all parse
- `test.yml` validated as YAML; both jobs resolve
- The new auth assertions confirmed red-then-green by restoring the old branch logic

CI on this PR is itself the proof for item 2 — the `backend` job has never run before.

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **Bug Fixes**
  * Fixed job list access for unauthenticated requests, ensuring they receive no job results.
  * Restricted full job visibility to administrators.
  * Ensured authenticated non-admin users can access only their own jobs.
  * Prevented invalid or malformed roles from receiving administrator access.

* **Tests**
  * Added automated coverage for job visibility and authentication scenarios.
  * Added backend checks to the continuous integration workflow.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->