### PR TITLE
fix: stop captioning the calibration prior as empirical sensitivity (#116)

### DIFF
--- a/frontend/src/App.css
+++ b/frontend/src/App.css
@@ -1429,6 +1429,17 @@ footer {
   color: var(--color-primary);
 }
 
+.matrix-stall-note {
+  font-size: 0.8125rem;
+  line-height: 1.5;
+  color: #92400e;
+  background: #fffbeb;
+  border: 1px solid #fde68a;
+  border-radius: 4px;
+  padding: 0.5rem 0.625rem;
+  margin: -0.75rem 0 1.5rem;
+}
+
 .matrix-description {
   font-size: 0.875rem;
   color: var(--color-secondary);

--- a/frontend/src/components/JobDetail.jsx
+++ b/frontend/src/components/JobDetail.jsx
@@ -321,7 +321,11 @@ function CalibratedResults({ results, jobId }) {
       {/* Misclassification Matrix (full width) */}
       {results.misclassification_matrix && (
         <div ref={misclassRef}>
-          <MisclassificationMatrix matrixData={results.misclassification_matrix} jobId={jobId} causeDisplayNames={displayNames} causeOrder={results.cause_order} />
+          {/* lambda/ciUnreliable so the panel can say what the matrix actually is
+              (issue #116): it is the identity-mixed prior, not empirical sensitivity. */}
+          <MisclassificationMatrix matrixData={results.misclassification_matrix} jobId={jobId} causeDisplayNames={displayNames} causeOrder={results.cause_order}
+            lambda={typeof results.lambda_calibpath === 'number' ? results.lambda_calibpath : null}
+            ciUnreliable={results.ci_unreliable === true || results.path_correction_stalled === true} />
         </div>
       )}
 

--- a/frontend/src/components/MisclassificationMatrix.jsx
+++ b/frontend/src/components/MisclassificationMatrix.jsx
@@ -120,7 +120,7 @@ function MatrixTable({ algoName, matrixData, jobId, causeDisplayNames, causeOrde
                       key={`${rowIdx}-${colIdx}`}
                       className={`matrix-cell${diag ? ' diagonal-cell' : ''}`}
                       style={{ backgroundColor: bgColor, color: textColor }}
-                      title={`P(VA=${va_causes[colIdx]} | CHAMPS=${champsCause}) = ${(value * 100).toFixed(1)}%${diag ? ' [Sensitivity]' : ''}`}
+                      title={`P(VA=${va_causes[colIdx]} | CHAMPS=${champsCause}) = ${(value * 100).toFixed(1)}%${diag ? ' [diagonal — retained mass, not empirical sensitivity]' : ''}`}
                     >
                       {Math.round(value * 100)}
                     </td>
@@ -156,14 +156,14 @@ function MatrixLegend() {
         <span>1.0 (High)</span>
       </div>
       <div className="legend-diagonal">
-        <span className="diagonal-indicator"></span> Diagonal = Sensitivity (correct classification)
+        <span className="diagonal-indicator"></span> Diagonal = mass retained on the same cause
       </div>
     </div>
   );
 }
 
 // Main component
-export function MisclassificationMatrix({ matrixData, jobId, causeDisplayNames, causeOrder }) {
+export function MisclassificationMatrix({ matrixData, jobId, causeDisplayNames, causeOrder, lambda, ciUnreliable }) {
   if (!matrixData || Object.keys(matrixData).length === 0) {
     return null;
   }
@@ -172,12 +172,30 @@ export function MisclassificationMatrix({ matrixData, jobId, causeDisplayNames, 
 
   return (
     <div className="misclass-section">
-      <h3>Misclassification Matrices</h3>
+      {/* issue #116: this is vacalibration's `Mmat_tomodel`, which its own plot titles
+          "Prior Mean of Misclassification Matrix — Used For Calibration". It is the
+          identity matrix mixed with the CHAMPS estimate at the path-correction λ, so its
+          diagonal is NOT the empirical sensitivity — on the shipped child/Ethiopia demo
+          (λ = 0.41, not even stalled) the diagonal averages 0.51 against the CHAMPS
+          estimate's 0.33, and at λ = 0.99 it reads ~0.99 against a real 0.135 for
+          malaria. The panel used to caption that diagonal "sensitivity". */}
+      <h3>Misclassification Matrices — Used For Calibration</h3>
       <p className="matrix-description">
-        P(VA cause | CHAMPS cause): how often each true (CHAMPS) cause is classified as
-        each predicted (VA) cause. Rows = CHAMPS causes, columns = VA causes; the blue
-        diagonal is sensitivity (correct classification).
+        P(VA cause | CHAMPS cause) for the prior mean vacalibration actually calibrated
+        with. Rows = CHAMPS causes, columns = VA causes. This is the CHAMPS estimate mixed
+        with the identity matrix at the path-correction λ
+        {typeof lambda === 'number' ? ` (λ = ${lambda.toFixed(2)})` : ''}, so the diagonal
+        is the mass each cause retains under that mixture — <strong>not</strong> the
+        algorithm's empirical sensitivity, which is lower.
       </p>
+      {ciUnreliable && (
+        <p className="matrix-stall-note">
+          Path correction could only use λ
+          {typeof lambda === 'number' ? ` = ${lambda.toFixed(2)}` : ' at its ceiling'}, so
+          this matrix is close to the identity and says little about misclassification.
+          The underlying CHAMPS estimate is unchanged and much further off-diagonal.
+        </p>
+      )}
 
       <div className="matrix-small-multiples">
         {algorithms.map(algoName => (

--- a/frontend/src/components/MisclassificationMatrix.test.js
+++ b/frontend/src/components/MisclassificationMatrix.test.js
@@ -99,3 +99,43 @@ describe('Misclassification small-multiples (issue #72)', () => {
     expect(matrixSrc).toContain('matrix-small-multiples')
   })
 })
+
+// issue #116: this panel displays `Mmat_tomodel`, which vacalibration's own plot titles
+// "Prior Mean of Misclassification Matrix — Used For Calibration". It is the identity
+// matrix mixed with the CHAMPS estimate at the path-correction lambda, NOT the empirical
+// misclassification rate. Measured on the shipped child/Ethiopia demo (lambda = 0.41,
+// not even stalled): displayed diagonal mean 0.51 against the CHAMPS estimate's 0.33;
+// at lambda = 0.99 it reads 0.99 against a real 0.135 for malaria. Calling that diagonal
+// "sensitivity" tells a researcher the algorithm is far more accurate than it is.
+describe('matrix is not labelled as empirical sensitivity (issue #116)', () => {
+  it('does not claim the diagonal is sensitivity', () => {
+    expect(matrixSrc).not.toMatch(/Diagonal = Sensitivity/)
+    expect(matrixSrc).not.toMatch(/\[Sensitivity\]/)
+    expect(matrixSrc).not.toMatch(/diagonal is sensitivity/)
+  })
+
+  it('uses vacalibration\'s own name for this matrix', () => {
+    expect(matrixSrc).toContain('Used For Calibration')
+  })
+
+  it('states that it is a lambda mixture rather than the empirical rate', () => {
+    expect(matrixSrc).toMatch(/mix|mixture/i)
+    expect(matrixSrc).toContain('λ')
+  })
+
+  it('renders the lambda value in the description, not only in the stall note', () => {
+    // Scoped to the description paragraph: asserting on the whole file passes even if
+    // the disclosure is removed here, because the stall note contains the same guard.
+    const desc = matrixSrc.split('className="matrix-description"')[1].split('</p>')[0]
+    expect(desc).toContain("typeof lambda === 'number'")
+    expect(desc).toContain('lambda.toFixed(2)')
+  })
+
+  it('warns when lambda is at the ceiling, where the matrix is ~identity', () => {
+    expect(matrixSrc).toContain('ciUnreliable')
+  })
+
+  it('accepts lambda through the component contract', () => {
+    expect(matrixSrc).toMatch(/MisclassificationMatrix\(\{[^}]*lambda/s)
+  })
+})


### PR DESCRIPTION
Closes #116.

## Problem

The panel displays vacalibration's `Mmat_tomodel`. The package's own plot titles that matrix **"Prior Mean of Misclassification Matrix — Used For Calibration"** — it is the identity matrix mixed with the CHAMPS estimate at the path-correction λ. Its diagonal is therefore the mass each cause *retains under that mixture*, not the algorithm's empirical sensitivity.

The panel captioned it `Diagonal = Sensitivity (correct classification)`, described it as "how often each true (CHAMPS) cause is classified as each predicted (VA) cause", and tooltipped every diagonal cell `[Sensitivity]`.

**This was wrong on every run, not just stalled ones.** Measured on the shipped `child_insilicova_ethiopia_vacalib` demo, which is not stalled:

| λ = 0.41 (normal demo run) | diagonal mean |
|---|---|
| CHAMPS estimate (`Mmat_study`) | **0.33** |
| displayed (`Mmat_tomodel`) | **0.51** |

On a stalled run (λ = 0.99) the displayed diagonal reads **0.99** where the real CHAMPS figure for `malaria` is **0.135** — a 7× overstatement of sensitivity.

`Mmat_tomodel` equals `Mmat_study` only at λ = 0, which occurs solely under `path_correction = FALSE` — a setting the dashboard never passes. And the panel renders **above** the chart, so a reader met the inflated claim first.

## Change

- Heading and description now use vacalibration's own name for the matrix, state explicitly that it is an identity mixture, and show λ
- The diagonal legend and the cell tooltip no longer say "sensitivity"
- When λ is at the ceiling, an explicit note says the matrix is close to the identity and says little about misclassification, and that the underlying CHAMPS estimate is unchanged
- `lambda` / `ciUnreliable` are threaded in from the job result (both already exist as of #115/#119)

## Deliberately not changed: the matrix itself

Switching the source field to `Mmat_study` (which vacalibration calls **"Study-Specific"**) was considered and rejected for this PR:

- `tests/test_misclass_matrix.R` states as its purpose that the dashboard's matrix **must equal vacalibration's "Used For Calibration" panel** — that is #104's requirement, and all 52 of its fixtures set `Mmat_tomodel`
- switching would break those 52 assertions and require re-baselining a numeric regression test against a real job

So this PR fixes the mislabelling, which is wrong regardless of which matrix is shown. Whether to *also* surface the Study-Specific matrix — the number a researcher reading "sensitivity" actually wants — is a separate call; say the word and I'll open it as its own issue.

## Verification

- 315 frontend tests pass, 0 skipped
- The 52 `test_misclass_matrix.R` assertions and 342 R assertions are untouched, confirming the matrix source did not move
- The three new label assertions are **mutation-tested**: reverting the legend, the tooltip, or the λ disclosure each fails a test
- The λ assertion is scoped to the description paragraph — a whole-file `toContain` initially passed even with the disclosure removed, because the stall note contains the same guard

🤖 Generated with [Claude Code](https://claude.com/claude-code)
