### PR TITLE
fix: install cmake so the backend image builds again

### DIFF
--- a/.claude/skills/comsa-k8s-deploy/assets/dockerfiles/Dockerfile.backend
+++ b/.claude/skills/comsa-k8s-deploy/assets/dockerfiles/Dockerfile.backend
@@ -14,6 +14,7 @@ RUN apt-get update && apt-get install -y \
     libpcre2-dev \
     libdeflate-dev \
     make \
+    cmake \
     gcc \
     g++ \
     default-jdk \

--- a/backend/Dockerfile
+++ b/backend/Dockerfile
@@ -3,6 +3,10 @@
 FROM rocker/r-ver:4.4
 
 # Install system dependencies
+# cmake is required by RcppParallel (a transitive dependency of openVA/EAVA), which
+# began requiring cmake >= 3.5 in a release between 2026-07-28 and 2026-08-12. The R
+# packages below are installed unpinned from CRAN, so this surfaced as a build failure
+# on the first backend deploy after that upstream change. Debian's cmake is 3.28.
 RUN apt-get update && apt-get install -y \
     libcurl4-openssl-dev \
     libssl-dev \
@@ -15,6 +19,7 @@ RUN apt-get update && apt-get install -y \
     libpcre2-dev \
     libdeflate-dev \
     make \
+    cmake \
     gcc \
     g++ \
     default-jdk \


### PR DESCRIPTION
Fixes the k8s-dev deploy, which has been broken since 2026-08-12.

## Problem

```
error: RcppParallel requires cmake (>= 3.5); cmake was not found
ERROR: configuration failed for package 'RcppParallel'
```

`RcppParallel` is a transitive dependency of openVA/EAVA. It began requiring cmake in a release published between **2026-07-28** (the last successful backend deploy) and **2026-08-12**. `backend/Dockerfile`'s apt list has `make`, `gcc` and `g++` but not `cmake`, and the R packages are installed **unpinned** from CRAN — so the upstream change landed silently and only surfaced on the next build that reached that layer.

| Deploy run | Result | |
|---|---|---|
| 2026-07-28 21:23 | ✅ | last success |
| 2026-08-12 16:05 | ❌ | #115 |
| 2026-08-13 16:30 | ❌ | #119 |
| 2026-08-13 17:06 | ✅ | #120 — **frontend only**, so the backend image was skipped |
| 2026-08-13 17:06 | ❌ | #121 |

**Not caused by any source change.** The failure is at `Dockerfile:38`, which installs CRAN packages; application code is `COPY`'d in a later layer, so no `.R` edit can affect it. The pattern above is just "the first backend changes since the upstream release".

## Change

Add `cmake` to the apt list. Also fixes the same omission in `.claude/skills/comsa-k8s-deploy/assets/dockerfiles/Dockerfile.backend`, so rebuilding from the template doesn't reintroduce it.

## Verification

Deliberately in two stages — a fast probe to test the hypothesis, then the real thing to confirm the conclusion:

1. **Probe (14s)**: a minimal image installing *only* `RcppParallel` confirmed cmake is absent from `rocker/r-ver:4.4` (`cmake: NOT PRESENT`) and that Debian's **cmake 3.28.3** satisfies the `>= 3.5` requirement. This ruled out "cmake alone isn't enough" before spending 20 minutes.
2. **Real build**: `docker build -f backend/Dockerfile .` completed end to end — all 11 layers `DONE`, including the previously failing layer 6 (openVA, EAVA, vacalibration, knitr) and the 91.5s Stan model compilation.
3. **Runtime check on the built image**, because a successful build is not the same as a working image:

```
cmake version 3.28.3
RcppParallel    OK 6.2.0
openVA          OK 1.2.0
EAVA            OK 1.0.0
vacalibration   OK 2.2
knitr           OK 1.51
plumber         OK 1.3.3
Precompiled Stan models: seqcalib_mmat.rds seqcalib.rds
```

## Follow-up worth considering separately

The root enabler is that R packages are installed unpinned (`repos='https://cloud.r-project.org'` always resolves to latest), so any upstream change can break the build at an arbitrary later date — this one sat hidden for 16 days because no backend deploy ran in between, which also made it look like it was caused by the merge that exposed it. A dated Posit Package Manager snapshot repo would make builds reproducible with a one-line change. Not included here to keep this fix minimal.

🤖 Generated with [Claude Code](https://claude.com/claude-code)
