### PR TITLE
Require login; make legacy jobs admin-only (issue #109)

### DIFF
--- a/backend/auth/middleware.R
+++ b/backend/auth/middleware.R
@@ -3,9 +3,13 @@
 
 source("auth/tokens.R")
 
-# Grace period: if TRUE, allow unauthenticated requests through (req$user = NULL)
-# Set to FALSE after frontend auth ships (Phase 5)
-AUTH_GRACE_PERIOD <- TRUE
+# Grace period: if TRUE, allow unauthenticated requests through (req$user = NULL).
+# Turned off now that frontend auth has shipped (login page, ProtectedRoute on
+# every route, admin users page) — the dashboard is login-only. An anonymous
+# request to any non-public endpoint now gets 401 instead of falling through.
+# Overridable by env only to unblock a one-off (e.g. a smoke test) without a
+# redeploy; absent or anything other than "true" keeps auth enforced.
+AUTH_GRACE_PERIOD <- tolower(Sys.getenv("AUTH_GRACE_PERIOD", "false")) == "true"
 
 PUBLIC_ENDPOINTS <- c(
   "/health",
@@ -70,12 +74,12 @@ require_admin <- function(req, res) {
   TRUE
 }
 
-# Helper: check if current user owns the job or is admin
+# HTTP wrapper over job_access_decision() (jobs/utils.R, kept there so it is
+# testable without jose). Translates the decision to TRUE / a 401 / a 403.
 check_job_access <- function(job, req, res) {
-  if (is.null(req$user)) return(TRUE)  # Grace period: no user = allow
-  if (req$user$role == "admin") return(TRUE)
-  if (is.null(job$user_id)) return(TRUE)  # Legacy job with no owner
-  if (job$user_id == req$user$id) return(TRUE)
-  res$status <- 403
-  return(list(error = "Access denied"))
+  switch(job_access_decision(req$user, job$user_id, AUTH_GRACE_PERIOD),
+    allow = TRUE,
+    unauthenticated = { res$status <- 401; list(error = "Authentication required") },
+    deny = { res$status <- 403; list(error = "Access denied") }
+  )
 }

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -1022,3 +1022,28 @@ job_visibility <- function(user) {
   }
   "own"
 }
+
+# Whether a request may read/act on ONE job. Pure decision, returned as a token
+# the HTTP layer translates: "allow" -> proceed, "unauthenticated" -> 401,
+# "deny" -> 403. check_job_access() in auth/middleware.R is the thin wrapper.
+#
+# Lives here (not middleware.R) for the same reason as job_visibility(): so it is
+# testable without `jose`, which auth/tokens.R pulls in.
+#
+#   anonymous  -> "unauthenticated", unless the grace period still stands
+#   admin      -> allow (any job)
+#   legacy job (no recorded owner) -> "deny" for a non-admin: pre-auth jobs are
+#                 admin-only, not exposed to whichever logged-in user guesses the id
+#   otherwise  -> allow only the owner
+job_access_decision <- function(user, job_user_id, grace_period = FALSE) {
+  if (is.null(user)) {
+    return(if (isTRUE(grace_period)) "allow" else "unauthenticated")
+  }
+  if (identical(as.character(user$role), "admin")) return("allow")
+  if (is.null(job_user_id) || length(job_user_id) == 0 ||
+      (length(job_user_id) == 1 && is.na(job_user_id))) {
+    return("deny")  # legacy, ownerless job -> admin only
+  }
+  if (identical(as.character(job_user_id), as.character(user$id))) return("allow")
+  "deny"
+}

--- a/frontend/src/api/client.js
+++ b/frontend/src/api/client.js
@@ -24,7 +24,7 @@ export function unbox(obj) {
   return obj;
 }
 
-function getAuthHeaders() {
+export function getAuthHeaders() {
   const headers = {};
   if (typeof localStorage !== 'undefined') {
     const token = localStorage.getItem('token');

--- a/frontend/src/components/DemoGallery.jsx
+++ b/frontend/src/components/DemoGallery.jsx
@@ -1,4 +1,5 @@
 import { useState, useEffect } from 'react';
+import { getAuthHeaders } from '../api/client';
 import './DemoGallery.css';
 
 const API_BASE = import.meta.env.VITE_API_BASE_URL || 'http://localhost:8000';
@@ -16,7 +17,9 @@ export default function DemoGallery({ onDemoLaunch }) {
 
   async function fetchDemos() {
     try {
-      const response = await fetch(`${API_BASE}/demos/list`);
+      // Auth header required now that the backend is login-only; the page is
+      // behind ProtectedRoute so a token is always present.
+      const response = await fetch(`${API_BASE}/demos/list`, { headers: getAuthHeaders() });
       const data = await response.json();
       setDemos(data.demos || []);
     } catch (err) {
@@ -33,7 +36,7 @@ export default function DemoGallery({ onDemoLaunch }) {
     try {
       const response = await fetch(`${API_BASE}/demos/launch`, {
         method: 'POST',
-        headers: { 'Content-Type': 'application/x-www-form-urlencoded' },
+        headers: { 'Content-Type': 'application/x-www-form-urlencoded', ...getAuthHeaders() },
         body: new URLSearchParams({ demo_id: demoId })
       });
 

--- a/tests/test_auth_visibility.R
+++ b/tests/test_auth_visibility.R
@@ -73,6 +73,40 @@ test("only an explicit admin role yields the admin scope",
      sum(sapply(list(NULL, list(role = "user"), list(role = NA), list(role = character(0))),
                 function(u) identical(job_visibility(u), "all"))) == 0)
 
+section("6. Single-job access — anonymous is 401 once the grace period is off")
+
+admin <- list(id = "admin1", role = "admin")
+alice <- list(id = "alice", role = "user")
+bob   <- list(id = "bob",   role = "user")
+
+test("anonymous + grace ON  -> allow", identical(job_access_decision(NULL, "alice", TRUE),  "allow"))
+test("anonymous + grace OFF -> unauthenticated (401)",
+     identical(job_access_decision(NULL, "alice", FALSE), "unauthenticated"))
+test("grace defaults to OFF", identical(job_access_decision(NULL, "alice"), "unauthenticated"))
+
+section("7. Single-job access — owner vs non-owner vs admin")
+
+test("owner may read own job", identical(job_access_decision(alice, "alice", FALSE), "allow"))
+test("non-owner is denied (403)", identical(job_access_decision(bob, "alice", FALSE), "deny"))
+test("admin may read anyone's job", identical(job_access_decision(admin, "alice", FALSE), "allow"))
+
+section("8. Legacy ownerless jobs are ADMIN ONLY")
+
+for (empty in list(NULL, NA, NA_character_, character(0))) {
+  lbl <- paste(utils::capture.output(str(empty)), collapse = " ")
+  test(sprintf("non-admin denied a legacy job (user_id=%s)", lbl),
+       identical(job_access_decision(alice, empty, FALSE), "deny"))
+  test(sprintf("admin allowed a legacy job (user_id=%s)", lbl),
+       identical(job_access_decision(admin, empty, FALSE), "allow"))
+}
+
+section("9. The old blanket-allow on legacy jobs is gone")
+
+# check_job_access used to `if (is.null(job$user_id)) return(TRUE)` for EVERY
+# caller. A logged-in non-admin must no longer read a pre-auth job by id.
+test("legacy job is not readable by an arbitrary logged-in user",
+     !identical(job_access_decision(list(id = "stranger", role = "user"), NULL, FALSE), "allow"))
+
 cat(sprintf("\n%s\n", strrep("=", 70)))
 cat(sprintf("Total: %d  Passed: %d  Failed: %d\n", .test_count, .pass_count, .fail_count))
 if (.fail_count > 0) {


### PR DESCRIPTION
Implements the two decisions on #109: the dashboard should be **login-only**, and **legacy ownerless jobs are admin-only**.

I checked the cluster for #110 while here (you asked me to look rather than ask) — that finding is separate and posted to #110; **this PR does not touch storage.**

## 1. Auth is now enforced

`AUTH_GRACE_PERIOD` let any request with no `Authorization` header through as `req$user = NULL`. Its stated exit condition — "after frontend auth ships (Phase 5)" — was met long ago (login page, `ProtectedRoute` on every route, admin users page). Turned off. An anonymous request to any non-public endpoint now gets **401** instead of falling through.

`/health`, `/auth/login`, `/auth/register` stay public (unchanged `PUBLIC_ENDPOINTS`).

The flag now reads from the environment, default off:

```r
AUTH_GRACE_PERIOD <- tolower(Sys.getenv("AUTH_GRACE_PERIOD", "false")) == "true"
```

so a one-off smoke test can re-enable it without a redeploy; anything other than `"true"` keeps auth on.

## 2. Legacy ownerless jobs → admin-only

`check_job_access` previously did `if (is.null(job$user_id)) return(TRUE)` for **every** caller. Once login is required, that would still let any logged-in user read a pre-auth job by guessing its id. Removed — admin sees legacy jobs, nobody else does. Consistent with `GET /jobs`, where a non-admin is already filtered to `WHERE user_id = $1` and never sees `NULL`-owner rows.

The decision is extracted as a pure `job_access_decision()` in `jobs/utils.R` (next to `job_visibility()`), so it is CI-testable without `jose` (which `auth/tokens.R` pulls in). `check_job_access` is now a thin wrapper translating to `TRUE` / 401 / 403.

## 3. Frontend fix so this does not break the live UI

`DemoGallery.jsx` called `/demos/list` and `/demos/launch` with a bare `fetch` and no auth header. Under enforced auth those would 401 and break the (logged-in, `ProtectedRoute`-gated) Demo Gallery. Both now send `getAuthHeaders()`, newly exported from `client.js`. I grepped every network call in `src/` — these two were the only ones bypassing the authenticated client; everything else already goes through `fetchJson`.

## Tests

`test_auth_visibility.R`: **17 → 32** assertions — anonymous is 401 once grace is off, owner vs non-owner vs admin on a single job, and legacy ownerless jobs admin-only across `NULL` / `NA` / `character(0)`. Confirmed as real guards by restoring the old blanket-allow: 4 fail, including *"legacy job is not readable by an arbitrary logged-in user"*. These run in the CI `backend` job added in #111.

Full: R 52/52 + 32/32, frontend 268/268 across 33 files, eslint clean, build succeeds, all changed R files parse.

## What to expect after deploy

- The site requires login for everything except health/login/register. Verified in the browser that the frontend already holds a token and sends it on every call **except** the two DemoGallery ones this PR fixes.
- Any unauthenticated API consumer breaks by design — including `frontend/src/api/integration.test.js` and the Playwright suite if they do not authenticate. Neither runs in CI (`integration.test.js` is excluded; no Playwright job), so CI is unaffected, but they need an auth step before running locally against an enforced backend.
- Real browser confirmation (anonymous → 401, admin still sees everything, Demo Gallery still loads) is post-deploy; I will do that once this is merged and rolled out.

🤖 Generated with [Claude Code](https://claude.com/claude-code)