### PR TITLE
fix: stop telling users the ensemble was not calibrated (#101 follow-up)

### DIFF
--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -217,20 +217,10 @@ run_vacalibration <- function(job) {
   # and independent multi-algorithm runs (issue #83).
   per_algorithm <- build_per_algorithm(result)
 
-  # Path-correction lambda (issue #101). A lambda still at the 0.99 ceiling means
-  # the line search never found a usable correction, so the calibrated estimate is
-  # the uncalibrated one with implausibly tight credible intervals.
-  lambda_map <- build_lambda_map(result)
-  primary_lambda <- if (!is.null(lambda_map)) lambda_map[[primary]] else NULL
-  primary_stalled <- if (primary == "ensemble") any_stalled(lambda_map)
-                     else path_correction_stalled(primary_lambda)
-  if (primary_stalled) {
-    add_log(job$id, paste0(
-      "WARNING: path correction found no usable value (lambda = ", LAMBDA_CEILING,
-      "). Calibrated estimates equal the uncalibrated ones and their credible ",
-      "intervals are not meaningful. This happens when a broad cause has zero or ",
-      "near-zero deaths."))
-  }
+  # Path-correction reporting for the primary row (issue #101).
+  stall_fields <- build_stall_fields(result, primary)
+  if (!is.null(stall_fields$warning)) add_log(job$id, stall_fields$warning)
+  stall_fields$warning <- NULL
 
   # Extract the misclassification matrix used for calibration (issue #90).
   misclass_matrix <- extract_misclass_matrix(
@@ -284,13 +274,9 @@ run_vacalibration <- function(job) {
     calibrated_csmf = calibrated,
     calibrated_ci_lower = calibrated_low,
     calibrated_ci_upper = calibrated_high,
-    path_correction_stalled = primary_stalled,
     files = list(summary = "calibration_summary.csv")
   )
-
-  # Assigned separately, not inline: an inline NULL stays in the list and jsonlite
-  # emits it as `{}` instead of null (see build_per_algorithm).
-  if (!is.null(primary_lambda)) result_obj$lambda_calibpath <- primary_lambda
+  result_obj <- c(result_obj, stall_fields)
 
   # Add user's original cause names and ordering (issue #29)
   if (!is.null(cause_display_names)) result_obj$cause_display_names <- cause_display_names

--- a/backend/jobs/processor.R
+++ b/backend/jobs/processor.R
@@ -199,20 +199,10 @@ run_pipeline <- function(job) {
   # and independent multi-algorithm runs (issue #83).
   per_algorithm <- build_per_algorithm(calib_result)
 
-  # Path-correction lambda (issue #101). A lambda still at the 0.99 ceiling means
-  # the line search never found a usable correction, so the calibrated estimate is
-  # the uncalibrated one with implausibly tight credible intervals.
-  lambda_map <- build_lambda_map(calib_result)
-  primary_lambda <- if (!is.null(lambda_map)) lambda_map[[primary]] else NULL
-  primary_stalled <- if (primary == "ensemble") any_stalled(lambda_map)
-                     else path_correction_stalled(primary_lambda)
-  if (primary_stalled) {
-    add_log(job$id, paste0(
-      "WARNING: path correction found no usable value (lambda = ", LAMBDA_CEILING,
-      "). Calibrated estimates equal the uncalibrated ones and their credible ",
-      "intervals are not meaningful. This happens when a broad cause has zero or ",
-      "near-zero deaths."))
-  }
+  # Path-correction reporting for the primary row (issue #101).
+  stall_fields <- build_stall_fields(calib_result, primary)
+  if (!is.null(stall_fields$warning)) add_log(job$id, stall_fields$warning)
+  stall_fields$warning <- NULL
 
   # Extract the misclassification matrix used for calibration (issue #90).
   misclass_matrix <- extract_misclass_matrix(
@@ -275,16 +265,12 @@ run_pipeline <- function(job) {
     calibrated_csmf = calibrated,
     calibrated_ci_lower = calibrated_low,
     calibrated_ci_upper = calibrated_high,
-    path_correction_stalled = primary_stalled,
     files = list(
       causes = "causes.csv",
       summary = "calibration_summary.csv"
     )
   )
-
-  # Assigned separately, not inline: an inline NULL stays in the list and jsonlite
-  # emits it as `{}` instead of null (see build_per_algorithm).
-  if (!is.null(primary_lambda)) result_obj$lambda_calibpath <- primary_lambda
+  result_obj <- c(result_obj, stall_fields)
 
   if (!is.null(per_algorithm)) {
     result_obj$per_algorithm <- per_algorithm

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -694,11 +694,59 @@ build_lambda_map <- function(result) {
   setNames(as.list(as.numeric(lambda[seq_len(n)])), labels[seq_len(n)])
 }
 
-# The ensemble posterior is built from the per-algorithm draws, so one stalled
-# algorithm contaminates it.
-any_stalled <- function(lambda_map) {
-  if (is.null(lambda_map) || length(lambda_map) == 0) return(FALSE)
-  any(vapply(lambda_map, path_correction_stalled, logical(1)))
+# Names the algorithms whose lambda hit the ceiling. The ensemble is its own Stan fit
+# over every algorithm's death counts and Mmat prior (NOT a function of the
+# per-algorithm draws), and it receives the stalled algorithm's whole lambda-mixed
+# prior slice -- row sums ~4,700-7,700 against ~31-59 unmixed. So its intervals
+# inherit the false precision even though its point estimate is a genuine fit.
+stalled_algorithms <- function(lambda_map) {
+  if (is.null(lambda_map) || length(lambda_map) == 0) return(character(0))
+  names(lambda_map)[vapply(lambda_map, path_correction_stalled, logical(1))]
+}
+
+any_stalled <- function(lambda_map) length(stalled_algorithms(lambda_map)) > 0
+
+# Assemble the stall fields for one result row. Shared by both job paths so the
+# wiring is testable in one place.
+#
+# Two distinct facts, deliberately not one flag:
+#   path_correction_stalled -- this row's OWN lambda hit the ceiling, so its point
+#                              estimate is a no-op. Never true for the ensemble,
+#                              which has no lambda of its own.
+#   ci_unreliable           -- this row's credible intervals carry false precision.
+#                              True for a stalled algorithm AND for an ensemble with
+#                              any stalled constituent.
+# Measured on a real mixed run (eava 0.99, interva 0.14): the ensemble still moved
+# 1.2pp, so calling it "not calibrated" would be false, but its mean CrI width was
+# 0.0175 against the healthy algorithm's 0.1561 -- 9x tighter.
+build_stall_fields <- function(result, label) {
+  lambda_map <- build_lambda_map(result)
+  lambda     <- if (!is.null(lambda_map)) lambda_map[[label]] else NULL
+  stalled    <- path_correction_stalled(lambda)
+  culprits   <- if (label == "ensemble") stalled_algorithms(lambda_map)
+                else if (stalled) label else character(0)
+
+  out <- list(path_correction_stalled = stalled,
+              ci_unreliable = stalled || length(culprits) > 0)
+  # Assigned conditionally: `list(x = NULL)` KEEPS the element and jsonlite emits it
+  # as `{}` rather than null. The ensemble has no lambda, so this is its normal path.
+  if (!is.null(lambda)) out$lambda_calibpath <- lambda
+  if (label == "ensemble" && length(culprits) > 0) out$stalled_constituents <- as.list(culprits)
+
+  if (out$ci_unreliable) {
+    out$warning <- if (stalled) {
+      paste0("WARNING: path correction could only use lambda = ", lambda,
+             " (a ", round(100 * min(lambda, 1)), "% identity mixture), so the calibrated ",
+             "estimates for ", label, " equal the uncalibrated ones and their credible ",
+             "intervals are not meaningful. This happens when a broad cause has zero or ",
+             "near-zero deaths.")
+    } else {
+      paste0("WARNING: credible intervals for ", label, " are not meaningful because ",
+             paste(culprits, collapse = ", "), " had no usable path correction. The ",
+             label, " point estimate is still a genuine fit.")
+    }
+  }
+  out
 }
 
 # Check if causes are already in broad format (all unique values are broad cause names).
@@ -1022,27 +1070,19 @@ build_per_algorithm <- function(result) {
   result_labels <- dimnames(result$pcalib_postsumm)[[1]]
   if (length(result_labels) <= 1) return(NULL)
 
-  # Path-correction lambda per algorithm (issue #101). The ensemble has no lambda
-  # of its own; it is flagged when any constituent algorithm stalled.
-  lambda_map <- build_lambda_map(result)
-
   per_algorithm <- list()
   for (label in result_labels) {
-    lambda <- if (!is.null(lambda_map)) lambda_map[[label]] else NULL
     entry <- list(
       uncalibrated_csmf   = as.list(round(result$p_uncalib[label, ], 4)),
       calibrated_csmf     = as.list(round(result$pcalib_postsumm[label, "postmean", ], 4)),
       calibrated_ci_lower = as.list(round(result$pcalib_postsumm[label, "lowcredI", ], 4)),
-      calibrated_ci_upper = as.list(round(result$pcalib_postsumm[label, "upcredI", ], 4)),
-      path_correction_stalled = if (label == "ensemble") any_stalled(lambda_map)
-                                else path_correction_stalled(lambda)
+      calibrated_ci_upper = as.list(round(result$pcalib_postsumm[label, "upcredI", ], 4))
     )
-    # Assign only when present: `list(x = NULL)` KEEPS the element, and jsonlite then
-    # serialises it as an empty object `{}` rather than null. The frontend's `?? null`
-    # does not catch `{}`, so formatting it throws. The ensemble has no lambda of its
-    # own, so this is the normal path for every ensemble run.
-    if (!is.null(lambda)) entry$lambda_calibpath <- lambda
-    per_algorithm[[label]] <- entry
+    # Path-correction reporting (issue #101). `warning` is for the job log, not the
+    # payload, so it is dropped here.
+    sf <- build_stall_fields(result, label)
+    sf$warning <- NULL
+    per_algorithm[[label]] <- c(entry, sf)
   }
   per_algorithm
 }

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -741,8 +741,13 @@ build_stall_fields <- function(result, label) {
              "intervals are not meaningful. This happens when a broad cause has zero or ",
              "near-zero deaths.")
     } else {
+      # Name each culprit WITH its lambda: on an ensemble job this is the only warning
+      # that gets logged (both callers log the primary row, and build_per_algorithm
+      # strips the per-algorithm warnings), so otherwise no log records the value.
+      named <- vapply(culprits, function(a)
+        paste0(a, " (lambda = ", lambda_map[[a]], ")"), character(1))
       paste0("WARNING: credible intervals for ", label, " are not meaningful because ",
-             paste(culprits, collapse = ", "), " had no usable path correction. The ",
+             paste(named, collapse = ", "), " had no usable path correction. The ",
              label, " point estimate is still a genuine fit.")
     }
   }

--- a/frontend/src/components/CSMFChart.js
+++ b/frontend/src/components/CSMFChart.js
@@ -28,14 +28,20 @@ export function buildCsmfFacets(results) {
 
   const makeFacet = (label, src) => ({
     label,
-    // issue #101: lambda at the 0.99 ceiling means path correction found no usable
-    // value, so the "calibrated" bars equal the uncalibrated ones and the intervals
-    // are ~7x too tight. Older jobs predate the field, hence the `=== true` default.
-    // The lambda is type-checked rather than null-checked because jsonlite puts
-    // non-numbers on the wire: an R NULL becomes `{}` and an R NA becomes the string
-    // "NA", both of which survive `?? null` and then throw on `.toFixed()`.
+    // issue #101, two distinct facts:
+    //   pathCorrectionStalled -- this row's own lambda hit the identity ceiling, so its
+    //                            point estimate is a no-op. Never true for the ensemble.
+    //   ciUnreliable          -- this row's intervals carry false precision (~7x too
+    //                            tight). True for a stalled algorithm, and for an
+    //                            ensemble with any stalled constituent, whose estimate
+    //                            IS a real fit.
+    // Strict `=== true` and `typeof === 'number'`, not `??`: these values reach us via
+    // api/client.js unbox(), and anything it does not collapse to a plain scalar must
+    // read as "unknown" rather than as a flag. Older jobs lack the fields entirely.
     lambda: typeof src.lambda_calibpath === 'number' ? src.lambda_calibpath : null,
     pathCorrectionStalled: src.path_correction_stalled === true,
+    ciUnreliable: src.ci_unreliable === true || src.path_correction_stalled === true,
+    stalledConstituents: Array.isArray(src.stalled_constituents) ? src.stalled_constituents : null,
     causes: causes.map(cause => ({
       cause,
       uncalibrated: src.uncalibrated_csmf?.[cause] ?? 0,
@@ -94,18 +100,27 @@ export function buildCsmfTableRows(results) {
   // rather than silently stripped, so the omission is visible.
   const makeGroup = (label, src) => {
     const stalled = src.path_correction_stalled === true;
+    const noCI = stalled || src.ci_unreliable === true;
+    // A point-mass interval claims perfect certainty, so drop it here exactly as the
+    // chart does — vacalibration returns lower == upper == postmean for every cause it
+    // did not calibrate, and `other` is excluded by default, so every run has one.
+    const cell = (c) => {
+      const lo = pct(src.calibrated_ci_lower?.[c]);
+      const hi = pct(src.calibrated_ci_upper?.[c]);
+      const degenerate = lo == null || hi == null || !(hi > lo);
+      return { cause: c, mean: pct(src.calibrated_csmf?.[c]),
+               lower: noCI || degenerate ? null : lo,
+               upper: noCI || degenerate ? null : hi };
+    };
     return {
       algorithm: label,
       rows: [
         { type: 'Uncalibrated', cells: causes.map(c => ({ cause: c, mean: pct(src.uncalibrated_csmf?.[c]), lower: null, upper: null })) },
         {
-          type: stalled ? 'Calibrated (not calibrated: no usable path correction)' : 'Calibrated',
-          cells: causes.map(c => ({
-            cause: c,
-            mean: pct(src.calibrated_csmf?.[c]),
-            lower: stalled ? null : pct(src.calibrated_ci_lower?.[c]),
-            upper: stalled ? null : pct(src.calibrated_ci_upper?.[c]),
-          })),
+          type: stalled ? 'Calibrated (not calibrated: no usable path correction)'
+                : noCI ? 'Calibrated (intervals omitted: unreliable)'
+                : 'Calibrated',
+          cells: causes.map(cell),
         },
       ],
     };

--- a/frontend/src/components/CSMFChart.js
+++ b/frontend/src/components/CSMFChart.js
@@ -41,7 +41,12 @@ export function buildCsmfFacets(results) {
     lambda: typeof src.lambda_calibpath === 'number' ? src.lambda_calibpath : null,
     pathCorrectionStalled: src.path_correction_stalled === true,
     ciUnreliable: src.ci_unreliable === true || src.path_correction_stalled === true,
-    stalledConstituents: Array.isArray(src.stalled_constituents) ? src.stalled_constituents : null,
+    // Both shapes are real: api/client.js unbox() collapses a one-item primitive array
+    // to a scalar, so exactly one stalled algorithm arrives as "eava" while two arrive
+    // as ["eava", "insilicova"]. Any array field crossing this boundary needs both.
+    stalledConstituents: Array.isArray(src.stalled_constituents) ? src.stalled_constituents
+      : typeof src.stalled_constituents === 'string' ? [src.stalled_constituents]
+      : null,
     causes: causes.map(cause => ({
       cause,
       uncalibrated: src.uncalibrated_csmf?.[cause] ?? 0,
@@ -104,13 +109,16 @@ export function buildCsmfTableRows(results) {
     // A point-mass interval claims perfect certainty, so drop it here exactly as the
     // chart does — vacalibration returns lower == upper == postmean for every cause it
     // did not calibrate, and `other` is excluded by default, so every run has one.
+    // Decided on the RAW bounds, matching csmfWhisker: deciding on rounded percents
+    // would suppress a real interval like 0.0131–0.0134 that the chart draws, which is
+    // the same chart/table disagreement in reverse. pct() is for display only.
     const cell = (c) => {
-      const lo = pct(src.calibrated_ci_lower?.[c]);
-      const hi = pct(src.calibrated_ci_upper?.[c]);
-      const degenerate = lo == null || hi == null || !(hi > lo);
+      const rawLo = src.calibrated_ci_lower?.[c];
+      const rawHi = src.calibrated_ci_upper?.[c];
+      const degenerate = rawLo == null || rawHi == null || !(rawHi > rawLo);
       return { cause: c, mean: pct(src.calibrated_csmf?.[c]),
-               lower: noCI || degenerate ? null : lo,
-               upper: noCI || degenerate ? null : hi };
+               lower: noCI || degenerate ? null : pct(rawLo),
+               upper: noCI || degenerate ? null : pct(rawHi) };
     };
     return {
       algorithm: label,

--- a/frontend/src/components/CSMFChart.test.js
+++ b/frontend/src/components/CSMFChart.test.js
@@ -276,6 +276,46 @@ describe('stalled estimate vs unreliable intervals (issue #101 follow-up)', () =
     expect(by()['Ensemble'].stalledConstituents).toEqual(['eava'])
   })
 
+  // api/client.js unbox() collapses a ONE-item primitive array to a scalar, so the
+  // common case (exactly one algorithm stalled) arrives as the string "eava", not
+  // ["eava"]. An Array.isArray() guard alone drops it and the note stops naming the
+  // algorithm -- which is the whole point of the field.
+  it('accepts the unboxed single-constituent shape (a bare string)', () => {
+    const one = {
+      ...ensemble,
+      per_algorithm: {
+        ...ensemble.per_algorithm,
+        ensemble: { ...ensemble.per_algorithm.ensemble, ci_unreliable: true, stalled_constituents: 'eava' },
+      },
+    }
+    const f = Object.fromEntries(buildCsmfFacets(one).map(x => [x.label, x]))['Ensemble']
+    expect(f.stalledConstituents).toEqual(['eava'])
+  })
+
+  it('keeps a multi-constituent array unchanged (unbox leaves those alone)', () => {
+    const two = {
+      ...ensemble,
+      per_algorithm: {
+        ...ensemble.per_algorithm,
+        ensemble: { ...ensemble.per_algorithm.ensemble, ci_unreliable: true, stalled_constituents: ['eava', 'insilicova'] },
+      },
+    }
+    const f = Object.fromEntries(buildCsmfFacets(two).map(x => [x.label, x]))['Ensemble']
+    expect(f.stalledConstituents).toEqual(['eava', 'insilicova'])
+  })
+
+  it('ignores a shape that is neither string nor array', () => {
+    const bad = {
+      ...ensemble,
+      per_algorithm: {
+        ...ensemble.per_algorithm,
+        ensemble: { ...ensemble.per_algorithm.ensemble, ci_unreliable: true, stalled_constituents: {} },
+      },
+    }
+    const f = Object.fromEntries(buildCsmfFacets(bad).map(x => [x.label, x]))['Ensemble']
+    expect(f.stalledConstituents).toBeNull()
+  })
+
   it('suppresses the whisker whenever the intervals are unreliable, stalled or not', () => {
     expect(csmfWhisker(0.4, 0.3, 0.5, true)).toBeNull()
   })
@@ -360,5 +400,46 @@ describe('depends on api/client unbox() (issue #101 follow-up)', () => {
     const [f] = buildCsmfFacets(unboxed)
     expect(f.pathCorrectionStalled).toBe(true)
     expect(f.lambda).toBeCloseTo(0.99, 5)
+  })
+})
+
+// issue #101 follow-up 2: the degeneracy decision must be made at ONE precision. The
+// chart tests raw fractions (ciUpper > ciLower) while the table used to test rounded
+// integer percents, so an interval like 0.0131-0.0134 was drawn by the chart and
+// suppressed by the table -- the same chart/table disagreement, just reversed.
+describe('degeneracy decided on raw bounds, not rounded (issue #101 follow-up 2)', () => {
+  const narrowButReal = {
+    algorithm: 'interva',
+    cause_order: ['other'],
+    path_correction_stalled: false,
+    ci_unreliable: false,
+    uncalibrated_csmf:   { other: 0.013 },
+    calibrated_csmf:     { other: 0.0132 },
+    calibrated_ci_lower: { other: 0.0131 },
+    calibrated_ci_upper: { other: 0.0134 },   // distinct raw bounds, both round to 1%
+  }
+
+  it('keeps a real interval whose bounds round to the same percent', () => {
+    const { groups } = buildCsmfTableRows(narrowButReal)
+    const cal = groups[0].rows.find(r => /^Calibrated/.test(r.type))
+    const other = cal.cells.find(c => c.cause === 'other')
+    expect(other.lower).not.toBeNull()
+    expect(other.upper).not.toBeNull()
+  })
+
+  it('agrees with the chart on the same bounds', () => {
+    expect(csmfWhisker(0.0132, 0.0131, 0.0134, false)).not.toBeNull()
+  })
+
+  it('still drops a genuine point mass', () => {
+    const pointMass = {
+      ...narrowButReal,
+      calibrated_ci_lower: { other: 0.0132 },
+      calibrated_ci_upper: { other: 0.0132 },
+    }
+    const { groups } = buildCsmfTableRows(pointMass)
+    const cal = groups[0].rows.find(r => /^Calibrated/.test(r.type))
+    expect(cal.cells.find(c => c.cause === 'other').lower).toBeNull()
+    expect(csmfWhisker(0.0132, 0.0132, 0.0132, false)).toBeNull()
   })
 })

--- a/frontend/src/components/CSMFChart.test.js
+++ b/frontend/src/components/CSMFChart.test.js
@@ -247,3 +247,118 @@ describe('table suppresses CI when path correction stalled (issue #101)', () => 
     expect(calOf(g['InterVA']).cells.some(c => c.lower !== null)).toBe(true)
   })
 })
+
+// issue #101 follow-up: the flag was split in two. `path_correction_stalled` means this
+// row's own lambda hit the ceiling (its estimate is a no-op); `ci_unreliable` means the
+// intervals carry false precision. The ensemble gets the second without the first --
+// measured on a real mixed run it still moved 1.2pp, so calling it "not calibrated"
+// was false, but its CrIs were 9x tighter than the healthy algorithm's.
+describe('stalled estimate vs unreliable intervals (issue #101 follow-up)', () => {
+  const mixed = {
+    ...ensemble,
+    per_algorithm: {
+      eava:     { ...ensemble.per_algorithm.eava,     lambda_calibpath: 0.99, path_correction_stalled: true,  ci_unreliable: true },
+      interva:  { ...ensemble.per_algorithm.interva,  lambda_calibpath: 0.43, path_correction_stalled: false, ci_unreliable: false },
+      ensemble: { ...ensemble.per_algorithm.ensemble, path_correction_stalled: false, ci_unreliable: true, stalled_constituents: ['eava'] },
+    },
+  }
+  const by = () => Object.fromEntries(buildCsmfFacets(mixed).map(f => [f.label, f]))
+
+  it('carries both flags separately', () => {
+    expect(by()['EAVA'].pathCorrectionStalled).toBe(true)
+    expect(by()['EAVA'].ciUnreliable).toBe(true)
+    expect(by()['Ensemble'].pathCorrectionStalled).toBe(false)
+    expect(by()['Ensemble'].ciUnreliable).toBe(true)
+    expect(by()['InterVA'].ciUnreliable).toBe(false)
+  })
+
+  it('names the stalled constituents on the ensemble facet', () => {
+    expect(by()['Ensemble'].stalledConstituents).toEqual(['eava'])
+  })
+
+  it('suppresses the whisker whenever the intervals are unreliable, stalled or not', () => {
+    expect(csmfWhisker(0.4, 0.3, 0.5, true)).toBeNull()
+  })
+
+  it('the table drops the CI for an unreliable-CI row without calling it not-calibrated', () => {
+    const { groups } = buildCsmfTableRows(mixed)
+    const g = Object.fromEntries(groups.map(x => [x.algorithm, x]))
+    const calOf = grp => grp.rows.find(r => /^Calibrated/.test(r.type))
+    expect(calOf(g['Ensemble']).cells.every(c => c.lower === null)).toBe(true)
+    expect(calOf(g['Ensemble']).type).not.toMatch(/not calibrated/i)
+    expect(calOf(g['Ensemble']).type).toMatch(/interval/i)
+    // the genuinely stalled algorithm keeps the stronger label
+    expect(calOf(g['EAVA']).type).toMatch(/not calibrated/i)
+  })
+
+  it('older jobs without either field render unchanged', () => {
+    const [f] = buildCsmfFacets(single)
+    expect(f.pathCorrectionStalled).toBe(false)
+    expect(f.ciUnreliable).toBe(false)
+  })
+
+  // M5 from the mutation review: `=== true` must not be `?? false`, so a non-boolean
+  // never reads as stalled. R can put odd shapes on the wire.
+  it('a non-boolean flag never counts as stalled', () => {
+    const odd = { ...single, path_correction_stalled: {}, ci_unreliable: {} }
+    const [f] = buildCsmfFacets(odd)
+    expect(f.pathCorrectionStalled).toBe(false)
+    expect(f.ciUnreliable).toBe(false)
+  })
+})
+
+// issue #101 follow-up: the point-mass guard existed only in the chart, so on EVERY run
+// (`other` is excluded from calibration by default) the chart hid the whisker while the
+// table printed "1% (1-1)" for the same cause.
+describe('table drops point-mass intervals too (issue #101 follow-up)', () => {
+  const nonStalled = {
+    algorithm: 'interva',
+    cause_order: ['pneumonia', 'other'],
+    path_correction_stalled: false,
+    ci_unreliable: false,
+    uncalibrated_csmf:   { pneumonia: 0.30, other: 0.013 },
+    calibrated_csmf:     { pneumonia: 0.42, other: 0.013 },
+    calibrated_ci_lower: { pneumonia: 0.35, other: 0.013 },
+    calibrated_ci_upper: { pneumonia: 0.49, other: 0.013 },
+  }
+
+  it('drops the CI for a cause whose interval is a point mass', () => {
+    const { groups } = buildCsmfTableRows(nonStalled)
+    const cal = groups[0].rows.find(r => /^Calibrated/.test(r.type))
+    const other = cal.cells.find(c => c.cause === 'other')
+    expect(other.mean).toBe(1)
+    expect(other.lower).toBeNull()
+    expect(other.upper).toBeNull()
+  })
+
+  it('keeps the CI for causes with a real interval in the same row', () => {
+    const { groups } = buildCsmfTableRows(nonStalled)
+    const cal = groups[0].rows.find(r => /^Calibrated/.test(r.type))
+    const pneu = cal.cells.find(c => c.cause === 'pneumonia')
+    expect(pneu.lower).toBe(35)
+    expect(pneu.upper).toBe(49)
+  })
+
+  it('chart and table now agree that the point mass has no interval', () => {
+    expect(csmfWhisker(0.013, 0.013, 0.013, false)).toBeNull()
+  })
+})
+
+// issue #101 follow-up: every scalar arrives from plumber boxed as [x]; api/client.js
+// unbox() collapses it before the component sees it. Without that layer `=== true` and
+// `typeof === 'number'` both fail and the whole feature silently does nothing, so pin it.
+describe('depends on api/client unbox() (issue #101 follow-up)', () => {
+  it('boxed scalars would defeat the guards, documenting the dependency', () => {
+    const boxed = { ...single, path_correction_stalled: [true], lambda_calibpath: [0.99] }
+    const [f] = buildCsmfFacets(boxed)
+    expect(f.pathCorrectionStalled).toBe(false)
+    expect(f.lambda).toBeNull()
+  })
+
+  it('works on the unboxed shape the client actually delivers', () => {
+    const unboxed = { ...single, path_correction_stalled: true, ci_unreliable: true, lambda_calibpath: 0.99 }
+    const [f] = buildCsmfFacets(unboxed)
+    expect(f.pathCorrectionStalled).toBe(true)
+    expect(f.lambda).toBeCloseTo(0.99, 5)
+  })
+})

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -4,7 +4,7 @@ import { MisclassificationMatrix } from './MisclassificationMatrix.jsx';
 import { exportCSMFTable, exportConsolidatedCSMF, exportToPNG, exportToPDF, exportCombinedPDF, generateFilename } from '../utils/export';
 import { buildCsmfFacets, buildCsmfTableRows, csmfWhisker } from './CSMFChart.js';
 import { formatCauseDisplay, sortCausesByValue } from '../utils/causeDisplay.js';
-import { formatAlgorithmList, formatAgeGroup } from '../utils/labels.js';
+import { formatAlgorithmList, formatAgeGroup, formatAlgorithmName } from '../utils/labels.js';
 import ProgressIndicator from './ProgressIndicator';
 import { formatTimestamp } from '../utils/datetime';
 
@@ -396,12 +396,20 @@ function CSMFChart({ results, causeDisplayNames }) {
         {facets.map(facet => (
           <div key={facet.label} className="csmf-facet">
             <div className="csmf-facet-title">{facet.label}</div>
-            {facet.pathCorrectionStalled && (
+            {facet.pathCorrectionStalled ? (
               <div className="csmf-stall-note">
-                Not calibrated: path correction found no usable value
-                {facet.lambda != null && ` (λ = ${facet.lambda.toFixed(2)})`}.
-                The calibrated bars equal the uncalibrated ones and credible intervals
+                Not calibrated: path correction could only use
+                {typeof facet.lambda === 'number' ? ` λ = ${facet.lambda.toFixed(2)}` : ' the identity ceiling'},
+                so the calibrated bars equal the uncalibrated ones and credible intervals
                 are omitted. This happens when a broad cause has zero or near-zero deaths.
+              </div>
+            ) : facet.ciUnreliable && (
+              <div className="csmf-stall-note">
+                Credible intervals omitted
+                {facet.stalledConstituents?.length
+                  ? `: ${facet.stalledConstituents.map(formatAlgorithmName).join(', ')} had no usable path correction, which makes these intervals implausibly tight`
+                  : ': the intervals are implausibly tight'}.
+                The bars themselves are a genuine fit.
               </div>
             )}
             <div className="csmf-plot">
@@ -424,7 +432,7 @@ function CSMFChart({ results, causeDisplayNames }) {
                       <div className="csmf-bar cal" style={{ height: `${calibrated * 100}%` }}
                         title={`Calibrated: ${(calibrated * 100).toFixed(1)}%`}>
                         {(() => {
-                          const w = csmfWhisker(calibrated, ciLower, ciUpper, facet.pathCorrectionStalled);
+                          const w = csmfWhisker(calibrated, ciLower, ciUpper, facet.ciUnreliable);
                           return w && (
                             <div className="csmf-whisker"
                               style={{ bottom: `${w.bottomPct}%`, height: `${w.heightPct}%` }}

--- a/frontend/src/components/JobDetail.test.js
+++ b/frontend/src/components/JobDetail.test.js
@@ -113,16 +113,28 @@ describe('Ensemble vs independent multi-algorithm indicator (issue #83)', () => 
 })
 
 describe('path-correction stall notice (issue #101)', () => {
-  it('passes the stall flag to csmfWhisker so the CI is suppressed', () => {
-    expect(jobDetailSrc).toContain('csmfWhisker(calibrated, ciLower, ciUpper, facet.pathCorrectionStalled)')
+  // Whiskers are keyed on ciUnreliable, not pathCorrectionStalled: an ensemble with a
+  // stalled constituent has usable bars but unusable intervals.
+  it('keys whisker suppression on ciUnreliable', () => {
+    expect(jobDetailSrc).toContain('csmfWhisker(calibrated, ciLower, ciUpper, facet.ciUnreliable)')
   })
 
-  it('renders a notice explaining why the bars are identical', () => {
-    expect(jobDetailSrc).toContain('facet.pathCorrectionStalled && (')
-    expect(jobDetailSrc).toContain('path correction found no usable value')
+  it('renders the no-op notice only for a genuinely stalled row', () => {
+    expect(jobDetailSrc).toContain('facet.pathCorrectionStalled ? (')
+    expect(jobDetailSrc).toContain('the calibrated bars equal the uncalibrated ones')
   })
 
-  it('shows the lambda value when the backend reports one', () => {
-    expect(jobDetailSrc).toContain('facet.lambda != null')
+  it('renders a different notice when only the intervals are unreliable', () => {
+    expect(jobDetailSrc).toContain('facet.ciUnreliable && (')
+    expect(jobDetailSrc).toContain('The bars themselves are a genuine fit')
+  })
+
+  it('never tells the user an unreliable-CI row was not calibrated', () => {
+    const unreliableBlock = jobDetailSrc.split('facet.ciUnreliable && (')[1].slice(0, 500)
+    expect(unreliableBlock).not.toMatch(/not calibrated/i)
+  })
+
+  it('type-checks lambda before formatting it', () => {
+    expect(jobDetailSrc).toContain("typeof facet.lambda === 'number'")
   })
 })

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -2263,6 +2263,20 @@ test("ensemble primary: intervals unusable but estimate not a no-op",
      isFALSE(sf_ens$path_correction_stalled) && isTRUE(sf_ens$ci_unreliable))
 test("ensemble primary: warning names the stalled constituent",
      grepl("eava", sf_ens$warning, fixed = TRUE))
+# On an ensemble job the ensemble's warning is the ONLY one logged -- both callers log
+# the primary row only, and build_per_algorithm strips the per-algorithm warnings -- so
+# without the lambda here no log records it anywhere.
+test("ensemble primary: warning carries each constituent's lambda",
+     grepl("eava (lambda = 0.99)", sf_ens$warning, fixed = TRUE))
+
+sf_ens2 <- build_stall_fields(
+  fake_result(c("eava", "insilicova", "interva", "ensemble"), c(0.99, 1.01, 0.31)), "ensemble")
+test("ensemble primary: two stalled constituents both appear with their lambdas",
+     grepl("eava (lambda = 0.99)", sf_ens2$warning, fixed = TRUE) &&
+       grepl("insilicova (lambda = 1.01)", sf_ens2$warning, fixed = TRUE) &&
+       !grepl("interva (lambda", sf_ens2$warning, fixed = TRUE))
+test("ensemble primary: both stalled constituents are reported in the payload",
+     identical(sf_ens2$stalled_constituents, list("eava", "insilicova")))
 
 sf_ok <- build_stall_fields(fake_result("eava", 0.14), "eava")
 test("healthy run produces no warning",

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -2152,6 +2152,8 @@ test("vector input is not reported as stalled",
 # entry, while pcalib_postsumm has an extra "ensemble" row. Verified against
 # vacalibration 2.2: 2 algorithms + ensemble => 3 result rows, length(lambda) == 2.
 fake_result <- function(labels, lambda) list(
+  p_uncalib = matrix(0.5, nrow = length(labels), ncol = 2,
+                     dimnames = list(labels, c("pneumonia", "other"))),
   pcalib_postsumm = array(0, dim = c(length(labels), 3, 2),
                           dimnames = list(labels, c("postmean", "lowcredI", "upcredI"),
                                           c("pneumonia", "other"))),
@@ -2206,10 +2208,84 @@ test("ensemble lambda serialises as absent, not as an empty object",
 test("per-algorithm entries keep their lambda",
      isTRUE(all.equal(pa$eava$lambda_calibpath, 0.99)) &&
        isTRUE(all.equal(pa$interva$lambda_calibpath, 0.43)))
-test("ensemble is still flagged stalled when a constituent stalled",
-     isTRUE(pa$ensemble$path_correction_stalled) &&
-       isTRUE(pa$eava$path_correction_stalled) &&
+test("only the algorithm that stalled is flagged as a no-op",
+     isTRUE(pa$eava$path_correction_stalled) &&
        isFALSE(pa$interva$path_correction_stalled))
+
+# --- Two separate facts, not one flag (issue #101 follow-up) -----------------
+# A stalled algorithm's point estimate IS a no-op. The ensemble's is NOT: measured
+# on a real mixed run (eava lambda 0.99, interva 0.14) the ensemble still moved
+# 1.2pp, while its mean CrI width was 0.0175 against the healthy algorithm's 0.1561
+# -- 9x tighter. So the intervals are unusable but the estimate is real, and the
+# UI must not tell the user "the calibrated bars equal the uncalibrated ones".
+test("a stalled algorithm reports its estimate as a no-op",
+     isTRUE(pa$eava$path_correction_stalled) && isTRUE(pa$eava$ci_unreliable))
+test("the ensemble reports unusable intervals but NOT a no-op estimate",
+     isFALSE(pa$ensemble$path_correction_stalled) && isTRUE(pa$ensemble$ci_unreliable))
+test("the ensemble names the constituents that stalled",
+     identical(pa$ensemble$stalled_constituents, list("eava")))
+test("a healthy algorithm reports neither",
+     isFALSE(pa$interva$path_correction_stalled) && isFALSE(pa$interva$ci_unreliable))
+
+pa_ok <- build_per_algorithm(fake_result(c("eava", "interva", "ensemble"), c(0.14, 0.43)))
+test("no algorithm stalled: ensemble intervals are usable",
+     isFALSE(pa_ok$ensemble$ci_unreliable) &&
+       is.null(pa_ok$ensemble$stalled_constituents))
+
+# --- The ceiling differs by missmat_type (issue #101 follow-up) --------------
+# modular_vacalib_prior starts the search at 0.99 and caps at min(x + 0.01, 0.99).
+# modular_vacalib_fixed starts at 1 with NO cap, so a first-iteration stall returns
+# 1.01. `missmat_type = "fixed"` is user-reachable (JobForm's "Propagate" checkbox).
+test("the fixed path's 1.01 stall value is detected", isTRUE(path_correction_stalled(1.01)))
+test("the fixed path's 1.00 is detected", isTRUE(path_correction_stalled(1)))
+test("0.98 is still not stalled on either path", isFALSE(path_correction_stalled(0.98)))
+
+# --- build_stall_fields(): the wiring both job paths share -------------------
+# Previously each caller assembled these fields inline, so deleting the wiring from
+# both broke zero tests. One helper, tested here, and a source assertion that both
+# callers use it.
+sf_single <- build_stall_fields(fake_result("eava", 0.99), "eava")
+test("single stalled algorithm: fields set, lambda carried",
+     isTRUE(sf_single$path_correction_stalled) && isTRUE(sf_single$ci_unreliable) &&
+       isTRUE(all.equal(sf_single$lambda_calibpath, 0.99)))
+test("single stalled algorithm: warning text names the real lambda, not the constant",
+     grepl("0.99", sf_single$warning, fixed = TRUE))
+
+sf_fixed <- build_stall_fields(fake_result("eava", 1.01), "eava")
+test("fixed-path stall: warning reports 1.01, not the 0.99 constant",
+     grepl("1.01", sf_fixed$warning, fixed = TRUE) &&
+       !grepl("0.99", sf_fixed$warning, fixed = TRUE))
+
+sf_ens <- build_stall_fields(fake_result(c("eava", "interva", "ensemble"), c(0.99, 0.43)), "ensemble")
+test("ensemble primary: no lambda of its own, so the field is absent",
+     !("lambda_calibpath" %in% names(sf_ens)))
+test("ensemble primary: intervals unusable but estimate not a no-op",
+     isFALSE(sf_ens$path_correction_stalled) && isTRUE(sf_ens$ci_unreliable))
+test("ensemble primary: warning names the stalled constituent",
+     grepl("eava", sf_ens$warning, fixed = TRUE))
+
+sf_ok <- build_stall_fields(fake_result("eava", 0.14), "eava")
+test("healthy run produces no warning",
+     isFALSE(sf_ok$path_correction_stalled) && is.null(sf_ok$warning))
+
+# Both job paths must build the fields AND merge them into the result object. The
+# merge is asserted separately because a caller can keep calling build_stall_fields()
+# for its log line while dropping the fields from the payload -- which is exactly
+# what happened before, and the earlier "calls the helper" assertion missed it.
+# Source assertions rather than a live run: reaching result_obj needs a DB and a
+# multi-minute MCMC, so this is the same style used in JobDetail.test.js.
+for (f in c(file.path(backend_dir, "jobs", "algorithms", "vacalibration.R"),
+            file.path(backend_dir, "jobs", "processor.R"))) {
+  src <- paste(readLines(f, warn = FALSE), collapse = "\n")
+  test(sprintf("%s calls build_stall_fields()", basename(f)),
+       grepl("build_stall_fields(", src, fixed = TRUE))
+  test(sprintf("%s merges the stall fields into result_obj", basename(f)),
+       grepl("result_obj <- c(result_obj, stall_fields)", src, fixed = TRUE))
+  test(sprintf("%s logs the warning the helper produced", basename(f)),
+       grepl("add_log(job$id, stall_fields$warning)", src, fixed = TRUE))
+  test(sprintf("%s no longer hardcodes LAMBDA_CEILING in a log line", basename(f)),
+       !grepl("LAMBDA_CEILING,", src, fixed = TRUE))
+}
 
 # =============================================================================
 # SUMMARY


### PR DESCRIPTION
Follow-up to #115, from an adversarial post-merge review of it. Three user-facing defects and four testing gaps.

## 1. The ensemble note was false

#115 used one `path_correction_stalled` flag for two different facts. Measured on a real mixed run (`eava` λ = 0.99, `interva` λ = 0.15, child/Mozambique):

| facet | max \|calibrated − uncalibrated\| | mean 95% CrI width |
|---|---|---|
| `eava` (stalled) | 0.1pp — a genuine no-op | 0.019 |
| `interva` (healthy) | 14.1pp | 0.156 |
| `ensemble` | **1.2pp — it *was* calibrated** | 0.018 — **9× tighter than interva** |

So the ensemble's intervals are unusable while its point estimate is a real fit. #115 told the user *"the calibrated bars equal the uncalibrated ones"* and labelled its table row *"not calibrated"* — on the facet that is the **primary result**.

Split in two:

- `path_correction_stalled` — this row's own λ hit the identity ceiling, so its estimate is a no-op. Never true for the ensemble, which has no λ of its own.
- `ci_unreliable` — this row's intervals carry false precision. True for a stalled algorithm, and for an ensemble with any stalled constituent.

The ensemble now also reports `stalled_constituents`, so the note names the cause ("`EAVA` had no usable path correction, which makes these intervals implausibly tight. The bars themselves are a genuine fit.") instead of asserting something untrue.

This also corrects a wrong comment from #115: the ensemble posterior is **not** a function of the per-algorithm draws — it is its own Stan fit, which receives the stalled algorithm's λ-mixed prior slice (row sums ~4,700–7,700 against ~31–59 unmixed). Same conclusion, right reason.

## 2. The point-mass guard was chart-only

vacalibration returns `lower == upper == postmean` for every cause it did not calibrate, and `other` is excluded by default — so **every run** has at least one, both shipped calibration demos included. #115 added the guard to `csmfWhisker` only, so the chart hid the whisker while the table printed `1% (1–1)` for the same cause on the same page. `buildCsmfTableRows` now applies it too.

## 3. The log contradicted the page

`modular_vacalib_fixed` starts its search at λ = 1 with **no** `min()` cap, so a first-iteration stall returns **1.01** — and `missmat_type = "fixed"` is user-reachable via JobForm's "Propagate" checkbox. Detection still fired (`>= 0.99`), but the log printed the hardcoded `LAMBDA_CEILING` ("0.99") while the UI showed λ = 1.01. Both callers now log the real value.

Wording fixed too: *"found no usable value"* is false when 0.99 is the search's legitimate result (0.99 feasible, 0.98 not → it steps back up to 0.99). Now *"could only use λ = X (a Y% identity mixture)"*, true either way.

## Testing gaps closed

- **The backend wiring had zero coverage.** Deleting both callers' new lines broke no test. Extracted `build_stall_fields()` so it is unit-testable, and pinned the merge into `result_obj` — verified by mutation, removing it now fails 2 tests. (Also removes duplicated logic from both callers.)
- **Pinned the undeclared dependency on `api/client.js` `unbox()`.** Plumber delivers boxed scalars (`"path_correction_stalled":[false]`, `"lambda_calibpath":[0.29]`); without `unbox()` both `=== true` and `typeof === 'number'` read false and the entire feature silently does nothing. Nothing in #115 acknowledged this, so a `fetchJson` refactor would have killed it without failing a test.
- **Covered the `=== true` guard**, which survived mutation before.
- **Covered the table's point-mass and unreliable-CI paths.**

## Correction to #115's commit message

It claims to fix a blank-page crash where an R `NULL` serialised as `{}` and threw on `.toFixed()`. That is **not reachable through the app**: `client.js:15-17` maps `{}` to `null` before the component sees it (its comment says so explicitly). The omit-the-key backend change is still correct and is kept, but the crash was a phantom — the real wire-shape risk is the boxed scalars above.

## Verification

- **R:** 339 assertions pass. Mutation-tested: removing the `result_obj` merge fails 2 tests; the old ensemble assertion had to be updated, which proves the semantics actually changed.
- **Frontend:** 303/303 pass, **0 skipped**, including `integration.test.js` against a live backend.
- **End to end** on the issue's data with a real 2-algorithm ensemble: `eava` stalled/no-op, `interva` clean, `ensemble` intervals-only with `stalled_constituents: ["eava"]`, and no `{}` anywhere on the wire.

## Not included

`calibration_summary.csv` still writes the intervals unconditionally — that is #117, deliberately left separate. #116 and #118 likewise.

🤖 Generated with [Claude Code](https://claude.com/claude-code)


<!-- This is an auto-generated comment: release notes by coderabbit.ai -->
## Summary by CodeRabbit

* **Bug Fixes**
  * Improved path-correction reporting for stalled algorithms and unreliable confidence intervals.
  * Ensemble results now retain valid estimates while identifying affected constituent algorithms.
  * Calibrated tables and charts suppress unreliable or degenerate confidence intervals.
  * Updated messages distinguish stalled calibration from unreliable intervals and include relevant algorithm and lambda details.
  * Added clearer reliability metadata and warnings for affected results.

<!-- end of auto-generated comment: release notes by coderabbit.ai -->