### PR TITLE
Persist uploaded inputs in Postgres (issue #110, option C)

### DIFF
--- a/.github/workflows/test.yml
+++ b/.github/workflows/test.yml
@@ -78,3 +78,6 @@ jobs:
 
       - name: Job enumeration scope
         run: Rscript tests/test_auth_visibility.R
+
+      - name: Input-file persistence codec (issue #110)
+        run: Rscript tests/test_input_persistence.R

--- a/backend/db/connection.R
+++ b/backend/db/connection.R
@@ -99,13 +99,18 @@ get_db_pool <- function() {
     )
     t_end <- Sys.time()
     message(sprintf("Connection pool initialized in %.3f sec", as.numeric(t_end - t_start)))
-    # Only clean up orphaned jobs on main server startup, not in background workers
+    # Idempotent: create the input-file mirror table if it does not exist yet
+    # (issue #110). Runs on EVERY pool init — main server and background workers
+    # alike — because workers also read/write it via ensure_input_files(); gating
+    # it to the main server would let a worker hit a missing table on a fresh
+    # deploy. CREATE ... IF NOT EXISTS makes the repeat harmless. Uses the pod's
+    # own DB credentials, so a deploy applies it with no manual migration step.
+    ensure_input_file_storage(.db_pool)
+
+    # Orphan cleanup, by contrast, must run once — main server startup only, not
+    # in per-job workers.
     if (Sys.getenv("COMSA_WORKER") != "1") {
       cleanup_orphaned_jobs()
-      # Idempotent: create the input-file mirror table if it does not exist yet
-      # (issue #110). Runs on every boot using the pod's own DB credentials, so a
-      # deploy applies it with no manual migration step.
-      ensure_input_file_storage(.db_pool)
     }
   }
   return(.db_pool)
@@ -222,6 +227,17 @@ load_job <- function(job_id) {
   }
 
   job <- as.list(result[1, ])
+
+  # The DB column is `input_file_path`; the rest of the codebase reads
+  # `input_file`. Historically this "worked" only through R's `$` prefix matching
+  # (job$input_file silently resolving to input_file_path), which is fragile and
+  # ambiguous once input_files also exists. Set an EXACT `input_file` element via
+  # `[[` so downstream reads are unambiguous (issue #110).
+  ifp <- job[["input_file_path"]]
+  if (is.null(job[["input_file"]]) &&
+      !is.null(ifp) && length(ifp) == 1 && !is.na(ifp) && nzchar(ifp)) {
+    job[["input_file"]] <- ifp
+  }
 
   # Parse JSONB fields - handle error field
   if (!is.null(job$error) && length(job$error) > 0 && !is.na(job$error) &&
@@ -346,7 +362,7 @@ ensure_input_file_storage <- function(conn = NULL) {
     dbExecute(conn, "
       CREATE TABLE IF NOT EXISTS job_input_files (
         id SERIAL PRIMARY KEY,
-        job_id UUID NOT NULL,
+        job_id UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
         filename TEXT NOT NULL,
         content_b64 TEXT NOT NULL,
         created_at TIMESTAMP NOT NULL DEFAULT NOW(),
@@ -395,14 +411,21 @@ restore_input_files <- function(job_id, dest_dir) {
 # THIS pod's disk; restore any missing ones from the DB. Returns TRUE if a
 # restore happened. No-op when everything is already present or nothing is stored.
 ensure_input_files <- function(job) {
-  paths <- c(job$input_files, job$input_file)
-  paths <- paths[!vapply(paths, function(p) is.null(p) || is.na(p) || !nzchar(p), logical(1))]
+  paths <- job_input_paths(job)  # jobs/utils.R — covers input_file_path too
   if (length(paths) == 0 || all(file.exists(paths))) return(invisible(FALSE))
   restored <- tryCatch(restore_input_files(job$id, file.path("data", "uploads", job$id)),
                        error = function(e) {
                          message("Warning: could not restore input files for ", job$id, ": ", conditionMessage(e))
                          character()
                        })
+  # Re-check the specific paths: a partial or failed restore should surface a
+  # targeted warning here rather than a generic "Input file not found" later.
+  still_missing <- paths[!file.exists(paths)]
+  if (length(still_missing) > 0) {
+    message("Warning: input file(s) still missing after restore for ", job$id, ": ",
+            paste(basename(still_missing), collapse = ", "),
+            " (", length(restored), " file(s) restored from DB)")
+  }
   invisible(length(restored) > 0)
 }
 

--- a/backend/db/connection.R
+++ b/backend/db/connection.R
@@ -102,6 +102,10 @@ get_db_pool <- function() {
     # Only clean up orphaned jobs on main server startup, not in background workers
     if (Sys.getenv("COMSA_WORKER") != "1") {
       cleanup_orphaned_jobs()
+      # Idempotent: create the input-file mirror table if it does not exist yet
+      # (issue #110). Runs on every boot using the pod's own DB credentials, so a
+      # deploy applies it with no manual migration step.
+      ensure_input_file_storage(.db_pool)
     }
   }
   return(.db_pool)
@@ -328,6 +332,78 @@ add_job_file <- function(job_id, file_type, file_name, file_path, file_size = NU
   ))
 
   invisible(TRUE)
+}
+
+# --- Input-file persistence (issue #110) -----------------------------------
+# The pod filesystem is ephemeral (no PVC — the namespace forbids one), so
+# uploaded CSVs vanish on every deploy/restart, breaking rerun and downloads.
+# Their bytes are mirrored here, base64 over TEXT, and restored to disk when a
+# fresh pod finds them missing. Idempotent DDL runs at pool init, so a normal
+# deploy applies it using the pod's own DB credentials — no manual migration.
+ensure_input_file_storage <- function(conn = NULL) {
+  if (is.null(conn)) conn <- get_db_connection()
+  tryCatch({
+    dbExecute(conn, "
+      CREATE TABLE IF NOT EXISTS job_input_files (
+        id SERIAL PRIMARY KEY,
+        job_id UUID NOT NULL,
+        filename TEXT NOT NULL,
+        content_b64 TEXT NOT NULL,
+        created_at TIMESTAMP NOT NULL DEFAULT NOW(),
+        UNIQUE (job_id, filename)
+      )")
+    dbExecute(conn, "CREATE INDEX IF NOT EXISTS idx_job_input_files_job_id ON job_input_files(job_id)")
+  }, error = function(e) {
+    message("Warning: could not ensure job_input_files table: ", conditionMessage(e))
+  })
+  invisible(TRUE)
+}
+
+# Mirror one uploaded file into the DB, keyed by (job_id, basename). Upsert so a
+# re-save or rerun overwrites rather than duplicates. Best-effort: a storage
+# failure must not fail the job submission, since the on-disk copy still serves
+# the current pod.
+save_input_file <- function(job_id, path) {
+  tryCatch({
+    conn <- get_db_connection()
+    dbExecute(conn, "
+      INSERT INTO job_input_files (job_id, filename, content_b64)
+      VALUES ($1::uuid, $2, $3)
+      ON CONFLICT (job_id, filename) DO UPDATE SET content_b64 = EXCLUDED.content_b64",
+      params = list(job_id, basename(path), encode_file_b64(path)))
+    invisible(TRUE)
+  }, error = function(e) {
+    message("Warning: could not persist input file ", basename(path), ": ", conditionMessage(e))
+    invisible(FALSE)
+  })
+}
+
+# Restore every stored input file for a job into dest_dir. Returns the character
+# vector of paths written (empty if none stored).
+restore_input_files <- function(job_id, dest_dir) {
+  conn <- get_db_connection()
+  rows <- dbGetQuery(conn,
+    "SELECT filename, content_b64 FROM job_input_files WHERE job_id = $1::uuid",
+    params = list(job_id))
+  if (nrow(rows) == 0) return(character())
+  vapply(seq_len(nrow(rows)), function(i) {
+    decode_b64_to_file(rows$content_b64[i], file.path(dest_dir, rows$filename[i]))
+  }, character(1))
+}
+
+# Before processing or rerun, make sure the job's recorded input files exist on
+# THIS pod's disk; restore any missing ones from the DB. Returns TRUE if a
+# restore happened. No-op when everything is already present or nothing is stored.
+ensure_input_files <- function(job) {
+  paths <- c(job$input_files, job$input_file)
+  paths <- paths[!vapply(paths, function(p) is.null(p) || is.na(p) || !nzchar(p), logical(1))]
+  if (length(paths) == 0 || all(file.exists(paths))) return(invisible(FALSE))
+  restored <- tryCatch(restore_input_files(job$id, file.path("data", "uploads", job$id)),
+                       error = function(e) {
+                         message("Warning: could not restore input files for ", job$id, ": ", conditionMessage(e))
+                         character()
+                       })
+  invisible(length(restored) > 0)
 }
 
 # Get files for a job

--- a/backend/jobs/processor.R
+++ b/backend/jobs/processor.R
@@ -40,6 +40,10 @@ process_job <- function(job_id) {
   job <- load_job_proc(job_id)
   if (is.null(job)) return(NULL)
 
+  # A fresh pod has none of the uploaded files on disk (issue #110); restore any
+  # missing ones from the DB mirror before the algorithm tries to read them.
+  ensure_input_files(job)
+
   update_job_status(job_id, "running")
 
   tryCatch({

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -1047,3 +1047,23 @@ job_access_decision <- function(user, job_user_id, grace_period = FALSE) {
   if (identical(as.character(job_user_id), as.character(user$id))) return("allow")
   "deny"
 }
+
+# --- Input-file persistence helpers (issue #110) ---------------------------
+# Uploaded CSVs live on the pod's ephemeral filesystem, which is wiped on every
+# deploy/restart, breaking rerun and downloads. To survive that, the bytes are
+# also stored in Postgres (db/connection.R). base64 over a TEXT column sidesteps
+# bytea driver quirks and preserves the exact bytes of any CSV encoding.
+# jsonlite is already a hard dependency and is the base64 codec here.
+
+# Read a file and return its contents as a single base64 string.
+encode_file_b64 <- function(path) {
+  raw <- readBin(path, what = "raw", n = file.info(path)$size)
+  jsonlite::base64_enc(raw)
+}
+
+# Decode a base64 string back to `path`, creating parent dirs. Returns the path.
+decode_b64_to_file <- function(b64, path) {
+  dir.create(dirname(path), recursive = TRUE, showWarnings = FALSE)
+  writeBin(jsonlite::base64_dec(b64), path)
+  path
+}

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -1055,6 +1055,22 @@ job_access_decision <- function(user, job_user_id, grace_period = FALSE) {
 # bytea driver quirks and preserves the exact bytes of any CSV encoding.
 # jsonlite is already a hard dependency and is the base64 codec here.
 
+# The on-disk input paths a job expects, from whichever field carries them:
+# `input_files` (ensemble), `input_file` (single), or the raw DB column
+# `input_file_path` when a job has not been normalized by load_job. Pure and
+# dependency-free so the "single-file jobs yield a path" guarantee is unit-tested
+# without a DB (issue #110 — that guarantee was the CodeRabbit finding).
+job_input_paths <- function(job) {
+  # `[[` with exact names on purpose: `$` does PREFIX matching, so `job$input_file`
+  # silently resolves to `input_file_path` (and is ambiguous once `input_files`
+  # also exists). The old single-file path "worked" only by that accident; read
+  # each field explicitly instead.
+  raw <- c(job[["input_files"]], job[["input_file"]], job[["input_file_path"]])
+  keep <- vapply(raw, function(p)
+    !(is.null(p) || length(p) == 0 || is.na(p) || !nzchar(p)), logical(1))
+  unique(as.character(raw[keep]))
+}
+
 # Read a file and return its contents as a single base64 string.
 encode_file_b64 <- function(path) {
   raw <- readBin(path, what = "raw", n = file.info(path)$size)

--- a/backend/migrations/003_input_file_storage.sql
+++ b/backend/migrations/003_input_file_storage.sql
@@ -1,0 +1,23 @@
+-- 003_input_file_storage.sql
+-- Issue #110: uploaded input CSVs lived only on the pod's ephemeral filesystem
+-- and were wiped on every deploy/restart, breaking rerun and downloads. Mirror
+-- their bytes here (base64 in a TEXT column) so a fresh pod can restore them.
+--
+-- This is applied AUTOMATICALLY and idempotently at backend startup by
+-- ensure_input_file_storage() in backend/db/connection.R, using the pod's own DB
+-- credentials — there is no manual migration step. This file is the canonical
+-- record of the schema; the CREATE ... IF NOT EXISTS below is safe to run by hand
+-- as well.
+
+CREATE TABLE IF NOT EXISTS job_input_files (
+    id          SERIAL PRIMARY KEY,
+    job_id      UUID NOT NULL,
+    filename    TEXT NOT NULL,
+    content_b64 TEXT NOT NULL,
+    created_at  TIMESTAMP NOT NULL DEFAULT NOW(),
+    UNIQUE (job_id, filename)
+);
+
+CREATE INDEX IF NOT EXISTS idx_job_input_files_job_id ON job_input_files(job_id);
+
+COMMENT ON TABLE job_input_files IS 'Base64-encoded uploaded input CSVs, mirrored from disk so they survive pod replacement (issue #110)';

--- a/backend/migrations/003_input_file_storage.sql
+++ b/backend/migrations/003_input_file_storage.sql
@@ -9,9 +9,15 @@
 -- record of the schema; the CREATE ... IF NOT EXISTS below is safe to run by hand
 -- as well.
 
+-- ON DELETE CASCADE matches job_files / job_logs: when a job is deleted its
+-- stored inputs go with it. NOTE: the app has no job-deletion endpoint today, and
+-- there is no automatic RETENTION/EXPIRY of stored uploads — the same gap already
+-- applies to job_files rows and the jobs table itself. A retention policy for
+-- identifying health data is a project-level decision tracked in issue #110, not
+-- solved here; this only guarantees deletion PROPAGATES once a job is removed.
 CREATE TABLE IF NOT EXISTS job_input_files (
     id          SERIAL PRIMARY KEY,
-    job_id      UUID NOT NULL,
+    job_id      UUID NOT NULL REFERENCES jobs(id) ON DELETE CASCADE,
     filename    TEXT NOT NULL,
     content_b64 TEXT NOT NULL,
     created_at  TIMESTAMP NOT NULL DEFAULT NOW(),

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -334,16 +334,19 @@ function(req) {
   # Store job in database
   save_job(job)
 
-  # Track uploaded files in database
+  # Track uploaded files in database, and mirror their CONTENT so they survive
+  # pod replacement (issue #110) — the on-disk copy is ephemeral.
   if (!is.null(job$input_files)) {
     for (fpath in job$input_files) {
       fname <- basename(fpath)
       fsize <- file.info(fpath)$size
       add_job_file(job_id, "input", fname, fpath, fsize)
+      save_input_file(job_id, fpath)
     }
   } else if (!is.null(job$input_file)) {
     file_size <- file.info(job$input_file)$size
     add_job_file(job_id, "input", "input.csv", job$input_file, file_size)
+    save_input_file(job_id, job$input_file)
   }
 
   # Start async processing
@@ -551,7 +554,12 @@ function(req, res, job_id, filename) {
   file_path <- file.path(output_dir, filename)
 
   if (!file.exists(file_path)) {
-    stop("File not found")
+    # A deploy replaces the pod and wipes data/outputs (issue #110). Say so plainly
+    # instead of 500-ing; outputs are regenerable, so point the user at rerun.
+    res$status <- 404
+    res$setHeader("Content-Type", "text/plain")
+    return(paste0("Output file '", basename(filename), "' is no longer available for this job. ",
+                  "Output files do not persist across server restarts; re-run the job to regenerate them."))
   }
 
   # Set correct content type for images
@@ -717,6 +725,10 @@ function(job_id) {
   if (is.null(old_job)) {
     return(list(error = "Job not found"))
   }
+
+  # The original's inputs may have been wiped with a previous pod (issue #110);
+  # restore them from the DB mirror before copying so rerun works across deploys.
+  ensure_input_files(old_job)
 
   # Create new job ID and upload directory
   new_job_id <- uuid::UUIDgenerate()

--- a/backend/plumber.R
+++ b/backend/plumber.R
@@ -787,6 +787,16 @@ function(job_id) {
   )
 
   save_job(new_job)
+
+  # Track and mirror the rerun's OWN input copies, exactly like POST /jobs, so the
+  # rerun job is itself restorable/rerunnable across a future pod restart (issue
+  # #110) — otherwise the fix would not extend to jobs created by rerun.
+  new_paths <- if (!is.null(new_input_files)) new_input_files else new_input_file
+  for (fpath in new_paths) {
+    add_job_file(new_job_id, "input", basename(fpath), fpath, file.info(fpath)$size)
+    save_input_file(new_job_id, fpath)
+  }
+
   start_job_async(new_job_id)
 
   list(

--- a/tests/test_input_persistence.R
+++ b/tests/test_input_persistence.R
@@ -1,0 +1,73 @@
+#!/usr/bin/env Rscript
+# Input-file persistence base64 codec (issue #110) — backend/jobs/utils.R
+#
+# The DB read/write (save_input_file / restore_input_files) needs a live
+# Postgres and is verified post-deploy. What is unit-testable without a DB is the
+# byte-exact round-trip that everything else rests on: a CSV written to the DB as
+# base64 must come back byte-identical, or a rehydrated input silently differs
+# from what the user uploaded. Deliberately dependency-free (base R + jsonlite).
+
+.test_count <- 0; .pass_count <- 0; .fail_count <- 0; .fail_msgs <- character()
+test <- function(name, expr) {
+  .test_count <<- .test_count + 1
+  ok <- tryCatch(isTRUE(expr), error = function(e) {
+    .fail_msgs <<- c(.fail_msgs, sprintf("  FAIL: %s -- error: %s", name, conditionMessage(e))); FALSE })
+  if (ok) { .pass_count <<- .pass_count + 1; cat(sprintf("  PASS: %s\n", name)) }
+  else { .fail_count <<- .fail_count + 1
+    if (!any(grepl(name, .fail_msgs, fixed = TRUE)))
+      .fail_msgs <<- c(.fail_msgs, sprintf("  FAIL: %s -- returned FALSE", name))
+    cat(sprintf("  FAIL: %s\n", name)) }
+}
+section <- function(t) cat(sprintf("\n=== %s ===\n", t))
+
+utils_path <- if (file.exists("backend/jobs/utils.R")) "backend/jobs/utils.R" else "../backend/jobs/utils.R"
+source(utils_path)
+
+tmp <- tempfile("persist_test_"); dir.create(tmp)
+roundtrip <- function(bytes) {
+  src <- file.path(tmp, "src.bin"); writeBin(bytes, src)
+  dst <- file.path(tmp, "sub", "dst.bin")   # nested dir: decode must create it
+  decode_b64_to_file(encode_file_b64(src), dst)
+  readBin(dst, "raw", n = file.info(dst)$size)
+}
+
+section("1. A typical VA CSV survives the round-trip byte-for-byte")
+
+csv <- charToRaw("ID,cause\nn1,Birth asphyxia\nn2,Neonatal sepsis\nn3,Prematurity\n")
+test("decoded bytes are identical to the original", identical(roundtrip(csv), csv))
+test("decode recreates a missing destination directory", {
+  # roundtrip above wrote into tmp/sub which did not exist beforehand
+  file.exists(file.path(tmp, "sub", "dst.bin"))
+})
+
+section("2. Edge content the codec must not corrupt")
+
+test("empty file round-trips to empty", identical(roundtrip(raw(0)), raw(0)))
+test("UTF-8 (accented cause names) survives", {
+  b <- charToRaw("ID,cause\n1,pneumonie aiguë\n2,paludisme\n"); identical(roundtrip(b), b)
+})
+test("embedded CR/LF and quotes survive", {
+  b <- charToRaw("ID,cause\r\n1,\"sepsis, neonatal\"\r\n"); identical(roundtrip(b), b)
+})
+test("arbitrary binary bytes (0x00-0xFF) survive", {
+  b <- as.raw(0:255); identical(roundtrip(b), b)
+})
+test("a larger file (50k rows) survives", {
+  big <- charToRaw(paste0("ID,cause\n", paste(sprintf("id%d,Prematurity", 1:50000), collapse = "\n"), "\n"))
+  identical(roundtrip(big), big)
+})
+
+section("3. base64 output is a plausible ASCII payload for a TEXT column")
+
+test("encode returns a single non-empty ASCII string", {
+  s <- encode_file_b64(file.path(tmp, "src.bin"))
+  is.character(s) && length(s) == 1 && nzchar(s) && !grepl("[^A-Za-z0-9+/=\r\n]", s)
+})
+
+unlink(tmp, recursive = TRUE)
+
+cat(sprintf("\n%s\n", strrep("=", 70)))
+cat(sprintf("Total: %d  Passed: %d  Failed: %d\n", .test_count, .pass_count, .fail_count))
+if (.fail_count > 0) { cat("\nFailures:\n"); for (m in .fail_msgs) cat(m, "\n"); quit(status = 1) }
+cat("All input persistence tests passed.\n")
+quit(status = 0)

--- a/tests/test_input_persistence.R
+++ b/tests/test_input_persistence.R
@@ -64,6 +64,29 @@ test("encode returns a single non-empty ASCII string", {
   is.character(s) && length(s) == 1 && nzchar(s) && !grepl("[^A-Za-z0-9+/=\r\n]", s)
 })
 
+section("4. job_input_paths pulls a path from whichever field carries it")
+
+# The CodeRabbit finding: load_job returns the DB column `input_file_path`, not
+# `input_file`, so a single-file job must still yield a path or restore no-ops.
+test("single-file job via input_file",
+     identical(job_input_paths(list(input_file = "data/uploads/j/input.csv")),
+               "data/uploads/j/input.csv"))
+test("single-file job via the raw DB column input_file_path",
+     identical(job_input_paths(list(input_file_path = "data/uploads/j/input.csv")),
+               "data/uploads/j/input.csv"))
+test("ensemble job via input_files (order preserved)",
+     identical(job_input_paths(list(input_files = c("a/input_interva.csv", "a/input_eava.csv"))),
+               c("a/input_interva.csv", "a/input_eava.csv")))
+test("input_file and input_file_path duplicate collapses to one",
+     identical(job_input_paths(list(input_file = "p.csv", input_file_path = "p.csv")), "p.csv"))
+test("a sample-data job (no input fields) yields nothing",
+     length(job_input_paths(list(use_sample_data = TRUE))) == 0)
+for (empty in list(NULL, NA, NA_character_, character(0), "")) {
+  test(sprintf("empty input_file_path (%s) yields nothing",
+               paste(utils::capture.output(str(empty)), collapse = " ")),
+       length(job_input_paths(list(input_file_path = empty))) == 0)
+}
+
 unlink(tmp, recursive = TRUE)
 
 cat(sprintf("\n%s\n", strrep("=", 70)))


### PR DESCRIPTION
Fixes the data loss in #110. You chose **option C** after I confirmed the cluster blocks the alternatives.

## Why C, not a PVC

You asked me to check the cluster rather than ask. I did, via a one-off read-only query using the deploy credentials:

- `persistentvolumeclaims is forbidden: User "k8s-dev-comsa-dashboard-admins" cannot create resource "persistentvolumeclaims"` — the admin role **cannot create PVCs**.
- The namespace ResourceQuota has only `ephemeral-storage` (20Gi), no `requests.storage` line — no persistent storage is allotted.

So **option A (PVC) needs a cluster admin**, and **B (S3) needs a bucket + credentials** neither of us has. The external Postgres already survives pod replacement (it is why job rows persist while their files vanish), so inputs go there.

## How it works

- **`job_input_files`** table: each uploaded CSV as base64 in a `TEXT` column, keyed by `(job_id, filename)`. base64-over-TEXT avoids `bytea` driver quirks and preserves exact bytes of any encoding.
- **Idempotent, no manual migration**: `ensure_input_file_storage()` runs `CREATE TABLE IF NOT EXISTS` at pool init using the pod's own DB credentials, so a normal deploy applies it. `003_input_file_storage.sql` records the schema. (This also removes the fragility that migrations were manual and undocumented — I can't reach the DB directly, password rotated, and that's fine.)
- **On upload** (`POST /jobs`): mirror each file to the DB right after the disk write. Best-effort — a storage failure logs a warning but does not fail submission, since the disk copy still serves the current pod.
- **On processing** (`process_job`): restore any missing inputs from the DB before the algorithm reads them, so a job submitted on one pod and run on another works.
- **On rerun** (`POST /jobs/<id>/rerun`): restore the original's inputs from the DB before copying — this is the exact failure from #110 (`Original input file not found`).

## Also: the download 500 → clean 404

`GET /jobs/<id>/download/<file>` did `stop("File not found")`, which plumber turns into a 500. It now returns a **404 with a plain message** — outputs do not persist across restarts, re-run to regenerate. Outputs are regenerable, so they are deliberately *not* mirrored (only inputs, which are irreplaceable user data).

The other half of that issue note — the Results tab offering export buttons it can't honour — is a frontend change left out of scope here; the backend now at least fails honestly.

## Tests

`tests/test_input_persistence.R` (8 assertions, in the CI backend job) proves the base64 codec is a **byte-exact round-trip** over empty / UTF-8 / CRLF+quotes / full `0x00`–`0xFF` / 50k-row content, and that decode recreates a missing directory. That is the part everything else rests on — a lossy round-trip would silently corrupt a rehydrated upload.

The DB read/write path (`save_input_file` / `restore_input_files`) needs a live Postgres and **is verified post-deploy** — I can't reach the DB from here. After merge+deploy I will confirm end-to-end: submit → redeploy (or restart) → rerun succeeds and downloads work, which is the exact scenario that failed in #110.

Full local run: R 52/52 + 32/32 + 8/8, frontend 268/268, all changed R files parse.

## What this does NOT do

- Does not back-fill jobs whose inputs are **already** gone (Sandi's `901322df`, and the test jobs). There is nothing to mirror for those — they predate this change. They still need re-upload. From this deploy forward, new uploads are safe.
- Does not touch the auth work (#109/#112) or the matrix fix (#104).

🤖 Generated with [Claude Code](https://claude.com/claude-code)

<!-- This is an auto-generated comment: release notes by coderabbit.ai -->

## Summary by CodeRabbit

* **New Features**
  * Uploaded input files are now preserved across server restarts and deployments.
  * Jobs and reruns automatically restore missing input files before processing.
* **Bug Fixes**
  * Improved handling of missing downloadable outputs with a clearer 404 message and rerun guidance.
* **Tests**
  * Added coverage for reliable file encoding and restoration, including CSV, Unicode, empty, multiline, and binary content.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->