### PR TITLE
fix: calibration_summary.csv presented stalled-run bounds as 95% CIs (#117)

### DIFF
--- a/backend/jobs/algorithms/vacalibration.R
+++ b/backend/jobs/algorithms/vacalibration.R
@@ -230,14 +230,10 @@ run_vacalibration <- function(job) {
 
   # Save outputs (output_dir already created above)
 
-  # Save calibration summary (primary result: ensemble or single algo)
-  summary_df <- data.frame(
-    cause = names(uncalibrated),
-    uncalibrated = unlist(uncalibrated),
-    calibrated_mean = unlist(calibrated),
-    calibrated_lower = unlist(calibrated_low),
-    calibrated_upper = unlist(calibrated_high)
-  )
+  # Save calibration summary (primary result: ensemble or single algo). Blanks the
+  # bounds and records lambda when the intervals are not meaningful (issue #117).
+  summary_df <- build_summary_df(uncalibrated, calibrated, calibrated_low,
+                                 calibrated_high, stall_fields)
   summary_file <- file.path(output_dir, "calibration_summary.csv")
   write.csv(summary_df, summary_file, row.names = FALSE)
   add_job_file(job$id, "output", "calibration_summary.csv", summary_file, file.info(summary_file)$size)

--- a/backend/jobs/processor.R
+++ b/backend/jobs/processor.R
@@ -219,14 +219,10 @@ run_pipeline <- function(job) {
   write.csv(all_cod, causes_file, row.names = FALSE)
   add_job_file(job$id, "output", "causes.csv", causes_file, file.info(causes_file)$size)
 
-  # Save calibration summary
-  summary_df <- data.frame(
-    cause = names(uncalibrated),
-    uncalibrated = unlist(uncalibrated),
-    calibrated_mean = unlist(calibrated),
-    calibrated_lower = unlist(calibrated_low),
-    calibrated_upper = unlist(calibrated_high)
-  )
+  # Save calibration summary. Blanks the bounds and records lambda when the intervals
+  # are not meaningful (issue #117).
+  summary_df <- build_summary_df(uncalibrated, calibrated, calibrated_low,
+                                 calibrated_high, stall_fields)
   summary_file <- file.path(output_dir, "calibration_summary.csv")
   write.csv(summary_df, summary_file, row.names = FALSE)
   add_job_file(job$id, "output", "calibration_summary.csv", summary_file, file.info(summary_file)$size)

--- a/backend/jobs/utils.R
+++ b/backend/jobs/utils.R
@@ -754,6 +754,54 @@ build_stall_fields <- function(result, label) {
   out
 }
 
+# Build the downloadable calibration_summary.csv (issue #117). This file is a job
+# artifact that outlives the page, so it must carry the same caveats the UI does:
+#   - when the intervals are unreliable (path correction stalled, or an ensemble with a
+#     stalled constituent) the bounds are blanked rather than presented as 95% CIs, and
+#     a reason column says why
+#   - a point-mass interval is blanked too, matching the chart and the comparison table
+#     (vacalibration returns lower == upper == postmean for causes it did not calibrate,
+#     and "other" is excluded by default, so every run has at least one)
+#   - lambda is always recorded for provenance, NA when the primary row has none
+#     (an ensemble has no lambda of its own)
+build_summary_df <- function(uncalibrated, calibrated, ci_lower, ci_upper, stall_fields) {
+  causes <- names(uncalibrated)
+  no_ci  <- isTRUE(stall_fields$ci_unreliable) || isTRUE(stall_fields$path_correction_stalled)
+  lambda <- if (is.null(stall_fields$lambda_calibpath)) NA_real_
+            else as.numeric(stall_fields$lambda_calibpath)
+
+  lo <- vapply(causes, function(c) as.numeric(ci_lower[[c]]), numeric(1))
+  hi <- vapply(causes, function(c) as.numeric(ci_upper[[c]]), numeric(1))
+  drop_ci <- no_ci | is.na(lo) | is.na(hi) | !(hi > lo)
+  lo[drop_ci] <- NA_real_
+  hi[drop_ci] <- NA_real_
+
+  df <- data.frame(
+    cause = causes,
+    uncalibrated = unlist(uncalibrated),
+    calibrated_mean = unlist(calibrated),
+    calibrated_lower = lo,
+    calibrated_upper = hi,
+    lambda_calibpath = lambda,
+    stringsAsFactors = FALSE
+  )
+
+  reason <- rep(NA_character_, length(causes))
+  if (no_ci) {
+    reason[] <- if (isTRUE(stall_fields$path_correction_stalled)) {
+      paste0("path correction could only use lambda = ", lambda,
+             "; calibrated equals uncalibrated and the interval is not meaningful")
+    } else {
+      paste0("intervals unreliable: ",
+             paste(unlist(stall_fields$stalled_constituents), collapse = ", "),
+             " had no usable path correction")
+    }
+  }
+  reason[is.na(reason) & drop_ci] <- "not calibrated; the interval is a point mass"
+  if (any(!is.na(reason))) df$ci_omitted_reason <- reason
+  df
+}
+
 # Check if causes are already in broad format (all unique values are broad cause names).
 # Normalizes both sides so spaces / underscores / hyphens / case all match.
 is_broad_format <- function(causes, age_group) {

--- a/tests/test_vacalibration_backend.R
+++ b/tests/test_vacalibration_backend.R
@@ -2282,6 +2282,71 @@ sf_ok <- build_stall_fields(fake_result("eava", 0.14), "eava")
 test("healthy run produces no warning",
      isFALSE(sf_ok$path_correction_stalled) && is.null(sf_ok$warning))
 
+# --- build_summary_df(): the downloadable CSV (issue #117) -------------------
+# calibration_summary.csv is a job artifact that outlives the page, so it must carry
+# the same caveat the UI does. Previously it wrote calibrated_lower/upper
+# unconditionally, with no lambda anywhere.
+sd_ok <- build_summary_df(
+  uncalibrated = list(pneumonia = 0.30, other = 0.10),
+  calibrated   = list(pneumonia = 0.42, other = 0.10),
+  ci_lower     = list(pneumonia = 0.35, other = 0.10),
+  ci_upper     = list(pneumonia = 0.49, other = 0.10),
+  stall_fields = list(path_correction_stalled = FALSE, ci_unreliable = FALSE,
+                      lambda_calibpath = 0.41))
+test("healthy run: CSV keeps the bounds",
+     all(c("calibrated_lower", "calibrated_upper") %in% names(sd_ok)) &&
+       isTRUE(all.equal(sd_ok$calibrated_lower[[1]], 0.35)))
+test("healthy run: CSV records lambda for provenance",
+     "lambda_calibpath" %in% names(sd_ok) && isTRUE(all.equal(sd_ok$lambda_calibpath[[1]], 0.41)))
+test("healthy run: point-mass bound is blanked, matching the UI",
+     is.na(sd_ok$calibrated_lower[[2]]) && is.na(sd_ok$calibrated_upper[[2]]))
+
+sd_stalled <- build_summary_df(
+  uncalibrated = list(pneumonia = 0.30, other = 0.10),
+  calibrated   = list(pneumonia = 0.30, other = 0.10),
+  ci_lower     = list(pneumonia = 0.29, other = 0.10),
+  ci_upper     = list(pneumonia = 0.31, other = 0.10),
+  stall_fields = list(path_correction_stalled = TRUE, ci_unreliable = TRUE,
+                      lambda_calibpath = 0.99))
+test("stalled run: bounds are blanked, not written as 95% CIs",
+     all(is.na(sd_stalled$calibrated_lower)) && all(is.na(sd_stalled$calibrated_upper)))
+test("stalled run: means are still written",
+     isTRUE(all.equal(sd_stalled$calibrated_mean[[1]], 0.30)))
+test("stalled run: CSV says why the bounds are missing",
+     "ci_omitted_reason" %in% names(sd_stalled) &&
+       grepl("path correction", sd_stalled$ci_omitted_reason[[1]], ignore.case = TRUE))
+test("stalled run: lambda is recorded",
+     isTRUE(all.equal(sd_stalled$lambda_calibpath[[1]], 0.99)))
+
+# Ensemble primary has no lambda of its own but still has unusable intervals.
+sd_ens <- build_summary_df(
+  uncalibrated = list(pneumonia = 0.30), calibrated = list(pneumonia = 0.33),
+  ci_lower = list(pneumonia = 0.32), ci_upper = list(pneumonia = 0.34),
+  stall_fields = list(path_correction_stalled = FALSE, ci_unreliable = TRUE,
+                      stalled_constituents = list("eava")))
+test("ensemble: bounds blanked even though the row itself did not stall",
+     is.na(sd_ens$calibrated_lower[[1]]))
+test("ensemble: lambda column is NA rather than absent",
+     "lambda_calibpath" %in% names(sd_ens) && is.na(sd_ens$lambda_calibpath[[1]]))
+
+test("the CSV survives a round-trip through write.csv/read.csv", {
+  f <- tempfile(fileext = ".csv"); on.exit(unlink(f))
+  write.csv(sd_stalled, f, row.names = FALSE)
+  back <- read.csv(f, stringsAsFactors = FALSE)
+  nrow(back) == nrow(sd_stalled) && all(is.na(back$calibrated_lower)) &&
+    isTRUE(all.equal(back$lambda_calibpath[[1]], 0.99))
+})
+
+# Both job paths must use the helper rather than assembling summary_df inline.
+for (f in c(file.path(backend_dir, "jobs", "algorithms", "vacalibration.R"),
+            file.path(backend_dir, "jobs", "processor.R"))) {
+  src <- paste(readLines(f, warn = FALSE), collapse = "\n")
+  test(sprintf("%s builds the summary CSV via build_summary_df()", basename(f)),
+       grepl("build_summary_df(", src, fixed = TRUE))
+  test(sprintf("%s no longer assembles calibrated_lower inline", basename(f)),
+       !grepl("calibrated_lower = unlist(", src, fixed = TRUE))
+}
+
 # Both job paths must build the fields AND merge them into the result object. The
 # merge is asserted separately because a caller can keep calling build_stall_fields()
 # for its log line while dropping the fields from the payload -- which is exactly


### PR DESCRIPTION
Closes #117.

## Problem

#115 and #119 stopped the chart, the on-page comparison table and the client-side CSV from presenting a stalled run's ~7×-too-tight intervals as credible intervals. The backend's own downloadable artifact still did.

Both job paths wrote the bounds unconditionally:

```r
summary_df <- data.frame(
  cause = names(uncalibrated),
  uncalibrated = unlist(uncalibrated),
  calibrated_mean = unlist(calibrated),
  calibrated_lower = unlist(calibrated_low),   # <- always written
  calibrated_upper = unlist(calibrated_high)
)
```

`primary_stalled` was already in scope **13 lines above** and never consulted. And `calibration_summary.csv` is the worse place for the problem: it is registered via `add_job_file`, so it outlives the page and is what actually gets circulated.

## Change

`build_summary_df()`:

- **blanks both bounds** when the intervals are unreliable — the row itself stalled, or it is an ensemble whose constituent stalled — and adds a `ci_omitted_reason` column saying which
- **blanks a point-mass interval** too, matching the chart and the table. vacalibration returns `lower == upper == postmean` for causes it did not calibrate, and `other` is excluded by default, so every run has at least one
- **always records `lambda_calibpath`** for provenance, `NA` when the primary row has none (an ensemble has no λ of its own)

Extracted into a helper because both callers had the identical inline `data.frame()` — which is precisely how this omission survived #119.

## Verification on real output, not fixtures

Emily's file from #101 (λ = 0.99, stalled):

```
"cause","uncalibrated","calibrated_mean","calibrated_lower","calibrated_upper","lambda_calibpath","ci_omitted_reason"
"malaria",0.0843,0.0843,NA,NA,0.99,"path correction could only use lambda = 0.99; calibrated equals uncalibrated and the interval is not meaningful"
```

Same input with `path_correction = FALSE` (λ = 0, a real calibration) — bounds preserved, reason column empty:

```
"malaria",0.0843,0.1109,0.0239,0.2658,0,NA
```

- **356 R assertions** pass (14 new, including a `write.csv`/`read.csv` round-trip so the NA columns survive serialisation), 52 misclass-matrix, 309 frontend, 0 skipped
- **Mutation-tested**: removing the suppression entirely fails 4 tests; suppressing only point masses and ignoring the stall fails 3; dropping the λ column fails 4
- Confirmed `stall_fields` is computed before the CSV writer in both paths (221→235 and 203→224), so there is no ordering hazard

## Note

If @sandy-pramanik changes the fallback behaviour in vacalibration (issue #101, item 2), the `path_correction_stalled` flag simply stops firing and the bounds are written normally again — the suppression goes dormant rather than becoming wrong. The λ column stays useful either way.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
